### PR TITLE
test: Add e2e flow-ingestion stack (nl6) and coverage baseline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,3 +34,20 @@ jobs:
           name: riptide-jar
           path: |
             target/*.jar
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - name: Set up JDK 25 for x64
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          architecture: x64
+          cache: maven
+      # The nl6 container needs NET_ADMIN + SYS_ADMIN and /dev/net/tun.
+      # Testcontainers requests them per container; the runner's root Docker
+      # daemon grants them without extra runner configuration.
+      - name: Integration and e2e tests
+        run: |
+          make e2e

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ help:
 	@echo "  help:         Show this help with explaining the build goals"
 	@echo "  jar:          Compile Riptide from source with tests and generate a runnable jar file in the target directory"
 	@echo "  oci:          Build OCI container image"
+	@echo "  coverage:     Run the unit test suite and render the JaCoCo coverage report"
+	@echo "  e2e:          Run integration and e2e tests (*IT, requires Docker) in addition to the unit suite"
 	@echo "  clean:        Clean the build artifacts"
 	@echo ""
 
@@ -51,6 +53,16 @@ deps-oci:
 .PHONY: jar
 jar: deps-jar
 	mvn $(BUILD_OPTS) --batch-mode --update-snapshots verify
+
+.PHONY: coverage
+coverage: deps-jar
+	mvn $(BUILD_OPTS) --batch-mode test jacoco:report
+	@echo "Coverage report: target/site/jacoco/index.html"
+
+.PHONY: e2e
+e2e: deps-jar deps-oci
+	mvn $(BUILD_OPTS) --batch-mode --update-snapshots verify -Pe2e
+	@echo "Coverage report (incl. e2e): target/site/jacoco/index.html"
 
 .PHONY: oci
 oci: deps-oci jar

--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ Build a container image in your local registry
 make oci
 ```
 
+Render a test coverage report (JaCoCo)
+
+```
+make coverage
+```
+
+Run the integration and e2e test tier (requires Docker; drives real NetFlow v5/v9 and IPFIX
+traffic from the [nl6](https://github.com/labmonkeys-space/nl6) simulator through riptide
+into ClickHouse). The nl6 image tag is pinned in `src/test/java/org/riptide/e2e/Nl6Container.java`
+and is bumped deliberately — it is a wire-format contract, not a Dependabot-managed dependency.
+
+```
+make e2e
+```
+
 # 🕹️ Run on your local system
 
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,21 @@
         <jquick.version>1.9.3</jquick.version>
         <clickhouse.version>0.9.7</clickhouse.version>
         <jmh.version>1.37</jmh.version>
+        <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
+        <testcontainers.version>1.21.3</testcontainers.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${testcontainers.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -168,6 +182,16 @@
             <version>${snmp4j-agent.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
             <dependency>
             <groupId>net.jqwik</groupId>
             <artifactId>jqwik</artifactId>
@@ -260,8 +284,58 @@
                 <artifactId>versions-maven-plugin</artifactId>
                 <version>${versions-maven-plugin.version}</version>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- Integration and e2e tests (*IT classes) need Docker; kept out of the default build. -->
+        <profile>
+            <id>e2e</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <!-- docker-java defaults to Docker API 1.32, which modern
+                                     daemons (e.g. OrbStack) reject; 1.44 = Docker 25+ (2024). -->
+                                <api.version>1.44</api.version>
+                            </systemPropertyVariables>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
     <repositories>
         <repository>
             <id>maven_central</id>

--- a/src/test/java/org/riptide/e2e/Nl6Container.java
+++ b/src/test/java/org/riptide/e2e/Nl6Container.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.e2e;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.dockerjava.api.model.Capability;
+import com.github.dockerjava.api.model.Device;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Map;
+
+/**
+ * The nl6 network simulator (https://github.com/labmonkeys-space/nl6) as a
+ * Testcontainers container, used as a flow generator for e2e tests.
+ *
+ * The image tag is a deliberate cross-repo contract with nl6's wire format —
+ * it is NOT managed by Dependabot; bump it in an explicit PR and investigate
+ * any e2e failures the bump surfaces.
+ *
+ * nl6 creates one TUN interface per simulated device, which requires
+ * NET_ADMIN + SYS_ADMIN capabilities and /dev/net/tun even when flow export
+ * uses a single shared socket (-flow-source-per-device=false).
+ */
+public final class Nl6Container extends GenericContainer<Nl6Container> {
+
+    private static final String IMAGE = "ghcr.io/labmonkeys-space/nl6:v0.15.1";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+
+    public Nl6Container() {
+        super(IMAGE);
+        withExposedPorts(8080);
+        withCreateContainerCmdModifier(cmd -> cmd.getHostConfig()
+                .withCapAdd(Capability.NET_ADMIN, Capability.SYS_ADMIN)
+                .withDevices(new Device("rwm", "/dev/net/tun", "/dev/net/tun")));
+        // Lets simulated devices reach riptide's listeners on the host JVM.
+        withExtraHost("host.docker.internal", "host-gateway");
+        withCommand("-flow-source-per-device=false", "-flow-template-interval", "5");
+        waitingFor(Wait.forHttp("/api/v1/flows/status").forPort(8080).forStatusCode(200));
+    }
+
+    @Override
+    public void start() {
+        try {
+            super.start();
+        } catch (final RuntimeException e) {
+            String logs = "";
+            try {
+                logs = getLogs();
+            } catch (final RuntimeException ignored) {
+                // container may be gone; fall through with the original failure
+            }
+            if (logs.contains("/dev/net/tun")) {
+                throw new IllegalStateException(
+                        "nl6 requires NET_ADMIN + SYS_ADMIN capabilities and /dev/net/tun; "
+                        + "this Docker environment does not grant them (see design of change e2e-flow-testing)", e);
+            }
+            throw e;
+        }
+    }
+
+    /** Creates a batch of devices exporting flows to the given host port on the Docker host. */
+    public void createDevices(final String startIp, final int count, final String protocol, final int collectorHostPort) throws Exception {
+        final var body = objectMapper.writeValueAsString(Map.of(
+                "start_ip", startIp,
+                "device_count", count,
+                "flow", Map.of(
+                        "collector", "host.docker.internal:" + collectorHostPort,
+                        "protocol", protocol,
+                        "tick_interval", "2s",
+                        "active_timeout", "5s",
+                        "inactive_timeout", "5s")));
+
+        final var request = HttpRequest.newBuilder(URI.create(apiBase() + "/devices"))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+        final var response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() / 100 != 2) {
+            throw new IllegalStateException("nl6 device creation failed (" + response.statusCode() + "): " + response.body());
+        }
+    }
+
+    /** Records sent so far for the collector speaking the given protocol, per nl6's ledger. */
+    public long sentRecords(final String protocol) throws Exception {
+        final var request = HttpRequest.newBuilder(URI.create(apiBase() + "/flows/status")).GET().build();
+        final var response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        final var collectors = objectMapper.readTree(response.body()).path("data").path("collectors");
+        for (final var collector : collectors) {
+            if (protocol.equals(collector.path("protocol").asText())) {
+                return collector.path("sent_records").asLong();
+            }
+        }
+        return 0;
+    }
+
+    private String apiBase() {
+        return "http://" + getHost() + ":" + getMappedPort(8080) + "/api/v1";
+    }
+}

