### PR TITLE
test: Add full-mode e2e — per-device exporters and SNMP walk-back

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,27 @@ jobs:
       # The nl6 container needs NET_ADMIN + SYS_ADMIN and /dev/net/tun.
       # Testcontainers requests them per container; the runner's root Docker
       # daemon grants them without extra runner configuration.
+      #
+      # Full-mode additionally needs (spike/full-mode-routing runs, July 2026):
+      # - unconfined seccomp/AppArmor on the nl6 container (its netns setup
+      #   runs `mount --make-shared`, denied by default profiles) — requested
+      #   per container by the harness; --privileged is never used
+      # - a host route into the simulated device network so riptide can walk
+      #   SNMP back to the per-device agents
+      - name: Provision full-mode (route into nl6 device network)
+        run: |
+          docker network create --subnet 172.30.42.0/24 nl6-fullmode
+          sudo ip route add 10.42.0.0/16 via 172.30.42.10
+          sudo sysctl -w net.ipv4.conf.all.rp_filter=2
+          sudo sysctl -w net.ipv4.conf.default.rp_filter=2
       - name: Integration and e2e tests
         run: |
           make e2e
+        env:
+          RIPTIDE_E2E_FULL_MODE: "1"
+      - name: Persist coverage report
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: jacoco-report
+          path: target/site/jacoco/

--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ and is bumped deliberately — it is a wire-format contract, not a Dependabot-ma
 make e2e
 ```
 
+The e2e tier includes an optional **full mode** (Linux only): nl6 devices export flows
+from per-device source IPs and riptide's SNMP enrichment walks back to each device's
+simulated agent. It is gated on `RIPTIDE_E2E_FULL_MODE=1` and skipped otherwise
+(e.g. on macOS). To run it on a Linux host:
+
+```
+docker network create --subnet 172.30.42.0/24 nl6-fullmode
+sudo ip route add 10.42.0.0/16 via 172.30.42.10
+sudo sysctl -w net.ipv4.conf.all.rp_filter=2
+RIPTIDE_E2E_FULL_MODE=1 make e2e
+```
+
 # 🕹️ Run on your local system
 
 ```

--- a/src/test/java/org/riptide/e2e/E2eTestSupport.java
+++ b/src/test/java/org/riptide/e2e/E2eTestSupport.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.e2e;
+
+import org.assertj.core.api.Assertions;
+
+import java.net.DatagramSocket;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.function.BooleanSupplier;
+
+/** Shared helpers for the e2e test tier. */
+final class E2eTestSupport {
+
+    private E2eTestSupport() {
+    }
+
+    /** Deadline-based polling; fails the test on timeout. Never a bare sleep. */
+    static void await(final Duration timeout, final String description, final BooleanSupplier condition)
+            throws InterruptedException {
+        final var deadline = Instant.now().plus(timeout);
+        while (Instant.now().isBefore(deadline)) {
+            if (condition.getAsBoolean()) {
+                return;
+            }
+            Thread.sleep(2000);
+        }
+        Assertions.fail("Timed out after %s waiting for %s".formatted(timeout, description));
+    }
+
+    static int freeUdpPort() {
+        try (var socket = new DatagramSocket(0)) {
+            return socket.getLocalPort();
+        } catch (final Exception e) {
+            throw new IllegalStateException("No free UDP port available", e);
+        }
+    }
+}

