### PR TITLE
chg: rename Repository to FlowRepository

### DIFF
--- a/src/main/java/org/riptide/configuration/ElasticsearchConfiguration.java
+++ b/src/main/java/org/riptide/configuration/ElasticsearchConfiguration.java
@@ -11,7 +11,7 @@ import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.riptide.config.ElasticsearchConfig;
-import org.riptide.repository.Repository;
+import org.riptide.repository.FlowRepository;
 import org.riptide.repository.elastic.ElasticFlowRepository;
 import org.riptide.repository.elastic.IndexSettings;
 import org.riptide.repository.elastic.IndexStrategy;
@@ -54,9 +54,9 @@ public class ElasticsearchConfiguration {
     }
 
     @Bean
-    public Repository elasticFlowRepository(final ElasticsearchConfig config,
-                                            final JestClient jestClient,
-                                            final MetricRegistry metricRegistry) {
+    public FlowRepository elasticFlowRepository(final ElasticsearchConfig config,
+                                                final JestClient jestClient,
+                                                final MetricRegistry metricRegistry) {
         final var indexSettings = new IndexSettings();
         indexSettings.setIndexPrefix(config.indexPrefix);
         indexSettings.setNumberOfReplicas(config.numberOfReplicas);

--- a/src/main/java/org/riptide/configuration/OpensearchConfiguration.java
+++ b/src/main/java/org/riptide/configuration/OpensearchConfiguration.java
@@ -1,7 +1,7 @@
 package org.riptide.configuration;
 
 import org.riptide.config.OpensearchConfig;
-import org.riptide.repository.Repository;
+import org.riptide.repository.FlowRepository;
 import org.riptide.repository.opensearch.OpensearchRepository;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
@@ -11,7 +11,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnBean(OpensearchConfig.class)
 public class OpensearchConfiguration {
     @Bean
-    public Repository opensearchRepository(final OpensearchConfig config) {
+    public FlowRepository opensearchRepository(final OpensearchConfig config) {
         return new OpensearchRepository(config);
     }
 }

--- a/src/main/java/org/riptide/configuration/RiptideConfiguration.java
+++ b/src/main/java/org/riptide/configuration/RiptideConfiguration.java
@@ -9,9 +9,7 @@ import org.riptide.classification.internal.AsyncReloadingClassificationEngine;
 import org.riptide.classification.internal.DefaultClassificationEngine;
 import org.riptide.classification.internal.TimingClassificationEngine;
 import org.riptide.classification.internal.csv.CsvImporter;
-import org.riptide.repository.Repository;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.riptide.repository.FlowRepository;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -30,8 +28,8 @@ public class RiptideConfiguration {
 
     // TODO MVR using Map<String, Repository> seems weird
     @Bean
-    public Map<String, Repository> flowRepositories(final ListableBeanFactory beanFactory) {
-        final var repositories = beanFactory.getBeansOfType(Repository.class);
+    public Map<String, FlowRepository> flowRepositories(final ListableBeanFactory beanFactory) {
+        final var repositories = beanFactory.getBeansOfType(FlowRepository.class);
         if (repositories.isEmpty()) {
             log.error("No flow persistence repository configured");
         }

--- a/src/main/java/org/riptide/pipeline/Pipeline.java
+++ b/src/main/java/org/riptide/pipeline/Pipeline.java
@@ -10,7 +10,7 @@ import org.riptide.classification.ClassificationRequest;
 import org.riptide.classification.IpAddr;
 import org.riptide.classification.Protocols;
 import org.riptide.flows.parser.data.Flow;
-import org.riptide.repository.Repository;
+import org.riptide.repository.FlowRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -67,7 +67,7 @@ public class Pipeline {
 //                    final DocumentEnricherImpl documentEnricher,
 //                    final InterfaceMarkerImpl interfaceMarker,
 //                    final FlowThresholdingImpl thresholding,
-                    final Map<String, Repository> repositories,
+                    final Map<String, FlowRepository> repositories,
                     final MetricRegistry metricRegistry
     ) {
         this.classificationEngine = Objects.requireNonNull(classificationEngine);
@@ -155,8 +155,8 @@ public class Pipeline {
         }
     }
 
-    private record Persister(Repository repository, Timer logTimer) {
-            private Persister(final Repository repository, final Timer logTimer) {
+    private record Persister(FlowRepository repository, Timer logTimer) {
+            private Persister(final FlowRepository repository, final Timer logTimer) {
                 this.repository = Objects.requireNonNull(repository);
                 this.logTimer = Objects.requireNonNull(logTimer);
             }

--- a/src/main/java/org/riptide/repository/FlowRepository.java
+++ b/src/main/java/org/riptide/repository/FlowRepository.java
@@ -11,7 +11,7 @@ import java.util.Collection;
  *
  * After parsing and processing of received flows, the result is passed to all exposed instances of this interface.
  */
-public interface Repository {
+public interface FlowRepository {
 
     /**
      * Persist a batch of flows.

--- a/src/main/java/org/riptide/repository/elastic/ElasticFlowRepository.java
+++ b/src/main/java/org/riptide/repository/elastic/ElasticFlowRepository.java
@@ -10,7 +10,7 @@ import io.searchbox.core.Bulk;
 import io.searchbox.core.Index;
 import org.riptide.pipeline.EnrichedFlow;
 import org.riptide.pipeline.FlowException;
-import org.riptide.repository.Repository;
+import org.riptide.repository.FlowRepository;
 import org.riptide.repository.elastic.bulk.BulkException;
 import org.riptide.repository.elastic.bulk.BulkRequest;
 import org.riptide.repository.elastic.bulk.BulkWrapper;
@@ -28,7 +28,7 @@ import java.util.Objects;
 import java.util.TimerTask;
 import java.util.concurrent.locks.ReentrantLock;
 
-public class ElasticFlowRepository implements Repository {
+public class ElasticFlowRepository implements FlowRepository {
 
     public static final String TRACER_FLOW_MODULE = "ElasticFlow";
 

--- a/src/main/java/org/riptide/repository/elastic/InitializingElasticFlowRepository.java
+++ b/src/main/java/org/riptide/repository/elastic/InitializingElasticFlowRepository.java
@@ -3,7 +3,7 @@ package org.riptide.repository.elastic;
 import io.searchbox.client.JestClient;
 import org.riptide.pipeline.EnrichedFlow;
 import org.riptide.pipeline.FlowException;
-import org.riptide.repository.Repository;
+import org.riptide.repository.FlowRepository;
 import org.riptide.repository.elastic.template.DefaultTemplateInitializer;
 
 import java.io.IOException;
@@ -14,23 +14,23 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * This {@link Repository} wrapper will ensure that the repository has
+ * This {@link FlowRepository} wrapper will ensure that the repository has
  * been initialized before any *write* calls are made to the given delegate.
  */
-public class InitializingElasticFlowRepository implements Repository {
+public class InitializingElasticFlowRepository implements FlowRepository {
 
     private final List<DefaultTemplateInitializer> initializers;
-    private final Repository delegate;
+    private final FlowRepository delegate;
     private final AtomicBoolean initialized = new AtomicBoolean(false);
 
-    public InitializingElasticFlowRepository(final Repository delegate,
+    public InitializingElasticFlowRepository(final FlowRepository delegate,
                                              final JestClient client,
                                              final IndexSettings rawIndexSettings/*,
                                       final IndexSettings aggIndexSettings*/) {
         this(delegate, new RawIndexInitializer(client, rawIndexSettings)/*, new AggregateIndexInitializer(bundleContext, client, aggIndexSettings)*/);
     }
 
-    private InitializingElasticFlowRepository(final Repository delegate, final DefaultTemplateInitializer... initializers) {
+    private InitializingElasticFlowRepository(final FlowRepository delegate, final DefaultTemplateInitializer... initializers) {
         this.delegate = Objects.requireNonNull(delegate);
         this.initializers = Arrays.asList(initializers);
     }

--- a/src/main/java/org/riptide/repository/elastic/SwitchedFlowRepository.java
+++ b/src/main/java/org/riptide/repository/elastic/SwitchedFlowRepository.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 
 import org.riptide.pipeline.EnrichedFlow;
 import org.riptide.pipeline.FlowException;
-import org.riptide.repository.Repository;
+import org.riptide.repository.FlowRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,15 +15,15 @@ import org.slf4j.LoggerFactory;
  *
  * Whether the flows are forwarded can be controlled by a property.
  */
-public class SwitchedFlowRepository implements Repository {
+public class SwitchedFlowRepository implements FlowRepository {
 
     private static final Logger LOG = LoggerFactory.getLogger(SwitchedFlowRepository.class);
 
-    private final Repository delegate;
+    private final FlowRepository delegate;
 
     private boolean enabled = true;
 
-    public SwitchedFlowRepository(final Repository delegate) {
+    public SwitchedFlowRepository(final FlowRepository delegate) {
         this.delegate = Objects.requireNonNull(delegate);
     }
 

--- a/src/main/java/org/riptide/repository/opensearch/OpensearchRepository.java
+++ b/src/main/java/org/riptide/repository/opensearch/OpensearchRepository.java
@@ -14,7 +14,7 @@ import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBui
 import org.riptide.config.OpensearchConfig;
 import org.riptide.pipeline.EnrichedFlow;
 import org.riptide.pipeline.FlowException;
-import org.riptide.repository.Repository;
+import org.riptide.repository.FlowRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Objects;
 
-public class OpensearchRepository implements Repository {
+public class OpensearchRepository implements FlowRepository {
 
     private static final Logger LOG = LoggerFactory.getLogger(OpensearchRepository.class);
 


### PR DESCRIPTION
The intention of this is to avoid possible future conflicts with spring's internal `Repository`s, as a `Repository` has a very concrete and specific meaning in the context of Spring.

Naming it `FlowRepository` makes it clear, that it is a `Repository` but not conflicting with spring.