### PR TITLE
chore: Attribute copyright to Riptide Labs in SPDX headers

### DIFF
--- a/src/main/java/org/riptide/RiptideApplication.java
+++ b/src/main/java/org/riptide/RiptideApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/bucketize/Bucket.java
+++ b/src/main/java/org/riptide/bucketize/Bucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/ClassificationEngine.java
+++ b/src/main/java/org/riptide/classification/ClassificationEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/ClassificationEnricher.java
+++ b/src/main/java/org/riptide/classification/ClassificationEnricher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/ClassificationRequest.java
+++ b/src/main/java/org/riptide/classification/ClassificationRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/ClassificationRuleProvider.java
+++ b/src/main/java/org/riptide/classification/ClassificationRuleProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/DefaultRule.java
+++ b/src/main/java/org/riptide/classification/DefaultRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/IpAddr.java
+++ b/src/main/java/org/riptide/classification/IpAddr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/Protocol.java
+++ b/src/main/java/org/riptide/classification/Protocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/ProtocolType.java
+++ b/src/main/java/org/riptide/classification/ProtocolType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/Protocols.java
+++ b/src/main/java/org/riptide/classification/Protocols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/Rule.java
+++ b/src/main/java/org/riptide/classification/Rule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/internal/AsyncReloadingClassificationEngine.java
+++ b/src/main/java/org/riptide/classification/internal/AsyncReloadingClassificationEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/internal/DefaultClassificationEngine.java
+++ b/src/main/java/org/riptide/classification/internal/DefaultClassificationEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/internal/TimingClassificationEngine.java
+++ b/src/main/java/org/riptide/classification/internal/TimingClassificationEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/internal/csv/CsvImporter.java
+++ b/src/main/java/org/riptide/classification/internal/csv/CsvImporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/internal/decision/Bound.java
+++ b/src/main/java/org/riptide/classification/internal/decision/Bound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/internal/decision/Bounds.java
+++ b/src/main/java/org/riptide/classification/internal/decision/Bounds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/internal/decision/Classifier.java
+++ b/src/main/java/org/riptide/classification/internal/decision/Classifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/internal/decision/PreprocessedRule.java
+++ b/src/main/java/org/riptide/classification/internal/decision/PreprocessedRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/internal/decision/Threshold.java
+++ b/src/main/java/org/riptide/classification/internal/decision/Threshold.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/internal/decision/Tree.java
+++ b/src/main/java/org/riptide/classification/internal/decision/Tree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/internal/matcher/DstAddressMatcher.java
+++ b/src/main/java/org/riptide/classification/internal/matcher/DstAddressMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/internal/matcher/DstPortMatcher.java
+++ b/src/main/java/org/riptide/classification/internal/matcher/DstPortMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/internal/matcher/IpMatcher.java
+++ b/src/main/java/org/riptide/classification/internal/matcher/IpMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/internal/matcher/Matcher.java
+++ b/src/main/java/org/riptide/classification/internal/matcher/Matcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/internal/matcher/PortMatcher.java
+++ b/src/main/java/org/riptide/classification/internal/matcher/PortMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/internal/matcher/ProtocolMatcher.java
+++ b/src/main/java/org/riptide/classification/internal/matcher/ProtocolMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/internal/matcher/SrcAddressMatcher.java
+++ b/src/main/java/org/riptide/classification/internal/matcher/SrcAddressMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/internal/matcher/SrcPortMatcher.java
+++ b/src/main/java/org/riptide/classification/internal/matcher/SrcPortMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/internal/value/IPPortRange.java
+++ b/src/main/java/org/riptide/classification/internal/value/IPPortRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/internal/value/IntegerValue.java
+++ b/src/main/java/org/riptide/classification/internal/value/IntegerValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/internal/value/IpRange.java
+++ b/src/main/java/org/riptide/classification/internal/value/IpRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/internal/value/IpValue.java
+++ b/src/main/java/org/riptide/classification/internal/value/IpValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/internal/value/PortValue.java
+++ b/src/main/java/org/riptide/classification/internal/value/PortValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/internal/value/ProtocolValue.java
+++ b/src/main/java/org/riptide/classification/internal/value/ProtocolValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/internal/value/RangedValue.java
+++ b/src/main/java/org/riptide/classification/internal/value/RangedValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/internal/value/RuleValue.java
+++ b/src/main/java/org/riptide/classification/internal/value/RuleValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/classification/internal/value/StringValue.java
+++ b/src/main/java/org/riptide/classification/internal/value/StringValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/clock/ClockCorrectionEnricher.java
+++ b/src/main/java/org/riptide/clock/ClockCorrectionEnricher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/config/ClickhouseConfig.java
+++ b/src/main/java/org/riptide/config/ClickhouseConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/config/DaemonConfig.java
+++ b/src/main/java/org/riptide/config/DaemonConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/config/ReceiverConfig.java
+++ b/src/main/java/org/riptide/config/ReceiverConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/config/enricher/ClockCorrectionConfiguration.java
+++ b/src/main/java/org/riptide/config/enricher/ClockCorrectionConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/config/enricher/HostnamesConfig.java
+++ b/src/main/java/org/riptide/config/enricher/HostnamesConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/configuration/ClickhouseConfiguration.java
+++ b/src/main/java/org/riptide/configuration/ClickhouseConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/configuration/RiptideConfiguration.java
+++ b/src/main/java/org/riptide/configuration/RiptideConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/dns/HostnamesEnricher.java
+++ b/src/main/java/org/riptide/dns/HostnamesEnricher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/dns/api/DnsResolver.java
+++ b/src/main/java/org/riptide/dns/api/DnsResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/dns/netty/CircuitBreakerDnsWrapper.java
+++ b/src/main/java/org/riptide/dns/netty/CircuitBreakerDnsWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/dns/netty/DefaultDnsReverseCache.java
+++ b/src/main/java/org/riptide/dns/netty/DefaultDnsReverseCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/dns/netty/DefaultDnsServerAddressProvider.java
+++ b/src/main/java/org/riptide/dns/netty/DefaultDnsServerAddressProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/dns/netty/DnsReverseCacheEntry.java
+++ b/src/main/java/org/riptide/dns/netty/DnsReverseCacheEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/dns/netty/NettyDnsConfiguration.java
+++ b/src/main/java/org/riptide/dns/netty/NettyDnsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/dns/netty/NettyDnsResolver.java
+++ b/src/main/java/org/riptide/dns/netty/NettyDnsResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/dns/netty/NettyDnsResolverWorker.java
+++ b/src/main/java/org/riptide/dns/netty/NettyDnsResolverWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/Daemon.java
+++ b/src/main/java/org/riptide/flows/Daemon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/listeners/Listener.java
+++ b/src/main/java/org/riptide/flows/listeners/Listener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/listeners/TcpListener.java
+++ b/src/main/java/org/riptide/flows/listeners/TcpListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/listeners/TcpParser.java
+++ b/src/main/java/org/riptide/flows/listeners/TcpParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/listeners/UdpListener.java
+++ b/src/main/java/org/riptide/flows/listeners/UdpListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/listeners/UdpParser.java
+++ b/src/main/java/org/riptide/flows/listeners/UdpParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/listeners/multi/Dispatchable.java
+++ b/src/main/java/org/riptide/flows/listeners/multi/Dispatchable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/listeners/multi/DispatchableUdpParser.java
+++ b/src/main/java/org/riptide/flows/listeners/multi/DispatchableUdpParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/listeners/multi/DispatchingUdpParser.java
+++ b/src/main/java/org/riptide/flows/listeners/multi/DispatchingUdpParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/FlowPacket.java
+++ b/src/main/java/org/riptide/flows/parser/FlowPacket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/Parser.java
+++ b/src/main/java/org/riptide/flows/parser/Parser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ParserBase.java
+++ b/src/main/java/org/riptide/flows/parser/ParserBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/Protocol.java
+++ b/src/main/java/org/riptide/flows/parser/Protocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/UdpParserBase.java
+++ b/src/main/java/org/riptide/flows/parser/UdpParserBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/data/Flow.java
+++ b/src/main/java/org/riptide/flows/parser/data/Flow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/data/Optionals.java
+++ b/src/main/java/org/riptide/flows/parser/data/Optionals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/data/Timeout.java
+++ b/src/main/java/org/riptide/flows/parser/data/Timeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/exceptions/IllegalFlowException.java
+++ b/src/main/java/org/riptide/flows/parser/exceptions/IllegalFlowException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/exceptions/InvalidPacketException.java
+++ b/src/main/java/org/riptide/flows/parser/exceptions/InvalidPacketException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/exceptions/MissingTemplateException.java
+++ b/src/main/java/org/riptide/flows/parser/exceptions/MissingTemplateException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ie/InformationElement.java
+++ b/src/main/java/org/riptide/flows/parser/ie/InformationElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ie/InformationElementDatabase.java
+++ b/src/main/java/org/riptide/flows/parser/ie/InformationElementDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ie/Semantics.java
+++ b/src/main/java/org/riptide/flows/parser/ie/Semantics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ie/Value.java
+++ b/src/main/java/org/riptide/flows/parser/ie/Value.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ie/values/BooleanValue.java
+++ b/src/main/java/org/riptide/flows/parser/ie/values/BooleanValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ie/values/DateTimeValue.java
+++ b/src/main/java/org/riptide/flows/parser/ie/values/DateTimeValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ie/values/FloatValue.java
+++ b/src/main/java/org/riptide/flows/parser/ie/values/FloatValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ie/values/IPv4AddressValue.java
+++ b/src/main/java/org/riptide/flows/parser/ie/values/IPv4AddressValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ie/values/IPv6AddressValue.java
+++ b/src/main/java/org/riptide/flows/parser/ie/values/IPv6AddressValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ie/values/ListValue.java
+++ b/src/main/java/org/riptide/flows/parser/ie/values/ListValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ie/values/MacAddressValue.java
+++ b/src/main/java/org/riptide/flows/parser/ie/values/MacAddressValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ie/values/NullValue.java
+++ b/src/main/java/org/riptide/flows/parser/ie/values/NullValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ie/values/OctetArrayValue.java
+++ b/src/main/java/org/riptide/flows/parser/ie/values/OctetArrayValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ie/values/SignedValue.java
+++ b/src/main/java/org/riptide/flows/parser/ie/values/SignedValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ie/values/StringValue.java
+++ b/src/main/java/org/riptide/flows/parser/ie/values/StringValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ie/values/UndeclaredValue.java
+++ b/src/main/java/org/riptide/flows/parser/ie/values/UndeclaredValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ie/values/UnsignedValue.java
+++ b/src/main/java/org/riptide/flows/parser/ie/values/UnsignedValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ie/values/ValueConversionService.java
+++ b/src/main/java/org/riptide/flows/parser/ie/values/ValueConversionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ie/values/visitor/BooleanVisitor.java
+++ b/src/main/java/org/riptide/flows/parser/ie/values/visitor/BooleanVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ie/values/visitor/DoubleVisitor.java
+++ b/src/main/java/org/riptide/flows/parser/ie/values/visitor/DoubleVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ie/values/visitor/DurationVisitor.java
+++ b/src/main/java/org/riptide/flows/parser/ie/values/visitor/DurationVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ie/values/visitor/InetAddressVisitor.java
+++ b/src/main/java/org/riptide/flows/parser/ie/values/visitor/InetAddressVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ie/values/visitor/InstantVisitor.java
+++ b/src/main/java/org/riptide/flows/parser/ie/values/visitor/InstantVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ie/values/visitor/IntegerVisitor.java
+++ b/src/main/java/org/riptide/flows/parser/ie/values/visitor/IntegerVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ie/values/visitor/LongVisitor.java
+++ b/src/main/java/org/riptide/flows/parser/ie/values/visitor/LongVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ie/values/visitor/StringVisitor.java
+++ b/src/main/java/org/riptide/flows/parser/ie/values/visitor/StringVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ie/values/visitor/UnsignedLongVisitor.java
+++ b/src/main/java/org/riptide/flows/parser/ie/values/visitor/UnsignedLongVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ie/values/visitor/ValueVisitor.java
+++ b/src/main/java/org/riptide/flows/parser/ie/values/visitor/ValueVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ipfix/InformationElementProvider.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/InformationElementProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ipfix/IpFixFlowBuilder.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/IpFixFlowBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ipfix/IpfixRawFlow.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/IpfixRawFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ipfix/IpfixTcpParser.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/IpfixTcpParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ipfix/IpfixUdpParser.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/IpfixUdpParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ipfix/proto/DataRecord.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/proto/DataRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ipfix/proto/DataSet.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/proto/DataSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ipfix/proto/FieldSpecifier.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/proto/FieldSpecifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ipfix/proto/FlowSet.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/proto/FlowSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ipfix/proto/FlowSetHeader.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/proto/FlowSetHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ipfix/proto/Header.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/proto/Header.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ipfix/proto/OptionsTemplateRecord.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/proto/OptionsTemplateRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ipfix/proto/OptionsTemplateRecordHeader.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/proto/OptionsTemplateRecordHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ipfix/proto/OptionsTemplateSet.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/proto/OptionsTemplateSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ipfix/proto/Packet.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/proto/Packet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ipfix/proto/Record.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/proto/Record.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ipfix/proto/TemplateRecord.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/proto/TemplateRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ipfix/proto/TemplateRecordHeader.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/proto/TemplateRecordHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/ipfix/proto/TemplateSet.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/proto/TemplateSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/netflow5/Netflow5FlowBuilder.java
+++ b/src/main/java/org/riptide/flows/parser/netflow5/Netflow5FlowBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/netflow5/Netflow5UdpParser.java
+++ b/src/main/java/org/riptide/flows/parser/netflow5/Netflow5UdpParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/netflow5/proto/Header.java
+++ b/src/main/java/org/riptide/flows/parser/netflow5/proto/Header.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/netflow5/proto/Packet.java
+++ b/src/main/java/org/riptide/flows/parser/netflow5/proto/Packet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/netflow5/proto/Record.java
+++ b/src/main/java/org/riptide/flows/parser/netflow5/proto/Record.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/netflow9/InformationElementProvider.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/InformationElementProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/netflow9/Netflow9FlowBuilder.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/Netflow9FlowBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/netflow9/Netflow9RawFlow.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/Netflow9RawFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/netflow9/Netflow9UdpParser.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/Netflow9UdpParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/netflow9/proto/DataRecord.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/proto/DataRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/netflow9/proto/DataSet.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/proto/DataSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/netflow9/proto/FieldSpecifier.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/proto/FieldSpecifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/netflow9/proto/FlowSet.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/proto/FlowSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/netflow9/proto/FlowSetHeader.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/proto/FlowSetHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/netflow9/proto/Header.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/proto/Header.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/netflow9/proto/OptionsTemplateRecord.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/proto/OptionsTemplateRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/netflow9/proto/OptionsTemplateRecordHeader.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/proto/OptionsTemplateRecordHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/netflow9/proto/OptionsTemplateSet.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/proto/OptionsTemplateSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/netflow9/proto/Packet.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/proto/Packet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/netflow9/proto/Record.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/proto/Record.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/netflow9/proto/ScopeFieldSpecifier.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/proto/ScopeFieldSpecifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/netflow9/proto/TemplateRecord.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/proto/TemplateRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/netflow9/proto/TemplateRecordHeader.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/proto/TemplateRecordHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/netflow9/proto/TemplateSet.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/proto/TemplateSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/session/Field.java
+++ b/src/main/java/org/riptide/flows/parser/session/Field.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/session/Scope.java
+++ b/src/main/java/org/riptide/flows/parser/session/Scope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/session/SequenceNumberTracker.java
+++ b/src/main/java/org/riptide/flows/parser/session/SequenceNumberTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/session/Session.java
+++ b/src/main/java/org/riptide/flows/parser/session/Session.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/session/TcpSession.java
+++ b/src/main/java/org/riptide/flows/parser/session/TcpSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/session/Template.java
+++ b/src/main/java/org/riptide/flows/parser/session/Template.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/session/UdpSessionManager.java
+++ b/src/main/java/org/riptide/flows/parser/session/UdpSessionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/state/ExporterState.java
+++ b/src/main/java/org/riptide/flows/parser/state/ExporterState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/state/OptionState.java
+++ b/src/main/java/org/riptide/flows/parser/state/OptionState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/state/ParserState.java
+++ b/src/main/java/org/riptide/flows/parser/state/ParserState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/parser/state/TemplateState.java
+++ b/src/main/java/org/riptide/flows/parser/state/TemplateState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/flows/utils/BufferUtils.java
+++ b/src/main/java/org/riptide/flows/utils/BufferUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/locality/LocalityEnricher.java
+++ b/src/main/java/org/riptide/locality/LocalityEnricher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/pipeline/EnrichedFlow.java
+++ b/src/main/java/org/riptide/pipeline/EnrichedFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/pipeline/Enricher.java
+++ b/src/main/java/org/riptide/pipeline/Enricher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/pipeline/FlowException.java
+++ b/src/main/java/org/riptide/pipeline/FlowException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/pipeline/FlowPersister.java
+++ b/src/main/java/org/riptide/pipeline/FlowPersister.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/pipeline/Pipeline.java
+++ b/src/main/java/org/riptide/pipeline/Pipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/pipeline/Source.java
+++ b/src/main/java/org/riptide/pipeline/Source.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/repository/FlowRepository.java
+++ b/src/main/java/org/riptide/repository/FlowRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/repository/clickhouse/ClickhouseFlow.java
+++ b/src/main/java/org/riptide/repository/clickhouse/ClickhouseFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
+++ b/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/snmp/CachingSnmpService.java
+++ b/src/main/java/org/riptide/snmp/CachingSnmpService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/snmp/DefaultSnmpService.java
+++ b/src/main/java/org/riptide/snmp/DefaultSnmpService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/snmp/SnmpCacheConfig.java
+++ b/src/main/java/org/riptide/snmp/SnmpCacheConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/snmp/SnmpConfiguration.java
+++ b/src/main/java/org/riptide/snmp/SnmpConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/snmp/SnmpDefinition.java
+++ b/src/main/java/org/riptide/snmp/SnmpDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/snmp/SnmpEndpoint.java
+++ b/src/main/java/org/riptide/snmp/SnmpEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/snmp/SnmpEnricher.java
+++ b/src/main/java/org/riptide/snmp/SnmpEnricher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/snmp/SnmpIfTable.java
+++ b/src/main/java/org/riptide/snmp/SnmpIfTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/snmp/SnmpIfXTable.java
+++ b/src/main/java/org/riptide/snmp/SnmpIfXTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/snmp/SnmpService.java
+++ b/src/main/java/org/riptide/snmp/SnmpService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/snmp/SnmpTable.java
+++ b/src/main/java/org/riptide/snmp/SnmpTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/snmp/SnmpUtils.java
+++ b/src/main/java/org/riptide/snmp/SnmpUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/snmp/SnmpVersion.java
+++ b/src/main/java/org/riptide/snmp/SnmpVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/utils/Durations.java
+++ b/src/main/java/org/riptide/utils/Durations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/main/java/org/riptide/utils/Tuple.java
+++ b/src/main/java/org/riptide/utils/Tuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/benchmarks/Benchmarks.java
+++ b/src/test/java/org/riptide/benchmarks/Benchmarks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/benchmarks/parser/ipfix/IpfixFullBenchmark.java
+++ b/src/test/java/org/riptide/benchmarks/parser/ipfix/IpfixFullBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/benchmarks/parser/ipfix/IpfixInterpreterBenchmark.java
+++ b/src/test/java/org/riptide/benchmarks/parser/ipfix/IpfixInterpreterBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/benchmarks/parser/ipfix/IpfixParserBenchmark.java
+++ b/src/test/java/org/riptide/benchmarks/parser/ipfix/IpfixParserBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/bucketize/BucketTest.java
+++ b/src/test/java/org/riptide/bucketize/BucketTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/classification/internal/ClassificationEnricherTest.java
+++ b/src/test/java/org/riptide/classification/internal/ClassificationEnricherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/classification/internal/DefaultClassificationEngineTest.java
+++ b/src/test/java/org/riptide/classification/internal/DefaultClassificationEngineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/classification/internal/DefaultClassificationExtendedEngineTest.java
+++ b/src/test/java/org/riptide/classification/internal/DefaultClassificationExtendedEngineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/classification/internal/value/IpValueTest.java
+++ b/src/test/java/org/riptide/classification/internal/value/IpValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/classification/internal/value/PortValueTest.java
+++ b/src/test/java/org/riptide/classification/internal/value/PortValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/classification/internal/value/RangedValueTest.java
+++ b/src/test/java/org/riptide/classification/internal/value/RangedValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/classification/internal/value/StringValueTest.java
+++ b/src/test/java/org/riptide/classification/internal/value/StringValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/configuration/RiptideConfigurationTest.java
+++ b/src/test/java/org/riptide/configuration/RiptideConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/dns/HostnamesEnricherTest.java
+++ b/src/test/java/org/riptide/dns/HostnamesEnricherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/dns/MockDnsServer.java
+++ b/src/test/java/org/riptide/dns/MockDnsServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/flows/ipfix/BlackboxTest.java
+++ b/src/test/java/org/riptide/flows/ipfix/BlackboxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/flows/ipfix/FlowTimeoutTest.java
+++ b/src/test/java/org/riptide/flows/ipfix/FlowTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/flows/netflow5/Netflow5ConverterTest.java
+++ b/src/test/java/org/riptide/flows/netflow5/Netflow5ConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/flows/netflow5/NetflowPacketTest.java
+++ b/src/test/java/org/riptide/flows/netflow5/NetflowPacketTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/flows/netflow9/BlackboxTest.java
+++ b/src/test/java/org/riptide/flows/netflow9/BlackboxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/flows/netflow9/FlowTimeoutTest.java
+++ b/src/test/java/org/riptide/flows/netflow9/FlowTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/flows/netflow9/Netflow9ConverterTest.java
+++ b/src/test/java/org/riptide/flows/netflow9/Netflow9ConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/flows/parser/BufferUtilsTest.java
+++ b/src/test/java/org/riptide/flows/parser/BufferUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/flows/parser/Netflow9TimeSwitchedParserTest.java
+++ b/src/test/java/org/riptide/flows/parser/Netflow9TimeSwitchedParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/flows/parser/ParserTest.java
+++ b/src/test/java/org/riptide/flows/parser/ParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/flows/parser/PayloadTest.java
+++ b/src/test/java/org/riptide/flows/parser/PayloadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/flows/parser/SequenceNumberTrackerTest.java
+++ b/src/test/java/org/riptide/flows/parser/SequenceNumberTrackerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/flows/parser/SnmpInputOutputParserTest.java
+++ b/src/test/java/org/riptide/flows/parser/SnmpInputOutputParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/flows/parser/ValueTest.java
+++ b/src/test/java/org/riptide/flows/parser/ValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/flows/parser/ipfix/InformationElementProviderTest.java
+++ b/src/test/java/org/riptide/flows/parser/ipfix/InformationElementProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/flows/parser/session/UdpSessionManagerTest.java
+++ b/src/test/java/org/riptide/flows/parser/session/UdpSessionManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/repository/NoopRepository.java
+++ b/src/test/java/org/riptide/repository/NoopRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/repository/TestRepository.java
+++ b/src/test/java/org/riptide/repository/TestRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/snmp/SnmpEnricherTest.java
+++ b/src/test/java/org/riptide/snmp/SnmpEnricherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/snmp/SnmpTest.java
+++ b/src/test/java/org/riptide/snmp/SnmpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/test/java/org/riptide/snmp/TestSnmpAgent.java
+++ b/src/test/java/org/riptide/snmp/TestSnmpAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Ronny Trommer <ronny@no42.org>
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 


### PR DESCRIPTION
Replaces the personal copyright line in all 220 Java source headers with `Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>`. One-line change per file, comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)