--- a/src/test/java/org/riptide/e2e/Nl6Container.java
+++ b/src/test/java/org/riptide/e2e/Nl6Container.java
@@ -15,6 +15,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -46,6 +47,28 @@ public final class Nl6Container extends GenericContainer<Nl6Container> {
         withExtraHost("host.docker.internal", "host-gateway");
         withCommand("-flow-source-per-device=false", "-flow-template-interval", "5");
         waitingFor(Wait.forHttp("/api/v1/flows/status").forPort(8080).forStatusCode(200));
+    }
+
+    /**
+     * Per-device source-IP mode (full-mode tier): each simulated device sends
+     * flows from its own IP inside the nl6sim namespace and answers SNMP there.
+     *
+     * Requires unconfined seccomp/AppArmor IN ADDITION to the TUN capabilities:
+     * nl6's netns setup runs `mount --make-shared`, which default container
+     * profiles deny (full-mode spike, July 2026). Granular caps stay and
+     * --privileged is deliberately never used (spec e2e-snmp-enrichment-testing,
+     * "Bounded container privileges"). The host needs a route into
+     * 10.42.0.0/16 via this container's static IP.
+     */
+    public Nl6Container perDevice(final String networkName, final String staticIpv4) {
+        withCreateContainerCmdModifier(cmd -> {
+            cmd.getHostConfig()
+                    .withSecurityOpts(List.of("seccomp=unconfined", "apparmor=unconfined"))
+                    .withNetworkMode(networkName);
+            cmd.withIpv4Address(staticIpv4);
+        });
+        withCommand("-flow-source-per-device=true", "-flow-template-interval", "5");
+        return this;
     }
 
     @Override

--- a/src/test/java/org/riptide/e2e/Nl6FlowIngestionIT.java
+++ b/src/test/java/org/riptide/e2e/Nl6FlowIngestionIT.java
@@ -16,10 +16,11 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
-import java.net.DatagramSocket;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.function.BooleanSupplier;
+
+import static org.riptide.e2e.E2eTestSupport.await;
+import static org.riptide.e2e.E2eTestSupport.freeUdpPort;
 
 /**
  * End-to-end: nl6-simulated devices export NetFlow v5 / v9 / IPFIX over real
@@ -158,23 +159,4 @@ public class Nl6FlowIngestionIT {
         }
     }
 
-    private static void await(final Duration timeout, final String description, final BooleanSupplier condition)
-            throws InterruptedException {
-        final var deadline = Instant.now().plus(timeout);
-        while (Instant.now().isBefore(deadline)) {
-            if (condition.getAsBoolean()) {
-                return;
-            }
-            Thread.sleep(2000);
-        }
-        Assertions.fail("Timed out after %s waiting for %s".formatted(timeout, description));
-    }
-
-    private static int freeUdpPort() {
-        try (var socket = new DatagramSocket(0)) {
-            return socket.getLocalPort();
-        } catch (final Exception e) {
-            throw new IllegalStateException("No free UDP port available", e);
-        }
-    }
 }

--- a/src/test/java/org/riptide/e2e/Nl6SnmpEnrichmentIT.java
+++ b/src/test/java/org/riptide/e2e/Nl6SnmpEnrichmentIT.java
@@ -16,8 +16,6 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.Duration;
 import java.util.Map;
@@ -39,7 +37,6 @@ import static org.riptide.e2e.E2eTestSupport.freeUdpPort;
  */
 @SpringBootTest
 @ActiveProfiles("e2e")
