### PR TITLE
feat: publish docker images to quay on build (#18)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   - push
   - workflow_dispatch
 jobs:
-  Build-And-Test:
+  Build-Test-DockerPublish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -19,3 +19,38 @@ jobs:
         run: mvn --batch-mode --update-snapshots verify
       - name: Docker Build
         run: mvn --batch-mode --update-snapshots jib:dockerBuild
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            quay.io/pikkalabs/riptide
+          flavor: |
+            latest=false
+            suffix=
+            prefix=
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=,event=branch
+            type=ref,event=pr
+            type=sha,prefix=,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix=
+            # set latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
+      - name: Docker publish
+        env:
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+        run:  |
+          TAGS=$(echo ${DOCKER_METADATA_OUTPUT_TAGS//quay.io\/pikkalabs\/riptide:/} | tr ' ' ,)
+          echo "Pushing docker image using the following tags: $TAGS"
+          mvn --batch-mode \
+            -D"jib.to.image=quay.io/pikkalabs/riptide:${GITHUB_SHA::7}" \
+            -D"jib.to.tags=$TAGS" \
+            -D"jib.to.auth.username=$QUAY_USERNAME" \
+            -D"jib.to.auth.password=$QUAY_PASSWORD" \
+            jib:build

--- a/pom.xml
+++ b/pom.xml
@@ -140,16 +140,18 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
+                <version>3.4.0</version>
                 <configuration>
                     <from>
                         <image>eclipse-temurin:21-jre-alpine</image>
                     </from>
                     <to>
-                        <image>pikkalabs/riptide</image>
-                        <tags>
-                            <tag>latest</tag>
-                            <tag>bleeding</tag>
-                        </tags>
+                        <!-- if :local is omitted, latest is used, which we don't want -->
+                        <image>quay.io/pikkalabs/riptide:local</image>
+                        <!-- sets additional tags. Uncommented on purpose, refer to https://github.com/GoogleContainerTools/jib/issues/2237 for more details -->
+<!--                        <tags>-->
+<!--                            <tag>additional</tag>-->
+<!--                        </tags>-->
                     </to>
                     <container>
                         <ports>


### PR DESCRIPTION
Here we publish the created docker images to `quay.io/pikkalabs/riptide`.

The tag behaviour is as follows:
- always tag with sha (is done by jib)
- use branch name if pr or branch
- only tag if default (main) branch (needs to be verified)
- use semantic versioning on tag creation (needs to be verified)

Some of these may need to be verified, as I was not able to verify `latest` and `semver` (obviously).

Resolve: #18