### PR TITLE
fix: use java 21 as docker base image (#11)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>
                     <from>
-                        <image>openjdk:alpine</image>
+                        <image>eclipse-temurin:21-jre-alpine</image>
                     </from>
                     <to>
                         <image>pikkalabs/riptide</image>


### PR DESCRIPTION
I randomly picked a source image, which has a reasonable size.