### PR TITLE
Fix: Failing SNMP agent tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <netty-all.version>4.2.10.Final</netty-all.version>
         <org-eclipse-persistence-moxy.version>4.0.9</org-eclipse-persistence-moxy.version>
         <resilience4j.version>2.3.0</resilience4j.version>
-        <snmp4j.version>3.8.2</snmp4j.version>
+        <snmp4j.version>3.9.7</snmp4j.version>
         <snmp4j-agent.version>3.8.3</snmp4j-agent.version>
         <dropwizard-metrics.version>4.2.38</dropwizard-metrics.version>
         <jquick.version>1.9.3</jquick.version>

--- a/src/main/java/org/riptide/snmp/SnmpUtils.java
+++ b/src/main/java/org/riptide/snmp/SnmpUtils.java
@@ -43,7 +43,7 @@ public final class SnmpUtils {
 
             if (entry == table.getColumn()) {
                 for (final VariableBinding vb : tableEvent.getColumns()) {
-                    if (vb != null && vb.getVariable() != null) {
+                    if (vb != null && vb.getVariable() != null && !vb.getVariable().toString().isEmpty()) {
                         snmpInterfaceMap.put(snmpIfIndex, vb.getVariable().toString());
                     }
                 }

--- a/src/main/java/org/riptide/snmp/SnmpVersion.java
+++ b/src/main/java/org/riptide/snmp/SnmpVersion.java
@@ -71,12 +71,20 @@ enum SnmpVersion {
         Target<?> getTarget(final Snmp snmp, final SnmpBuilder snmpBuilder, final SnmpEndpoint snmpEndpoint) throws UnknownHostException {
             final Address targetAddress = getTargetAddress(snmpEndpoint);
             final byte[] targetEngineID = snmp.discoverAuthoritativeEngineID(targetAddress, 1000);
-            return snmpBuilder
+            var userBuilder = snmpBuilder
                     .v3()
                     .target(targetAddress)
-                    .user(snmpEndpoint.getSnmpDefinition().getSecurityName(), targetEngineID)
-                    .auth(snmpEndpoint.getSnmpDefinition().getAuthProtocol()).authPassphrase(snmpEndpoint.getSnmpDefinition().getAuthPassphrase())
-                    .priv(snmpEndpoint.getSnmpDefinition().getPrivProtocol()).privPassphrase(snmpEndpoint.getSnmpDefinition().getPrivPassphrase())
+                    .user(snmpEndpoint.getSnmpDefinition().getSecurityName(), targetEngineID);
+
+            if (snmpEndpoint.getSnmpDefinition().getAuthProtocol() != null && snmpEndpoint.getSnmpDefinition().getAuthPassphrase() != null) {
+                userBuilder = userBuilder.auth(snmpEndpoint.getSnmpDefinition().getAuthProtocol()).authPassphrase(snmpEndpoint.getSnmpDefinition().getAuthPassphrase());
+            }
+
+            if (snmpEndpoint.getSnmpDefinition().getPrivProtocol() != null && snmpEndpoint.getSnmpDefinition().getPrivPassphrase() != null) {
+                userBuilder = userBuilder.priv(snmpEndpoint.getSnmpDefinition().getPrivProtocol()).privPassphrase(snmpEndpoint.getSnmpDefinition().getPrivPassphrase());
+            }
+
+            return userBuilder
                     .done()
                     .timeout(snmpEndpoint.getSnmpDefinition().getTimeout())
                     .retries(snmpEndpoint.getSnmpDefinition().getRetries())


### PR DESCRIPTION
Tests run in parallel and create port binding issues. Increment ports for the tests and add null checks to get rid of the NPE errors.