-@Testcontainers
 @EnabledIfEnvironmentVariable(named = "RIPTIDE_E2E_FULL_MODE", matches = "1",
         disabledReason = "full-mode e2e needs a Linux host with a route into nl6's device network (see README)")
 public class Nl6SnmpEnrichmentIT {
@@ -50,7 +47,6 @@ public class Nl6SnmpEnrichmentIT {
     private static final String FIRST_DEVICE = "10.42.0.1";
     private static final long MIN_RECORDS = 50;
 
-    @Container
     private static final GenericContainer<?> CLICKHOUSE = new GenericContainer<>("clickhouse/clickhouse-server:25.3")
             .withEnv("CLICKHOUSE_DB", "riptide")
             .withEnv("CLICKHOUSE_USER", "riptide")
@@ -58,13 +54,23 @@ public class Nl6SnmpEnrichmentIT {
             .withExposedPorts(8123)
             .waitingFor(Wait.forHttp("/ping").forPort(8123).forStatusCode(200));
 
-    @Container
     private static final Nl6Container NL6 = new Nl6Container().perDevice(FULL_MODE_NETWORK, NL6_STATIC_IP);
 
     private static final int NETFLOW9_PORT = freeUdpPort();
 
     private static Client queryClient;
     private static Map<Integer, String> groundTruthIfNames;
+
+    static {
+        // Containers must outlive this class's CACHED Spring context (closed only
+        // at JVM exit): stopping them per-class (@Container) leaves the context's
+        // pipeline retrying inserts into a dead ClickHouse and starves later e2e
+        // classes in the same JVM. Started here, reaped by Ryuk at JVM death —
+        // same lifecycle as Nl6FlowIngestionIT. This block never runs when the
+        // class is disabled by the RIPTIDE_E2E_FULL_MODE gate (no class init).
+        CLICKHOUSE.start();
+        NL6.start();
+    }
 
     @DynamicPropertySource
     static void riptideProperties(final DynamicPropertyRegistry registry) {

--- a/src/test/java/org/riptide/e2e/Nl6SnmpEnrichmentIT.java
+++ b/src/test/java/org/riptide/e2e/Nl6SnmpEnrichmentIT.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.e2e;
+
+import com.clickhouse.client.api.Client;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static org.riptide.e2e.E2eTestSupport.await;
+import static org.riptide.e2e.E2eTestSupport.freeUdpPort;
+
+/**
+ * Full-mode e2e: nl6 devices export flows with per-device source IPs and
+ * riptide's SNMP enrichment walks back to each device's nl6 SNMP agent.
+ *
+ * Environment contract (see README "full mode" and the e2e CI job):
+ * - Docker network "nl6-fullmode" exists with subnet 172.30.42.0/24
+ * - host route: ip route add 10.42.0.0/16 via 172.30.42.10 (+ loose rp_filter)
+ * - RIPTIDE_E2E_FULL_MODE=1 set (the gate)
+ *
+ * Without the gate this class is SKIPPED. With the gate set, a broken
+ * environment (missing route, unreachable agents) FAILS loudly.
+ */
+@SpringBootTest
+@ActiveProfiles("e2e")
+@Testcontainers
+@EnabledIfEnvironmentVariable(named = "RIPTIDE_E2E_FULL_MODE", matches = "1",
+        disabledReason = "full-mode e2e needs a Linux host with a route into nl6's device network (see README)")
+public class Nl6SnmpEnrichmentIT {
+
+    private static final String FULL_MODE_NETWORK = "nl6-fullmode";
+    private static final String NL6_STATIC_IP = "172.30.42.10";
+    private static final int DEVICE_COUNT = 5;
+    private static final String FIRST_DEVICE = "10.42.0.1";
+    private static final long MIN_RECORDS = 50;
+
+    @Container
+    private static final GenericContainer<?> CLICKHOUSE = new GenericContainer<>("clickhouse/clickhouse-server:25.3")
+            .withEnv("CLICKHOUSE_DB", "riptide")
+            .withEnv("CLICKHOUSE_USER", "riptide")
+            .withEnv("CLICKHOUSE_PASSWORD", "riptide")
+            .withExposedPorts(8123)
+            .waitingFor(Wait.forHttp("/ping").forPort(8123).forStatusCode(200));
+
+    @Container
+    private static final Nl6Container NL6 = new Nl6Container().perDevice(FULL_MODE_NETWORK, NL6_STATIC_IP);
+
+    private static final int NETFLOW9_PORT = freeUdpPort();
+
+    private static Client queryClient;
+    private static Map<Integer, String> groundTruthIfNames;
+
+    @DynamicPropertySource
+    static void riptideProperties(final DynamicPropertyRegistry registry) {
+        registry.add("riptide.clickhouse.endpoint",
+                () -> "http://" + CLICKHOUSE.getHost() + ":" + CLICKHOUSE.getMappedPort(8123));
+        registry.add("riptide.clickhouse.username", () -> "riptide");
+        registry.add("riptide.clickhouse.password", () -> "riptide");
+
+        registry.add("riptide.receivers.nf9.type", () -> "netflow9");
+        registry.add("riptide.receivers.nf9.host", () -> "0.0.0.0");
+        registry.add("riptide.receivers.nf9.port", () -> NETFLOW9_PORT);
+
+        registry.add("riptide.snmp.config.definitions[0].subnet-address", () -> "10.42.0.0/16");
+        registry.add("riptide.snmp.config.definitions[0].port", () -> 161);
+        registry.add("riptide.snmp.config.definitions[0].snmp-version", () -> "v2c");
+        registry.add("riptide.snmp.config.definitions[0].community", () -> "public");
+    }
+
+    @BeforeAll
+    static void startTrafficAndVerifyEnvironment() throws Exception {
+        queryClient = new Client.Builder()
+                .addEndpoint("http://" + CLICKHOUSE.getHost() + ":" + CLICKHOUSE.getMappedPort(8123))
+                .setUsername("riptide")
+                .setPassword("riptide")
+                .setDefaultDatabase("riptide")
+                .build();
+
+        NL6.createDevices(FIRST_DEVICE, DEVICE_COUNT, "netflow9", NETFLOW9_PORT);
+
+        // Gate is set, so a broken environment must FAIL, not limp along:
+        // the ground-truth walk exercises the host->netns route and the agent.
+        groundTruthIfNames = SnmpIfNameWalker.walkIfNames(FIRST_DEVICE);
+        if (groundTruthIfNames.isEmpty()) {
+            Assertions.fail(("RIPTIDE_E2E_FULL_MODE is set but no SNMP response from %s - is the host route "
+                    + "'ip route add 10.42.0.0/16 via %s' in place and rp_filter loose?")
+                    .formatted(FIRST_DEVICE, NL6_STATIC_IP));
+        }
+    }
+
+    @Test
+    void verifyPerDeviceExporterAttribution() throws Exception {
+        await(Duration.ofMinutes(3), "nl6 ledger to reach " + MIN_RECORDS + " netflow9 records",
+                () -> sentRecordsUnchecked() >= MIN_RECORDS);
+
+        await(Duration.ofMinutes(2), DEVICE_COUNT + " distinct exporter addresses in ClickHouse",
+                () -> countDistinctExporters() == DEVICE_COUNT);
+
+        final var exporters = queryClient.queryAll("SELECT DISTINCT exporterAddr FROM flows ORDER BY exporterAddr")
+                .stream().map(r -> r.getString("exporterAddr")).toList();
+        Assertions.assertThat(exporters)
+                .containsExactly("10.42.0.1", "10.42.0.2", "10.42.0.3", "10.42.0.4", "10.42.0.5");
+    }
+
+    @Test
+    void verifyIfNameEnrichmentAgainstAgent() throws Exception {
+        await(Duration.ofMinutes(3), "enriched interface names for exporter " + FIRST_DEVICE,
+                () -> countEnrichedRows(FIRST_DEVICE) > 0);
+
+        final var row = queryClient.queryAll(
+                "SELECT any(inputSnmpIfName) AS inName, any(outputSnmpIfName) AS outName FROM flows"
+                        + " WHERE exporterAddr = '" + FIRST_DEVICE + "' AND inputSnmpIfName IS NOT NULL").getFirst();
+
+        // nl6 flows always carry ifIndex 1 (ingress) and 2 (egress); the agent's
+        // ifXTable is the ground truth for what those must resolve to.
+        Assertions.assertThat(row.getString("inName")).isEqualTo(groundTruthIfNames.get(1));
+        Assertions.assertThat(row.getString("outName")).isEqualTo(groundTruthIfNames.get(2));
+    }
+
+    private long countDistinctExporters() {
+        try {
+            return queryClient.queryAll("SELECT uniqExact(exporterAddr) AS c FROM flows").getFirst().getLong("c");
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private long countEnrichedRows(final String exporter) {
+        try {
+            return queryClient.queryAll("SELECT count() AS c FROM flows WHERE exporterAddr = '" + exporter
+                    + "' AND inputSnmpIfName IS NOT NULL AND outputSnmpIfName IS NOT NULL").getFirst().getLong("c");
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private long sentRecordsUnchecked() {
+        try {
+            return NL6.sentRecords("netflow9");
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/org/riptide/e2e/SnmpIfNameWalker.java
+++ b/src/test/java/org/riptide/e2e/SnmpIfNameWalker.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.e2e;
+
+import org.snmp4j.CommunityTarget;
+import org.snmp4j.Snmp;
+import org.snmp4j.mp.SnmpConstants;
+import org.snmp4j.smi.OID;
+import org.snmp4j.smi.OctetString;
+import org.snmp4j.smi.UdpAddress;
+import org.snmp4j.transport.DefaultUdpTransportMapping;
+import org.snmp4j.util.DefaultPDUFactory;
+import org.snmp4j.util.TableUtils;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Ground-truth ifName lookup for the full-mode e2e test: walks a device's
+ * ifXTable directly with plain snmp4j, independent of riptide's own SNMP
+ * service code (which is what the test is verifying).
+ */
+public final class SnmpIfNameWalker {
+
+    private static final OID IF_NAME = new OID("1.3.6.1.2.1.31.1.1.1.1");
+
+    private SnmpIfNameWalker() {
+    }
+
+    /** Walks ifXTable ifName (v2c/public) and returns ifIndex -> ifName. */
+    public static Map<Integer, String> walkIfNames(final String address) throws IOException {
+        try (var snmp = new Snmp(new DefaultUdpTransportMapping())) {
+            snmp.listen();
+
+            final var target = new CommunityTarget<UdpAddress>();
+            target.setCommunity(new OctetString("public"));
+            target.setAddress(new UdpAddress(InetAddress.getByName(address), 161));
+            target.setVersion(SnmpConstants.version2c);
+            target.setTimeout(2000);
+            target.setRetries(2);
+
+            final var tableUtils = new TableUtils(snmp, new DefaultPDUFactory());
+            final var names = new HashMap<Integer, String>();
+            for (final var row : tableUtils.getTable(target, new OID[]{IF_NAME}, null, null)) {
+                if (row.isError() || row.getColumns() == null || row.getColumns()[0] == null) {
+                    continue;
+                }
+                names.put(row.getIndex().get(0), row.getColumns()[0].getVariable().toString());
+            }
+            return names;
+        }
+    }
+}


### PR DESCRIPTION
Implements OpenSpec change `full-mode-e2e` (follow-up to #151).

## What
- **`Nl6SnmpEnrichmentIT`** — nl6 devices export NetFlow v9 from **per-device source IPs**; riptide's SNMP enrichment walks back to each device's simulated agent and the resolved names are asserted in ClickHouse against an independent snmp4j ifXTable walk (ground truth from the agent, not hardcoded).
- Asserts per-device exporter attribution: `DISTINCT exporterAddr` == the 5 device IPs.
- **Gating**: `RIPTIDE_E2E_FULL_MODE=1` — skipped in ~0s without it (macOS/local verified); gated-but-broken environments fail loudly naming the missing route.
- **Privileges**: granular caps + unconfined seccomp/AppArmor on the full-mode container only (nl6's netns needs `mount --make-shared`; spike-verified). Never `--privileged`; the shared-socket tier stays confined.
- CI provisions network/route/rp_filter and uploads the JaCoCo report artifact.
- Fix found during CI: `@Container` per-class teardown vs JVM-lifetime cached Spring contexts — the orphaned context retried inserts into its dead ClickHouse and starved the fast tier. All e2e ITs now use static-block container lifecycle.

## Coverage
SNMP-stack **class-level coverage is unchanged** (already unit-covered via TestSnmpAgent: SnmpEnricher/CachingSnmpService/SnmpUtils at 100%). Full-mode's contribution is behavioral: the subnet-definition lookup, real network walk-back, and `inputSnmpIfName`/`outputSnmpIfName` persistence are now verified end-to-end with per-device attribution — none of which unit tests can prove.

## Verification
- Ungated local: 522 units green, fast tier green, full-mode skipped in ~0s.
- **CI: 5/5 consecutive green runs** of the e2e job including full-mode (2m30–2m45s each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)