--- a/src/test/java/org/riptide/e2e/Nl6FlowIngestionIT.java
+++ b/src/test/java/org/riptide/e2e/Nl6FlowIngestionIT.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.e2e;
+
+import com.clickhouse.client.api.Client;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import java.net.DatagramSocket;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.function.BooleanSupplier;
+
+/**
+ * End-to-end: nl6-simulated devices export NetFlow v5 / v9 / IPFIX over real
+ * UDP into riptide's listeners (running in this JVM), through parsing,
+ * enrichment, and classification, into a real ClickHouse. Assertions
+ * reconcile ClickHouse row counts against nl6's per-collector ledger.
+ */
+@SpringBootTest
+@ActiveProfiles("e2e")
+public class Nl6FlowIngestionIT {
+
+    /** Minimum ledger records per protocol before reconciliation starts. */
+    private static final long MIN_RECORDS = 50;
+    /** Tolerance for v9/IPFIX records legitimately dropped before the first template. */
+    private static final double TEMPLATE_EPSILON = 0.05;
+
+    private static final GenericContainer<?> CLICKHOUSE = new GenericContainer<>("clickhouse/clickhouse-server:25.3")
+            .withEnv("CLICKHOUSE_DB", "riptide")
+            .withEnv("CLICKHOUSE_USER", "riptide")
+            .withEnv("CLICKHOUSE_PASSWORD", "riptide")
+            .withExposedPorts(8123)
+            .waitingFor(Wait.forHttp("/ping").forPort(8123).forStatusCode(200));
+
+    private static final Nl6Container NL6 = new Nl6Container();
+
+    private static final int NETFLOW5_PORT = freeUdpPort();
+    private static final int NETFLOW9_PORT = freeUdpPort();
+    private static final int IPFIX_PORT = freeUdpPort();
+
+    private static final Instant TEST_START = Instant.now();
+
+    private static Client queryClient;
+
+    static {
+        // Containers must be up before the Spring context binds properties.
+        CLICKHOUSE.start();
+        NL6.start();
+    }
+
+    @DynamicPropertySource
+    static void riptideProperties(final DynamicPropertyRegistry registry) {
+        registry.add("riptide.clickhouse.endpoint",
+                () -> "http://" + CLICKHOUSE.getHost() + ":" + CLICKHOUSE.getMappedPort(8123));
+        registry.add("riptide.clickhouse.username", () -> "riptide");
+        registry.add("riptide.clickhouse.password", () -> "riptide");
+
+        registry.add("riptide.receivers.nf5.type", () -> "netflow5");
+        registry.add("riptide.receivers.nf5.host", () -> "0.0.0.0");
+        registry.add("riptide.receivers.nf5.port", () -> NETFLOW5_PORT);
+
+        registry.add("riptide.receivers.nf9.type", () -> "netflow9");
+        registry.add("riptide.receivers.nf9.host", () -> "0.0.0.0");
+        registry.add("riptide.receivers.nf9.port", () -> NETFLOW9_PORT);
+
+        registry.add("riptide.receivers.ipfix.type", () -> "ipfix");
+        registry.add("riptide.receivers.ipfix.host", () -> "0.0.0.0");
+        registry.add("riptide.receivers.ipfix.port", () -> IPFIX_PORT);
+    }
+
+    @BeforeAll
+    static void startTraffic() throws Exception {
+        queryClient = new Client.Builder()
+                .addEndpoint("http://" + CLICKHOUSE.getHost() + ":" + CLICKHOUSE.getMappedPort(8123))
+                .setUsername("riptide")
+                .setPassword("riptide")
+                .setDefaultDatabase("riptide")
+                .build();
+
+        NL6.createDevices("10.42.0.1", 3, "netflow5", NETFLOW5_PORT);
+        NL6.createDevices("10.42.1.1", 3, "netflow9", NETFLOW9_PORT);
+        NL6.createDevices("10.42.2.1", 3, "ipfix", IPFIX_PORT);
+    }
+
+    @Test
+    void verifyNetflow5ReachesClickhouse() throws Exception {
+        reconcile("netflow5", "NetflowV5", 0.0);
+    }
+
+    @Test
+    void verifyNetflow9ReachesClickhouse() throws Exception {
+        reconcile("netflow9", "NetflowV9", TEMPLATE_EPSILON);
+        verifyTimestampsSane("NetflowV9");
+    }
+
+    @Test
+    void verifyIpfixReachesClickhouse() throws Exception {
+        reconcile("ipfix", "IPFIX", TEMPLATE_EPSILON);
+        verifyTimestampsSane("IPFIX");
+    }
+
+    /**
+     * Waits until nl6's ledger reports at least MIN_RECORDS sent for the
+     * protocol, snapshots the ledger, then polls ClickHouse until the row
+     * count reaches the snapshot minus tolerance.
+     */
+    private void reconcile(final String nl6Protocol, final String chProtocol, final double epsilon) throws Exception {
+        await(Duration.ofMinutes(3), "nl6 ledger to reach " + MIN_RECORDS + " " + nl6Protocol + " records",
+                () -> sentRecordsUnchecked(nl6Protocol) >= MIN_RECORDS);
+
+        final long ledger = NL6.sentRecords(nl6Protocol);
+        final long threshold = (long) Math.ceil(ledger * (1.0 - epsilon));
+
+        await(Duration.ofMinutes(2), chProtocol + " rows in ClickHouse to reach " + threshold + " (ledger " + ledger + ")",
+                () -> countRows(chProtocol) >= threshold);
+
+        final var row = queryClient.queryAll(
+                "SELECT exporterAddr, application FROM flows WHERE flowProtocol = '" + chProtocol + "' LIMIT 1").getFirst();
+        Assertions.assertThat(row.getString("exporterAddr")).isNotEmpty();
+    }
+
+    private void verifyTimestampsSane(final String chProtocol) throws Exception {
+        final var row = queryClient.queryAll(
+                "SELECT min(firstSwitched) AS minFirst, max(lastSwitched) AS maxLast FROM flows WHERE flowProtocol = '"
+                        + chProtocol + "'").getFirst();
+        final var window = Duration.ofHours(1);
+        Assertions.assertThat(row.getLocalDateTime("minFirst").atZone(java.time.ZoneId.systemDefault()).toInstant())
+                .isAfter(TEST_START.minus(window));
+        Assertions.assertThat(row.getLocalDateTime("maxLast").atZone(java.time.ZoneId.systemDefault()).toInstant())
+                .isBefore(Instant.now().plus(window));
+    }
+
+    private long countRows(final String chProtocol) {
+        try {
+            return queryClient.queryAll("SELECT count() AS c FROM flows WHERE flowProtocol = '" + chProtocol + "'")
+                    .getFirst().getLong("c");
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private long sentRecordsUnchecked(final String protocol) {
+        try {
+            return NL6.sentRecords(protocol);
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void await(final Duration timeout, final String description, final BooleanSupplier condition)
+            throws InterruptedException {
+        final var deadline = Instant.now().plus(timeout);
+        while (Instant.now().isBefore(deadline)) {
+            if (condition.getAsBoolean()) {
+                return;
+            }
+            Thread.sleep(2000);
+        }
+        Assertions.fail("Timed out after %s waiting for %s".formatted(timeout, description));
+    }
+
+    private static int freeUdpPort() {
+        try (var socket = new DatagramSocket(0)) {
+            return socket.getLocalPort();
+        } catch (final Exception e) {
+            throw new IllegalStateException("No free UDP port available", e);
+        }
+    }
+}

--- a/src/test/java/org/riptide/repository/NoopRepository.java
+++ b/src/test/java/org/riptide/repository/NoopRepository.java
@@ -8,6 +8,7 @@ package org.riptide.repository;
 import org.riptide.pipeline.EnrichedFlow;
 import org.riptide.pipeline.FlowException;
 import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
@@ -15,8 +16,10 @@ import java.util.List;
 
 /// NOOP implementation of a FlowRepository, otherwise spring context dies, which we for test purposes
 /// don't want, but is in production the correct behavior.
+/// Excluded under the e2e profile, where tests exercise the real ClickhouseRepository.
 @Service
 @Primary
+@Profile("!e2e")
 public class NoopRepository implements FlowRepository {
     @Override
     public void persist(List<EnrichedFlow> flows) throws FlowException, IOException {

--- a/src/test/java/org/riptide/repository/clickhouse/ClickhouseRepositoryIT.java
+++ b/src/test/java/org/riptide/repository/clickhouse/ClickhouseRepositoryIT.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.repository.clickhouse;
+
+import com.clickhouse.client.api.Client;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.riptide.config.ClickhouseConfig;
+import org.riptide.flows.parser.data.Flow;
+import org.riptide.pipeline.EnrichedFlow;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.net.InetAddress;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+/**
+ * First real-ClickHouse test of the repository: schema creation on a fresh
+ * server, batch insert, and query-back of the persisted values.
+ */
+@Testcontainers
+public class ClickhouseRepositoryIT {
+
+    @Container
+    private static final GenericContainer<?> CLICKHOUSE = new GenericContainer<>("clickhouse/clickhouse-server:25.3")
+            .withEnv("CLICKHOUSE_DB", "riptide")
+            .withEnv("CLICKHOUSE_USER", "riptide")
+            .withEnv("CLICKHOUSE_PASSWORD", "riptide")
+            .withExposedPorts(8123)
+            .waitingFor(Wait.forHttp("/ping").forPort(8123).forStatusCode(200));
+
+    private static ClickhouseRepository repository;
+    private static Client queryClient;
+
+    @BeforeAll
+    static void setUp() {
+        final var config = new ClickhouseConfig();
+        config.endpoint = "http://" + CLICKHOUSE.getHost() + ":" + CLICKHOUSE.getMappedPort(8123);
+        config.username = "riptide";
+        config.password = "riptide";
+
+        repository = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), config);
+        repository.start();
+
+        queryClient = new Client.Builder()
+                .addEndpoint(config.endpoint)
+                .setUsername(config.username)
+                .setPassword(config.password)
+                .setDefaultDatabase(config.database)
+                .build();
+    }
+
+    @Test
+    void verifyPersistedFlowsAreQueryable() throws Exception {
+        final var now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+        repository.persist(List.of(
+                testFlow(now, 10001, 443, 1234L),
+                testFlow(now, 10002, 53, 5678L)));
+
+        final var count = queryClient.queryAll("SELECT count() AS c FROM flows").getFirst().getLong("c");
+        Assertions.assertThat(count).isEqualTo(2);
+
+        final var rows = queryClient.queryAll(
+                "SELECT srcPort, dstPort, bytes, flowProtocol, exporterAddr FROM flows ORDER BY srcPort");
+        Assertions.assertThat(rows).hasSize(2);
+        Assertions.assertThat(rows.getFirst().getInteger("srcPort")).isEqualTo(10001);
+        Assertions.assertThat(rows.getFirst().getInteger("dstPort")).isEqualTo(443);
+        Assertions.assertThat(rows.getFirst().getLong("bytes")).isEqualTo(1234L);
+        Assertions.assertThat(rows.getFirst().getString("flowProtocol")).isEqualTo("IPFIX");
+        Assertions.assertThat(rows.getFirst().getString("exporterAddr")).isEqualTo("203.0.113.7");
+    }
+
+    private static EnrichedFlow testFlow(final Instant now, final int srcPort, final int dstPort, final long bytes) throws Exception {
+        return EnrichedFlow.builder()
+                .receivedAt(now)
+                .timestamp(now)
+                .firstSwitched(now.minusSeconds(10))
+                .deltaSwitched(now.minusSeconds(10))
+                .lastSwitched(now)
+                .flowProtocol(Flow.FlowProtocol.IPFIX)
+                .location("default")
+                .exporterAddr("203.0.113.7")
+                .srcAddr(InetAddress.getByName("192.0.2.10"))
+                .srcPort(srcPort)
+                .srcAs(64512L)
+                .srcMaskLen(24)
+                .dstAddr(InetAddress.getByName("198.51.100.20"))
+                .dstPort(dstPort)
+                .dstAs(64513L)
+                .dstMaskLen(24)
+                .inputSnmp(1)
+                .outputSnmp(2)
+                .bytes(bytes)
+                .packets(7L)
+                .direction(Flow.Direction.INGRESS)
+                .engineId(0)
+                .engineType(0)
+                .vlan(0)
+                .ipProtocolVersion(4)
+                .protocol(17)
+                .tcpFlags(0)
+                .tos(0)
+                .samplingAlgorithm(Flow.SamplingAlgorithm.Unassigned)
+                .samplingInterval(1.0)
+                .srcLocality(Flow.Locality.PUBLIC)
+                .dstLocality(Flow.Locality.PUBLIC)
+                .flowLocality(Flow.Locality.PUBLIC)
+                .build();
+    }
+}


### PR DESCRIPTION
Implements OpenSpec change `e2e-flow-testing` — three additive test tiers:

## Coverage baseline (JaCoCo, report-only)
`make coverage` renders the report. **Baseline including e2e: 76.6% instruction / 64.1% branch.** E2e-only paths now visibly covered (UdpListener 134/194, ClickhouseRepository 78/87, IpfixUdpParser 62/70 instructions) — the point of running riptide in-JVM.

## ClickHouse integration tier
`ClickhouseRepositoryIT` — first-ever test of the repository against a real ClickHouse (Testcontainers): schema creation on a fresh server, batch insert, query-back of field values.

## nl6 e2e tier
`Nl6FlowIngestionIT` — [nl6](https://github.com/labmonkeys-space/nl6) (pinned **v0.15.1**, NET_ADMIN+SYS_ADMIN+/dev/net/tun per its TUN-based device model) simulates devices exporting **NetFlow v5, v9, and IPFIX** over real UDP to riptide listeners on dynamic free ports, through parsing/enrichment/classification into ClickHouse. Assertions reconcile row counts against nl6's `/flows/status` ledger: v5 exact, v9/IPFIX with 5% template-warmup tolerance; deadline polling, no fixed sleeps.

## Mechanics
- `*IT` classes run only under `-Pe2e` (`make e2e`); default `mvn test` stays Docker-free
- New `e2e` CI job (capabilities work on standard runners — Testcontainers requests them per container)
- `NoopRepository` excluded via `@Profile("!e2e")` so the real repository is wired in e2e
- docker-java API-version default (1.32) pinned to 1.44 in failsafe config (modern daemons reject 1.32)

## Verification
Local: 522 unit tests green and Docker-free; **5/5 consecutive e2e runs green, zero flakes** (e2e class 16–24s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)