### PR TITLE
fix: elastic bean auto detection

### DIFF
--- a/src/main/java/org/riptide/RiptideApplication.java
+++ b/src/main/java/org/riptide/RiptideApplication.java
@@ -2,9 +2,11 @@ package org.riptide;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {ElasticsearchClientAutoConfiguration.class, ElasticsearchRestClientAutoConfiguration.class})
 @ConfigurationPropertiesScan
 public class RiptideApplication {
     public static void main(final String... args) {


### PR DESCRIPTION
due to spring boot's auto configuration some elastic beans are created even if elastic is disabled. This excludes elastic auto detection and uses "our" configuration instead.