### PR TITLE
chg: use gson where possible and use annotation based deserialization/serialization (#38)

### DIFF
--- a/config/checkstyle-import-control.xml
+++ b/config/checkstyle-import-control.xml
@@ -11,6 +11,9 @@
     <disallow class="com.google.common.base.Functions" />
     <disallow class="com.google.common.collect.Lists" />
 
+    <!-- We agreed on using Gson instead of ObjectMapper -->
+    <disallow pkg="com.fasterxml.jackson" />
+
     <!-- Prevent Junit 4 as a precaution, as sometimes IntelliJ adds it -->
     <disallow pkg="org.junit" exact-match="true" />
 </import-control>

--- a/src/main/java/org/riptide/pipeline/ConversationKey.java
+++ b/src/main/java/org/riptide/pipeline/ConversationKey.java
@@ -1,14 +1,9 @@
 package org.riptide.pipeline;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
-
-import java.io.StringWriter;
-import java.util.Objects;
 
 /**
  * Contains all of the fields used to uniquely identify a conversation.
@@ -25,72 +20,4 @@ public class ConversationKey {
     private final String upperIp;
     private final String application;
 
-    /**
-     * Utility class for building the {@link ConversationKey} and
-     * converting it to/from a string so that it can be used in
-     * group-by statements when querying.
-     *
-     * These methods are optimized for speed when generating the key,
-     * with the constraint that we must also be able to decode the key.
-     *
-     * @author jwhite
-     */
-    public static class Utils {
-        private static final Gson gson = new GsonBuilder().create();
-
-        // TODO MVR remove gson
-        public static ConversationKey fromJsonString(String json) {
-            final Object[] array = gson.fromJson(json, Object[].class);
-            if (array.length != 5) {
-                throw new IllegalArgumentException("Invalid conversation key string: " + json);
-            }
-            return new ConversationKey((String) array[0], ((Number) array[1]).intValue(),
-                    (String) array[2], (String) array[3], (String) array[4]);
-        }
-
-        public static String getConvoKeyAsJsonString(final String location,
-                                                     final Integer protocol,
-                                                     final String srcAddr,
-                                                     final String dstAddr,
-                                                     final String application) {
-            // Only generate the key if all of the required fields are set
-            if (location != null
-                    && protocol != null
-                    && srcAddr != null
-                    && dstAddr != null) {
-                // Build the JSON string manually
-                // This is faster than creating some new object on which we can use gson.toJson or similar
-                final StringWriter writer = new StringWriter();
-                writer.write("[");
-
-                // Use GSON to encode the location, since this may contain characters that need to be escape
-                writer.write(gson.toJson(location));
-                writer.write(",");
-                writer.write(Integer.toString(protocol));
-                writer.write(",");
-
-                // Write out addresses in canonical format (lower one first)
-                if (Objects.compare(srcAddr, dstAddr, String::compareTo) < 0) {
-                    writer.write(gson.toJson(srcAddr));
-                    writer.write(",");
-                    writer.write(gson.toJson(dstAddr));
-                } else {
-                    writer.write(gson.toJson(dstAddr));
-                    writer.write(",");
-                    writer.write(gson.toJson(srcAddr));
-                }
-                writer.write(",");
-
-                if (application != null) {
-                    writer.write(gson.toJson(application));
-                } else {
-                    writer.write("null");
-                }
-
-                writer.write("]");
-                return writer.toString();
-            }
-            return null;
-        }
-    }
 }

