### PR TITLE
fix: Declare org.jetbrains:annotations as direct dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <ipaddress.version>5.6.1</ipaddress.version>
         <jakarta-xml-bind-api.version>4.0.5</jakarta-xml-bind-api.version>
         <java.version>25</java.version>
+        <jetbrains-annotations.version>26.0.2</jetbrains-annotations.version>
         <lombok.version>1.18.44</lombok.version>
         <mapstruct.version>1.6.3</mapstruct.version>
         <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
@@ -128,6 +129,15 @@
             <artifactId>org.eclipse.persistence.moxy</artifactId>
             <version>${org-eclipse-persistence-moxy.version}</version>
             <scope>runtime</scope>
+        </dependency>
+
+        <!-- JetBrains annotations (@NotNull, @Language) used in sources; compile-time only.
+             Was previously available transitively via resilience4j 2.3.x -> kotlin-stdlib. -->
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>${jetbrains-annotations.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- support for lombok -->


### PR DESCRIPTION
Fixes the compilation failure on `main` introduced by #143.

`ClickhouseRepository` (`@Language`) and `ValueConversionService` (`@NotNull`) use JetBrains annotations that were only on the classpath transitively via resilience4j 2.3.x → kotlin-stdlib → `org.jetbrains:annotations:13.0`. resilience4j 2.4.0 dropped its Kotlin dependency, so the undeclared usage broke.

Declares `org.jetbrains:annotations:26.0.2` explicitly with `provided` scope (compile-time only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)