### PR TITLE
feat: Make classification rules location configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,9 @@ application-local.properties
 ### Docker Compose Override ###
 compose.override.y*ml
 docker-compose.override.y*ml
+
+# AI tools
+_bmad-output/
+_bmad/
+openspec/
+.claude/

--- a/src/main/java/org/riptide/config/ClassificationConfig.java
+++ b/src/main/java/org/riptide/config/ClassificationConfig.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+@ConfigurationProperties(prefix = "riptide.classification")
+@Data
+public class ClassificationConfig {
+    /**
+     * The classification rules CSV as a Spring resource location,
+     * e.g. "classpath:/classification-rules.csv" or "file:/etc/riptide/rules.csv".
+     */
+    private Resource rules = new ClassPathResource("classification-rules.csv");
+}

--- a/src/main/java/org/riptide/config/ReceiverConfig.java
+++ b/src/main/java/org/riptide/config/ReceiverConfig.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.xbill.DNS.dnssec.R;
 
 import java.time.Duration;
 

--- a/src/main/java/org/riptide/configuration/RiptideConfiguration.java
+++ b/src/main/java/org/riptide/configuration/RiptideConfiguration.java
@@ -7,13 +7,13 @@ package org.riptide.configuration;
 
 import com.codahale.metrics.MetricRegistry;
 import lombok.extern.slf4j.Slf4j;
-import org.riptide.RiptideApplication;
 import org.riptide.classification.ClassificationEngine;
 import org.riptide.classification.ClassificationRuleProvider;
 import org.riptide.classification.internal.AsyncReloadingClassificationEngine;
 import org.riptide.classification.internal.DefaultClassificationEngine;
 import org.riptide.classification.internal.TimingClassificationEngine;
 import org.riptide.classification.internal.csv.CsvImporter;
+import org.riptide.config.ClassificationConfig;
 import org.riptide.flows.parser.ie.values.ValueConversionService;
 import org.riptide.flows.parser.ie.values.visitor.ValueVisitor;
 import org.riptide.flows.parser.ipfix.IpfixRawFlow;
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 
 @Configuration
@@ -56,9 +57,20 @@ public class RiptideConfiguration {
     }
 
     @Bean
-    ClassificationRuleProvider classificationRuleProvider(final CsvImporter importer) throws IOException {
-        final var rules = importer.parse(RiptideApplication.class.getResourceAsStream("/classification-rules.csv"), true);
-        return ClassificationRuleProvider.forList(rules);
+    ClassificationRuleProvider classificationRuleProvider(final CsvImporter importer,
+                                                          final ClassificationConfig config) {
+        // Re-parse on every call so the reloading engine picks up edits to a
+        // file-based rules resource; a one-shot snapshot would make reload() a no-op.
+        final ClassificationRuleProvider provider = () -> {
+            try (var stream = config.getRules().getInputStream()) {
+                return importer.parse(stream, true);
+            } catch (final IOException e) {
+                throw new UncheckedIOException("Cannot load classification rules from " + config.getRules(), e);
+            }
+        };
+        // Fail fast at startup instead of on the async reload thread.
+        provider.getRules();
+        return provider;
     }
 
     @Bean

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,15 @@ spring.main.keep-alive=true
 spring.config.additional-location=optional:file:/etc/riptide/config.yaml
 
 # DAEMON
-riptide.daemon.port=9999
+# Receivers are empty by default: the daemon starts no listeners. Note that
+# entries defined here merge with (and cannot be removed by) external config.
+# RECEIVER EXAMPLE
+#riptide.receivers.ipfix.type=ipfix
+#riptide.receivers.ipfix.host=0.0.0.0
+#riptide.receivers.ipfix.port=4739
+
+# CLASSIFICATION EXAMPLE
+#riptide.classification.rules=file:/etc/riptide/classification-rules.csv
 
 # CLICKHOUSE
 riptide.clickhouse.endpoint=http://localhost:8123

--- a/src/test/java/org/riptide/configuration/ClassificationRuleProviderTest.java
+++ b/src/test/java/org/riptide/configuration/ClassificationRuleProviderTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.configuration;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.riptide.classification.internal.csv.CsvImporter;
+import org.riptide.config.ClassificationConfig;
+import org.springframework.core.io.FileSystemResource;
+
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class ClassificationRuleProviderTest {
+
+    private static final String HEADER = "name;protocol;srcAddress;srcPort;dstAddress;dstPort;exporterFilter;omnidirectional\n";
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void verifyReloadPicksUpFileChanges() throws Exception {
+        final var rulesFile = tempDir.resolve("rules.csv");
+        Files.writeString(rulesFile, HEADER + "ntp;udp;;;;123;;true\n");
+
+        final var config = new ClassificationConfig();
+        config.setRules(new FileSystemResource(rulesFile));
+
+        final var provider = new RiptideConfiguration().classificationRuleProvider(new CsvImporter(), config);
+        Assertions.assertThat(provider.getRules()).hasSize(1);
+
+        Files.writeString(rulesFile, HEADER + "ntp;udp;;;;123;;true\nssh;tcp;;;;22;;true\n");
+        Assertions.assertThat(provider.getRules()).hasSize(2);
+    }
+
+    @Test
+    void verifyFailsFastOnUnreadableResource() {
+        final var config = new ClassificationConfig();
+        config.setRules(new FileSystemResource(tempDir.resolve("missing.csv")));
+
+        Assertions.assertThatThrownBy(() -> new RiptideConfiguration().classificationRuleProvider(new CsvImporter(), config))
+                .isInstanceOf(UncheckedIOException.class);
+    }
+}


### PR DESCRIPTION
## What

- **`ClassificationConfig`** (`riptide.classification.rules`): classification rules CSV as a Spring `Resource` (`classpath:` default, `file:` supported). The rule provider re-parses the resource on every `getRules()`, so `AsyncReloadingClassificationEngine.reload()` genuinely picks up file edits (previously `forList()` froze a startup snapshot, making reload a silent no-op for external files). Stream is closed per parse; startup fails fast on unreadable/malformed rules instead of surfacing on the async reload thread.
- **Receiver defaults cleaned up**: removes the dead `riptide.daemon.port` key; ships the IPFIX receiver as a commented example rather than a live default. Review found a baked-in receiver binds UDP 0.0.0.0:9999 in every Spring context — including the test suite (verified via lsof) — and Spring's map-merge semantics make a default receivers entry impossible to remove from external config.
- **No infrastructure in the repo**: ClickHouse endpoint defaults to `localhost:8123` (matches `deployment/clickhouse`).
- Housekeeping: unused import dropped in `ReceiverConfig`, AI tool working dirs added to `.gitignore`.

## Tests

New `ClassificationRuleProviderTest` covers re-parse-on-reload against an edited file and fail-fast on a missing resource. Full suite: **522 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)