--- a/src/main/java/org/riptide/pipeline/EnrichedFlow.java
+++ b/src/main/java/org/riptide/pipeline/EnrichedFlow.java
@@ -466,7 +466,7 @@ public class EnrichedFlow implements Flow {
     }
 
     public String getConvoKey() {
-        return ConversationKey.Utils.getConvoKeyAsJsonString(
+        return Utils.getConvoKeyAsJsonString(
                 this.getLocation(),
                 this.getProtocol(),
                 this.getSrcAddr().getHostAddress(),

--- a/src/main/java/org/riptide/pipeline/Utils.java
+++ b/src/main/java/org/riptide/pipeline/Utils.java
@@ -1,0 +1,37 @@
+package org.riptide.pipeline;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import java.util.Objects;
+
+/**
+ * Utility class for building the {@link ConversationKey} and
+ * converting it to/from a string so that it can be used in
+ * group-by statements when querying.
+ *
+ * @author jwhite
+ */
+public final class Utils {
+
+    private static final Gson gson = new GsonBuilder().create();
+
+    public static ConversationKey fromJsonString(String json) {
+        return gson.fromJson(json, ConversationKey.class);
+    }
+
+    public static String getConvoKeyAsJsonString(final String location, final Integer protocol, final String srcAddr, final String dstAddr, final String application) {
+        if (location != null && protocol != null && srcAddr != null && dstAddr != null) {
+            final var criteria = Objects.compare(srcAddr, dstAddr, String::compareTo) < 0;
+            final var lower = criteria ? srcAddr : dstAddr;
+            final var higher = criteria ? dstAddr : srcAddr;
+            final var conversationKey = new ConversationKey(location, protocol, lower, higher, application);
+            return gson.toJson(conversationKey);
+        }
+        return null;
+    }
+
+    private Utils() {
+
+    }
+}

--- a/src/main/java/org/riptide/repository/elastic/IndexSettings.java
+++ b/src/main/java/org/riptide/repository/elastic/IndexSettings.java
@@ -1,53 +1,25 @@
 package org.riptide.repository.elastic;
 
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+@Data
 public class IndexSettings {
 
+    @SerializedName("index_prefix")
     private String indexPrefix;
 
+    @SerializedName("number_of_shards")
     private Integer numberOfShards;
 
+    @SerializedName("number_of_replicas")
     private Integer numberOfReplicas;
 
+    @SerializedName("routing_partition_size")
     private Integer routingPartitionSize;
 
+    @SerializedName("refresh_interval")
     private String refreshInterval;
-
-    public String getIndexPrefix() {
-        return this.indexPrefix;
-    }
-
-    public void setIndexPrefix(String indexPrefix) {
-        this.indexPrefix = indexPrefix;
-    }
-
-    public Integer getNumberOfShards() {
-        return this.numberOfShards;
-    }
-
-    public void setNumberOfShards(Integer numberOfShards) {
-        this.numberOfShards = numberOfShards;
-    }
-
-
-    public Integer getNumberOfReplicas() {
-        return this.numberOfReplicas;
-    }
-
-    public void setNumberOfReplicas(Integer numberOfReplicas) {
-        this.numberOfReplicas = numberOfReplicas;
-    }
-
-    public Integer getRoutingPartitionSize() {
-        return this.routingPartitionSize;
-    }
-
-    public void setRoutingPartitionSize(Integer routingPartitionSize) {
-        this.routingPartitionSize = routingPartitionSize;
-    }
-
-    public String getRefreshInterval() {
-        return this.refreshInterval;
-    }
 
     public boolean isEmpty() {
         return this.indexPrefix == null

--- a/src/main/java/org/riptide/repository/elastic/bulk/BulkErrorDto.java
+++ b/src/main/java/org/riptide/repository/elastic/bulk/BulkErrorDto.java
@@ -1,0 +1,14 @@
+package org.riptide.repository.elastic.bulk;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+@Data
+public class BulkErrorDto {
+    private final String type;
+
+    private final String reason;
+
+    @SerializedName("caused_by")
+    private final BulkErrorDto cause;
+}

--- a/src/main/java/org/riptide/repository/elastic/template/Template.java
+++ b/src/main/java/org/riptide/repository/elastic/template/Template.java
@@ -1,0 +1,31 @@
+package org.riptide.repository.elastic.template;
+
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+import org.riptide.repository.elastic.IndexSettings;
+
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+@Data
+public class Template {
+    @SerializedName("index_patterns")
+    private List<String> indexPatterns;
+
+    private Map<String, IndexSettings> settings;
+
+    public Optional<IndexSettings> getIndexSettingsSafe() {
+        if (settings != null) {
+            return Optional.ofNullable(settings.get("index"));
+        }
+        return Optional.empty();
+    }
+
+    public IndexSettings getIndexSettings() {
+        return getIndexSettingsSafe()
+                .orElseThrow(() -> new NoSuchElementException("Provided template does not contain IndexSettings"));
+    }
+}

--- a/src/main/java/org/riptide/repository/elastic/template/TemplateMerger.java
+++ b/src/main/java/org/riptide/repository/elastic/template/TemplateMerger.java
@@ -2,81 +2,58 @@ package org.riptide.repository.elastic.template;
 
 import com.google.common.base.Strings;
 import com.google.gson.Gson;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import com.google.gson.JsonPrimitive;
 import org.riptide.repository.elastic.IndexSettings;
+
+import java.util.ArrayList;
+import java.util.HashMap;
 
 /**
  * Merges an existing elastic template with provided (optional) settings.
  */
 public class TemplateMerger {
 
-    private static final String SETTINGS_KEY = "settings";
-    private static final String INDEX_KEY = "index";
-
     public String merge(final String template, final IndexSettings indexSettings) {
-        final JsonElement json = new JsonParser().parse(template);
-        if (!json.isJsonObject()) {
-            throw new IllegalArgumentException("Provided template is not a valid json object");
-        }
-        JsonObject object = merge(json.getAsJsonObject(), indexSettings);
-        return new Gson().toJson(object);
+        final var gson = new Gson();
+        final var templateObject = gson.fromJson(template, Template.class);
+        final var mergedTemplate = merge(templateObject, indexSettings);
+        return gson.toJson(mergedTemplate);
     }
 
-    public JsonObject merge(final JsonObject template, final IndexSettings indexSettings) {
+    public Template merge(final Template template, final IndexSettings indexSettings) {
         if (indexSettings != null && !indexSettings.isEmpty()) {
-            addMissingProperties(template);
+            // Ensure settings -> index is always set
+            if (template.getSettings() == null) {
+                template.setSettings(new HashMap<>());
+            }
+            template.getSettings().putIfAbsent("index", new IndexSettings());
 
             // Prepend the index prefix to the template pattern
             if (!Strings.isNullOrEmpty(indexSettings.getIndexPrefix())) {
-                JsonArray indexPatterns = template.getAsJsonArray("index_patterns");
-                if (indexPatterns == null) {
-                    indexPatterns = new JsonArray();
-                    indexPatterns.add(indexSettings.getIndexPrefix() + "*");
-                    template.add("index_patterns", indexPatterns);
-                } else {
-                    for (int i = 0; i < indexPatterns.size(); i++) {
-                        final String newPattern = indexSettings.getIndexPrefix() + indexPatterns.get(i).getAsString();
-                        indexPatterns.set(i, new JsonPrimitive(newPattern));
-                    }
+                if (template.getIndexPatterns() == null) {
+                    template.setIndexPatterns(new ArrayList<>());
                 }
-                template.add("index_patterns", indexPatterns);
+                if (template.getIndexPatterns().isEmpty()) {
+                    template.getIndexPatterns().add(indexSettings.getIndexPrefix() + "*");
+                } else {
+                    template.getIndexPatterns().replaceAll(pattern -> indexSettings.getIndexPrefix() + pattern);
+                }
             }
-
-            final JsonObject indexObject = template.get(SETTINGS_KEY).getAsJsonObject().get(INDEX_KEY).getAsJsonObject();
-            if (indexSettings.getNumberOfShards() != null) {
-                indexObject.addProperty("number_of_shards", indexSettings.getNumberOfShards());
-            }
-            if (indexSettings.getNumberOfReplicas() != null) {
-                indexObject.addProperty("number_of_replicas", indexSettings.getNumberOfReplicas());
-            }
-            if (indexSettings.getRefreshInterval() != null) {
-                indexObject.addProperty("refresh_interval", indexSettings.getRefreshInterval());
-            }
-            if (indexSettings.getRoutingPartitionSize() != null) {
-                indexObject.addProperty("routing_partition_size", indexSettings.getRoutingPartitionSize());
-            }
+            template.getIndexSettingsSafe().ifPresent(indexObject -> {
+                if (indexSettings.getNumberOfShards() != null) {
+                    indexObject.setNumberOfShards(indexSettings.getNumberOfShards());
+                }
+                if (indexSettings.getNumberOfReplicas() != null) {
+                    indexObject.setNumberOfReplicas(indexSettings.getNumberOfReplicas());
+                }
+                if (indexSettings.getRefreshInterval() != null) {
+                    indexObject.setRefreshInterval(indexSettings.getRefreshInterval());
+                }
+                if (indexSettings.getRoutingPartitionSize() != null) {
+                    indexObject.setRoutingPartitionSize(indexSettings.getRoutingPartitionSize());
+                }
+            });
         }
         return template;
     }
-
-    private void addMissingProperties(final JsonObject template) {
-        final JsonObject settings = addMissingProperty(template, SETTINGS_KEY);
-        addMissingProperty(settings, INDEX_KEY);
-    }
-
-    private JsonObject addMissingProperty(JsonObject root, String property) {
-        if (root.get(property) == null) {
-            root.add(property, new JsonObject());
-        }
-        if (!root.get(property).isJsonObject()) {
-            throw new IllegalArgumentException("Provided template contains property '" + property + "' must be of type JsonObject");
-        }
-        return root.get(property).getAsJsonObject();
-    }
-
 
 }

--- a/src/test/java/org/riptide/pipeline/UtilsTest.java
+++ b/src/test/java/org/riptide/pipeline/UtilsTest.java
@@ -1,0 +1,33 @@
+package org.riptide.pipeline;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.json.JsonContent;
+
+
+class UtilsTest {
+    private static final String JSON = Utils.getConvoKeyAsJsonString("SomeLoc", 1, "1.1.1.1", "2.2.2.2", "ulf");
+
+    @Test
+    void verifySerialization() {
+        final var jsonContent = new JsonContent<>(getClass(), null, JSON);
+        Assertions.assertThat(jsonContent).extractingJsonPathStringValue("$.location").isEqualTo("SomeLoc");
+        Assertions.assertThat(jsonContent).extractingJsonPathValue("$.protocol").isEqualTo(1);
+        Assertions.assertThat(jsonContent).extractingJsonPathStringValue("$.lowerIp").isEqualTo("1.1.1.1");
+        Assertions.assertThat(jsonContent).extractingJsonPathStringValue("$.upperIp").isEqualTo("2.2.2.2");
+        Assertions.assertThat(jsonContent).extractingJsonPathStringValue("$.application").isEqualTo("ulf");
+    }
+
+    @Test
+    void verifyDeserialization() {
+        final var expectedKey = new ConversationKey(
+                "SomeLoc",
+                1,
+                "1.1.1.1",
+                "2.2.2.2",
+                "ulf");
+        final var actualKey = Utils.fromJsonString(JSON);
+        Assertions.assertThat(actualKey).isEqualTo(expectedKey);
+    }
+
+}

--- a/src/test/java/org/riptide/repository/elastic/bulk/BulkUtilsTest.java
+++ b/src/test/java/org/riptide/repository/elastic/bulk/BulkUtilsTest.java
@@ -1,0 +1,33 @@
+package org.riptide.repository.elastic.bulk;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class BulkUtilsTest {
+
+    @Test
+    void verifyExceptionParsing() {
+        // Parse Error
+        final String error = "{\"type\":\"mapper_parsing_exception\",\"reason\":\"failed to parse [timestamp]\",\"caused_by\":{\"type\":\"number_format_exception\",\"reason\":\"For input string: \\\"XXX\\\"\"}}";
+        final Exception exception = BulkUtils.convertToException(error);
+
+        // verify exception
+        Assertions.assertThat(exception.getMessage()).isEqualTo("mapper_parsing_exception: failed to parse [timestamp]");
+        Assertions.assertThat(exception.getCause()).isNotNull();
+        Assertions.assertThat(exception.getCause().getMessage()).isEqualTo("number_format_exception: For input string: \"XXX\"");
+        Assertions.assertThat(exception.getCause().getCause()).isNull();
+    }
+
+    @Test
+    void verifyErrorParsing() {
+        final var errorString = "{\"type\":\"mapper_parsing_exception\",\"reason\":\"failed to parse [timestamp]\",\"caused_by\":{\"type\":\"number_format_exception\",\"reason\":\"For input string: \\\"XXX\\\"\"}}";
+        final var dto = BulkUtils.parse(errorString);
+        Assertions.assertThat(dto.getType()).isEqualTo("mapper_parsing_exception");
+        Assertions.assertThat(dto.getReason()).isEqualTo("failed to parse [timestamp]");
+        Assertions.assertThat(dto.getCause()).isNotNull();
+        Assertions.assertThat(dto.getCause().getType()).isEqualTo("number_format_exception");
+        Assertions.assertThat(dto.getCause().getReason()).isEqualTo("For input string: \"XXX\"");
+        Assertions.assertThat(dto.getCause().getCause()).isNull();
+    }
+
+}

--- a/src/test/java/org/riptide/repository/elastic/template/TemplateMergerTest.java
+++ b/src/test/java/org/riptide/repository/elastic/template/TemplateMergerTest.java
@@ -1,0 +1,65 @@
+package org.riptide.repository.elastic.template;
+
+
+import com.google.gson.Gson;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.riptide.repository.elastic.IndexSettings;
+
+public class TemplateMergerTest {
+    @Test
+    void verifyEmptyTemplateMergeWithEmptySettings() {
+        Assertions.assertThat(new TemplateMerger().merge("{}", new IndexSettings())).isEqualTo("{}");
+        Assertions.assertThat(new TemplateMerger().merge(new Template(), new IndexSettings())).isEqualTo(new Template());
+    }
+
+    @Test
+    void verifyEmptyTemplateMergeWithNullSettings() {
+        Assertions.assertThat(new TemplateMerger().merge("{}", null)).isEqualTo("{}");
+        Assertions.assertThat(new TemplateMerger().merge(new Template(), null)).isEqualTo(new Template());
+    }
+
+    @Test
+    void verifyEmptyTemplateMergeWithFullyDefinedSettings() {
+        final String inputJson = """
+                {
+                    "index_patterns":["prefix*"],
+                    settings: {
+                        index: {
+                          number_of_shards: 5,
+                          number_of_replicas: 10,
+                          refresh_interval: 10s,
+                          routing_partition_size: 20
+                        }
+                    }
+                }
+                """;
+
+        // Configure settings
+        final IndexSettings settings = new IndexSettings();
+        settings.setIndexPrefix("prefix");
+        settings.setNumberOfShards(5);
+        settings.setNumberOfReplicas(10);
+        settings.setRefreshInterval("10s");
+        settings.setRoutingPartitionSize(20);
+
+        // Verify
+        final var template = new Gson().fromJson(inputJson, Template.class);
+        final var expectedJson = new Gson().toJson(template);
+        Assertions.assertThat(expectedJson).isEqualTo(new TemplateMerger().merge("{}", settings));
+        Assertions.assertThat(template).isEqualTo(new TemplateMerger().merge(new Template(), settings));
+    }
+
+    @Test
+    void verifyIndexPrefixHandling() {
+        final String expectedJson = "{\"index_patterns\":[\"prefix-test-*\"],\"settings\":{\"index\":{}}}";
+
+         // Configure settings
+        final IndexSettings settings = new IndexSettings();
+        settings.setIndexPrefix("prefix-");
+
+        // Verify
+        final var expectedJsonObject = new Gson().fromJson(expectedJson, Template.class);
+        Assertions.assertThat(expectedJson).isEqualTo(new TemplateMerger().merge("{\"index_patterns\":[\"test-*\"]}", settings));
+    }
+}

--- a/src/test/java/org/riptide/repository/elastic/template/TemplateTest.java
+++ b/src/test/java/org/riptide/repository/elastic/template/TemplateTest.java
@@ -1,0 +1,33 @@
+package org.riptide.repository.elastic.template;
+
+import com.google.gson.Gson;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TemplateTest {
+
+    @Test
+    void verifyParsing() {
+        final String input = """
+                {                                
+                    settings: {                     
+                        index: {                      
+                          number_of_shards: 5,        
+                          number_of_replicas: 10,     
+                          refresh_interval: 10s,      
+                          routing_partition_size: 20  
+                        }                             
+                    },                              
+                    "index_patterns":["prefix*"]
+                }
+                """;
+        final var template = new Gson().fromJson(input, Template.class);
+        Assertions.assertThat(template.getIndexSettings()).isNotNull();
+        Assertions.assertThat(template.getIndexSettings().getNumberOfShards()).isEqualTo(5);
+        Assertions.assertThat(template.getIndexSettings().getNumberOfReplicas()).isEqualTo(10);
+        Assertions.assertThat(template.getIndexSettings().getRefreshInterval()).isEqualTo("10s");
+        Assertions.assertThat(template.getIndexSettings().getRoutingPartitionSize()).isEqualTo(20);
+        Assertions.assertThat(template.getIndexSettings().isEmpty()).isFalse();
+    }
+
+}


### PR DESCRIPTION
Here we make use of serialization/deserialization of Gson instead of JsonParser or manually creating the String.

This will be a bit slower, but as of now, we prefer readability and consistency over performance.
Let's see, if we have to redo this.

Maybe we can get rid of the objects used here in general, but for now I kept them.

Note: some tests fail, due to json vs string comparisation. I will fix them.

Resolves #38 