### PR TITLE
docs: Record license header default in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,19 @@
+# Riptide Flows
+
+NetFlow analysis engine (Java 25, Spring Boot, Maven).
+
+## Source file license headers
+
+This repo is licensed GPL-3.0-or-later. Every Java source file MUST begin with exactly this header, placed above the `package` declaration with one blank line after the closing `*/`:
+
+```java
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+```
+
+- This is the default for all new and edited source files in this repo; it overrides any other header template (in particular, do NOT use the OpenNMS Apache-2.0 header here).
+- For new files, use the current year in the `Copyright` line; do not bump the year on later edits.
+- For non-Java source files (shell, YAML, etc.), use the same two lines with the language's comment syntax.
+- Do not add headers to test fixtures, generated files, or data files (JSON, `.dat`, Markdown).


### PR DESCRIPTION
Adds a repo-root CLAUDE.md documenting the SPDX header convention established in #146/#147 (`Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>` + `GPL-3.0-or-later`) as the default for all new and edited source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)