### PR TITLE
feat(snmp): reference SNMP credentials via SecretRef instead of plaintext

### DIFF
--- a/src/main/java/org/riptide/secrets/EnvSecretResolver.java
+++ b/src/main/java/org/riptide/secrets/EnvSecretResolver.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.secrets;
+
+import org.springframework.stereotype.Component;
+
+import java.util.function.Function;
+
+/**
+ * Resolves {@code env://NAME} from environment variables.
+ */
+@Component
+public class EnvSecretResolver implements SecretResolver {
+
+    private final Function<String, String> environment;
+
+    public EnvSecretResolver() {
+        this(System::getenv);
+    }
+
+    EnvSecretResolver(final Function<String, String> environment) {
+        this.environment = environment;
+    }
+
+    @Override
+    public String scheme() {
+        return "env";
+    }
+
+    @Override
+    public String resolve(final SecretRef ref) {
+        final String value = this.environment.apply(ref.getValue());
+        if (value == null) {
+            throw new IllegalArgumentException("Environment variable '" + ref.getValue() + "' is not set (secret ref " + ref + ")");
+        }
+        return value;
+    }
+}

--- a/src/main/java/org/riptide/secrets/FileSecretResolver.java
+++ b/src/main/java/org/riptide/secrets/FileSecretResolver.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.secrets;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * Resolves {@code file:///path} (whole file, trimmed) or {@code file:///path#key}
+ * (a key inside a properties file).
+ *
+ * <p>When {@code riptide.secrets.allowed-paths} is set, only files below one of the listed
+ * directories are readable — the same sandboxing idea as Kafka's {@code allowed.paths}.</p>
+ */
+@Component
+public class FileSecretResolver implements SecretResolver {
+
+    private final List<Path> allowedPaths;
+
+    public FileSecretResolver(@Value("${riptide.secrets.allowed-paths:}") final List<String> allowedPaths) {
+        this.allowedPaths = allowedPaths.stream()
+                .filter(p -> !p.isBlank())
+                .map(p -> {
+                    try {
+                        // match the toRealPath form used when checking refs
+                        return Path.of(p).toRealPath();
+                    } catch (IOException e) {
+                        return Path.of(p).toAbsolutePath().normalize();
+                    }
+                })
+                .toList();
+    }
+
+    @Override
+    public String scheme() {
+        return "file";
+    }
+
+    @Override
+    public String resolve(final SecretRef ref) {
+        final Path path;
+        final String content;
+        try {
+            // toRealPath resolves symlinks so they cannot escape the allowed-paths sandbox
+            path = Path.of(ref.getValue()).toRealPath();
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Cannot read secret ref " + ref, e);
+        }
+
+        if (!this.allowedPaths.isEmpty() && this.allowedPaths.stream().noneMatch(path::startsWith)) {
+            throw new IllegalArgumentException("Path of secret ref " + ref + " is outside riptide.secrets.allowed-paths");
+        }
+
+        try {
+            content = Files.readString(path);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Cannot read secret ref " + ref, e);
+        }
+
+        if (ref.getKey() == null) {
+            return content.trim();
+        }
+
+        final Properties properties = new Properties();
+        try {
+            properties.load(new StringReader(content));
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Cannot parse properties for secret ref " + ref, e);
+        }
+        final String value = properties.getProperty(ref.getKey());
+        if (value == null) {
+            throw new IllegalArgumentException("Key '" + ref.getKey() + "' not found for secret ref " + ref);
+        }
+        return value;
+    }
+}

--- a/src/main/java/org/riptide/secrets/PlainSecretResolver.java
+++ b/src/main/java/org/riptide/secrets/PlainSecretResolver.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.secrets;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Literal fallback for values without a scheme. Intended for migration and test fixtures;
+ * production config should use {@code env://} or {@code file://} references.
+ */
+@Component
+public class PlainSecretResolver implements SecretResolver {
+
+    @Override
+    public String scheme() {
+        return SecretRef.SCHEME_PLAIN;
+    }
+
+    @Override
+    public String resolve(final SecretRef ref) {
+        return ref.getValue();
+    }
+}

--- a/src/main/java/org/riptide/secrets/SecretRef.java
+++ b/src/main/java/org/riptide/secrets/SecretRef.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.secrets;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+/**
+ * A reference to a secret, never the secret itself. Parsed from a URI-style string:
+ *
+ * <ul>
+ *   <li>{@code env://RIPTIDE_SNMP_COMMUNITY} — environment variable</li>
+ *   <li>{@code file:///run/secrets/community} — file content (trimmed)</li>
+ *   <li>{@code file:///etc/riptide/secrets.properties#snmp.community} — key inside a properties file</li>
+ *   <li>any value without {@code ://} — literal fallback ({@code plain}) for migration and tests</li>
+ * </ul>
+ *
+ * The single-String constructor lets Spring bind configuration properties directly.
+ * {@link #toString()} never exposes a literal secret.
+ */
+@Getter
+@EqualsAndHashCode
+public final class SecretRef {
+
+    public static final String SCHEME_PLAIN = "plain";
+
+    private final String scheme;
+    private final String value;
+    private final String key;
+
+    public SecretRef(final String ref) {
+        if (ref == null || ref.isBlank()) {
+            throw new IllegalArgumentException("Secret reference must not be blank");
+        }
+
+        final int schemeEnd = ref.indexOf("://");
+        if (schemeEnd <= 0) {
+            this.scheme = SCHEME_PLAIN;
+            this.value = ref;
+            this.key = null;
+            return;
+        }
+
+        this.scheme = ref.substring(0, schemeEnd);
+        final String rest = ref.substring(schemeEnd + 3);
+        final int fragment = rest.indexOf('#');
+        if (fragment >= 0) {
+            this.value = rest.substring(0, fragment);
+            this.key = rest.substring(fragment + 1);
+        } else {
+            this.value = rest;
+            this.key = null;
+        }
+
+        if (this.value.isBlank()) {
+            throw new IllegalArgumentException("Secret reference '" + this + "' has no value part");
+        }
+    }
+
+    /**
+     * Null-safe factory: {@code null} stays {@code null} (optional credentials such as
+     * SNMPv3 auth/priv passphrases).
+     */
+    public static SecretRef of(final String ref) {
+        return ref == null ? null : new SecretRef(ref);
+    }
+
+    @Override
+    public String toString() {
+        if (SCHEME_PLAIN.equals(this.scheme)) {
+            return "plain://***";
+        }
+        return this.scheme + "://" + this.value + (this.key != null ? "#" + this.key : "");
+    }
+}

--- a/src/main/java/org/riptide/secrets/SecretResolver.java
+++ b/src/main/java/org/riptide/secrets/SecretResolver.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.secrets;
+
+/**
+ * Resolves a {@link SecretRef} of a single scheme to its secret value. Implementations are
+ * discovered as Spring beans and dispatched by {@link SecretResolvers}.
+ */
+public interface SecretResolver {
+
+    String scheme();
+
+    /**
+     * @throws IllegalArgumentException if the reference cannot be resolved
+     */
+    String resolve(SecretRef ref);
+}

--- a/src/main/java/org/riptide/secrets/SecretResolvers.java
+++ b/src/main/java/org/riptide/secrets/SecretResolvers.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.secrets;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Dispatches a {@link SecretRef} to the {@link SecretResolver} registered for its scheme.
+ */
+@Service
+public class SecretResolvers {
+
+    private final Map<String, SecretResolver> resolvers;
+
+    public SecretResolvers(final List<SecretResolver> resolvers) {
+        this.resolvers = resolvers.stream().collect(Collectors.toMap(SecretResolver::scheme, Function.identity()));
+    }
+
+    /**
+     * Null-safe: a {@code null} reference (optional credential) resolves to {@code null}.
+     *
+     * @throws IllegalArgumentException on an unknown scheme or a failing resolver
+     */
+    public String resolve(final SecretRef ref) {
+        if (ref == null) {
+            return null;
+        }
+        final SecretResolver resolver = this.resolvers.get(ref.getScheme());
+        if (resolver == null) {
+            throw new IllegalArgumentException("No secret resolver for scheme '" + ref.getScheme() + "' (secret ref " + ref + ")");
+        }
+        return resolver.resolve(ref);
+    }
+
+    /**
+     * Registry with all built-in resolvers — for use outside a Spring context (tests, tools).
+     */
+    public static SecretResolvers defaults() {
+        return new SecretResolvers(List.of(new PlainSecretResolver(), new EnvSecretResolver(), new FileSecretResolver(List.of())));
+    }
+}

--- a/src/main/java/org/riptide/snmp/DefaultSnmpService.java
+++ b/src/main/java/org/riptide/snmp/DefaultSnmpService.java
@@ -5,7 +5,10 @@
 
 package org.riptide.snmp;
 
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.riptide.secrets.SecretResolvers;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
@@ -13,14 +16,21 @@ import java.util.Optional;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class DefaultSnmpService implements SnmpService {
+
+    @NonNull
+    private final SecretResolvers secretResolvers;
+
     @Override
     public Optional<String> getIfName(final SnmpEndpoint snmpEndpoint, final int ifIndex) {
         try {
-            final var value = SnmpUtils.getSnmpInterfaceMap(snmpEndpoint).get(ifIndex);
+            final var value = SnmpUtils.getSnmpInterfaceMap(snmpEndpoint, this.secretResolvers).get(ifIndex);
             return Optional.ofNullable(value);
-        } catch (IOException e) {
-            log.warn("Error fetching value from {} at index {}", snmpEndpoint, ifIndex);
+        } catch (IOException | IllegalArgumentException e) {
+            // IllegalArgumentException: an unresolvable secret reference must degrade to an
+            // unenriched flow, never fail the pipeline and drop the batch.
+            log.warn("Error fetching value from {} at index {}: {}", snmpEndpoint, ifIndex, e.getMessage());
             return Optional.empty();
         }
     }

--- a/src/main/java/org/riptide/snmp/SnmpDefinition.java
+++ b/src/main/java/org/riptide/snmp/SnmpDefinition.java
@@ -7,6 +7,7 @@ package org.riptide.snmp;
 
 import java.net.InetSocketAddress;
 
+import org.riptide.secrets.SecretRef;
 import org.snmp4j.fluent.TargetBuilder;
 
 import inet.ipaddr.IPAddressString;
@@ -16,13 +17,13 @@ import lombok.Data;
 public class SnmpDefinition {
     private TargetBuilder.AuthProtocol authProtocol;
 
-    private String authPassphrase;
+    private SecretRef authPassphrase;
 
     private TargetBuilder.PrivProtocol privProtocol;
 
-    private String privPassphrase;
+    private SecretRef privPassphrase;
 
-    private String community;
+    private SecretRef community;
 
     private String securityName;
 

--- a/src/main/java/org/riptide/snmp/SnmpUtils.java
+++ b/src/main/java/org/riptide/snmp/SnmpUtils.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import org.riptide.secrets.SecretResolvers;
 import org.snmp4j.Snmp;
 import org.snmp4j.Target;
 import org.snmp4j.fluent.SnmpBuilder;
@@ -58,10 +59,10 @@ public final class SnmpUtils {
         return snmpInterfaceMap;
     }
 
-    public static Map<Integer, String> getSnmpInterfaceMap(final SnmpEndpoint snmpEndpoint) throws IOException {
+    public static Map<Integer, String> getSnmpInterfaceMap(final SnmpEndpoint snmpEndpoint, final SecretResolvers secretResolvers) throws IOException {
         final SnmpBuilder snmpBuilder = snmpEndpoint.getSnmpDefinition().getSnmpVersion().getSnmpBuilder();
         try (Snmp snmp = snmpBuilder.build()) {
-            final Target<?> target = snmpEndpoint.getSnmpDefinition().getSnmpVersion().getTarget(snmp, snmpBuilder, snmpEndpoint);
+            final Target<?> target = snmpEndpoint.getSnmpDefinition().getSnmpVersion().getTarget(snmp, snmpBuilder, snmpEndpoint, secretResolvers);
             // query ifXTable first, if not available fallback to ifTable
             final var snmpInterfaceMap = walkTable(snmp, target, SNMP_IFX_TABLE);
             if (snmpInterfaceMap.isEmpty()) {

--- a/src/main/java/org/riptide/snmp/SnmpVersion.java
+++ b/src/main/java/org/riptide/snmp/SnmpVersion.java
@@ -5,6 +5,7 @@
 
 package org.riptide.snmp;
 
+import org.riptide.secrets.SecretResolvers;
 import org.snmp4j.Snmp;
 import org.snmp4j.Target;
 import org.snmp4j.fluent.SnmpBuilder;
@@ -28,11 +29,11 @@ enum SnmpVersion {
         }
 
         @Override
-        Target<?> getTarget(final Snmp snmp, final SnmpBuilder snmpBuilder, final SnmpEndpoint snmpEndpoint) throws UnknownHostException {
+        Target<?> getTarget(final Snmp snmp, final SnmpBuilder snmpBuilder, final SnmpEndpoint snmpEndpoint, final SecretResolvers secretResolvers) throws UnknownHostException {
             return snmpBuilder
                     .v1()
                     .target(getTargetAddress(snmpEndpoint))
-                    .community(new OctetString(snmpEndpoint.getSnmpDefinition().getCommunity()))
+                    .community(new OctetString(secretResolvers.resolve(snmpEndpoint.getSnmpDefinition().getCommunity())))
                     .timeout(snmpEndpoint.getSnmpDefinition().getTimeout())
                     .retries(snmpEndpoint.getSnmpDefinition().getRetries())
                     .build();
@@ -50,11 +51,11 @@ enum SnmpVersion {
         }
 
         @Override
-        Target<?> getTarget(final Snmp snmp, final SnmpBuilder snmpBuilder, final SnmpEndpoint snmpEndpoint) throws UnknownHostException {
+        Target<?> getTarget(final Snmp snmp, final SnmpBuilder snmpBuilder, final SnmpEndpoint snmpEndpoint, final SecretResolvers secretResolvers) throws UnknownHostException {
             return snmpBuilder
                     .v2c()
                     .target(getTargetAddress(snmpEndpoint))
-                    .community(new OctetString(snmpEndpoint.getSnmpDefinition().getCommunity()))
+                    .community(new OctetString(secretResolvers.resolve(snmpEndpoint.getSnmpDefinition().getCommunity())))
                     .timeout(snmpEndpoint.getSnmpDefinition().getTimeout())
                     .retries(snmpEndpoint.getSnmpDefinition().getRetries())
                     .build();
@@ -73,7 +74,7 @@ enum SnmpVersion {
         }
 
         @Override
-        Target<?> getTarget(final Snmp snmp, final SnmpBuilder snmpBuilder, final SnmpEndpoint snmpEndpoint) throws UnknownHostException {
+        Target<?> getTarget(final Snmp snmp, final SnmpBuilder snmpBuilder, final SnmpEndpoint snmpEndpoint, final SecretResolvers secretResolvers) throws UnknownHostException {
             final Address targetAddress = getTargetAddress(snmpEndpoint);
             final byte[] targetEngineID = snmp.discoverAuthoritativeEngineID(targetAddress, 1000);
             var userBuilder = snmpBuilder
@@ -82,11 +83,11 @@ enum SnmpVersion {
                     .user(snmpEndpoint.getSnmpDefinition().getSecurityName(), targetEngineID);
 
             if (snmpEndpoint.getSnmpDefinition().getAuthProtocol() != null && snmpEndpoint.getSnmpDefinition().getAuthPassphrase() != null) {
-                userBuilder = userBuilder.auth(snmpEndpoint.getSnmpDefinition().getAuthProtocol()).authPassphrase(snmpEndpoint.getSnmpDefinition().getAuthPassphrase());
+                userBuilder = userBuilder.auth(snmpEndpoint.getSnmpDefinition().getAuthProtocol()).authPassphrase(secretResolvers.resolve(snmpEndpoint.getSnmpDefinition().getAuthPassphrase()));
             }
 
             if (snmpEndpoint.getSnmpDefinition().getPrivProtocol() != null && snmpEndpoint.getSnmpDefinition().getPrivPassphrase() != null) {
-                userBuilder = userBuilder.priv(snmpEndpoint.getSnmpDefinition().getPrivProtocol()).privPassphrase(snmpEndpoint.getSnmpDefinition().getPrivPassphrase());
+                userBuilder = userBuilder.priv(snmpEndpoint.getSnmpDefinition().getPrivProtocol()).privPassphrase(secretResolvers.resolve(snmpEndpoint.getSnmpDefinition().getPrivPassphrase()));
             }
 
             return userBuilder
@@ -100,7 +101,7 @@ enum SnmpVersion {
 
     abstract SnmpBuilder getSnmpBuilder() throws IOException;
 
-    abstract Target<?> getTarget(Snmp snmp, SnmpBuilder snmpBuilder, SnmpEndpoint snmpEndpoint) throws UnknownHostException;
+    abstract Target<?> getTarget(Snmp snmp, SnmpBuilder snmpBuilder, SnmpEndpoint snmpEndpoint, SecretResolvers secretResolvers) throws UnknownHostException;
 
     Address getTargetAddress(SnmpEndpoint snmpEndpoint) throws UnknownHostException {
         return new UdpAddress(snmpEndpoint.getInetSocketAddress().getAddress(), snmpEndpoint.getInetSocketAddress().getPort());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,10 +25,17 @@ riptide.clickhouse.database=riptide
 riptide.snmp.cache.retentionMs=600000
 
 # SNMP CONFIG EXAMPLE
+# Credentials (community, auth-passphrase, priv-passphrase) are secret references,
+# resolved at poll time — never put plaintext secrets here. Supported schemes:
+#   env://NAME                                          environment variable
+#   file:///run/secrets/community                       file content (trimmed)
+#   file:///etc/riptide/sec.properties#snmp.community   key in a properties file
+# Optionally restrict file:// access:
+#riptide.secrets.allowed-paths=/run/secrets,/etc/riptide
 #riptide.snmp.config.definitions[0].subnet-address=10.20.30.0/24
 #riptide.snmp.config.definitions[0].port=161
 #riptide.snmp.config.definitions[0].snmp-version=v2c
-#riptide.snmp.config.definitions[0].community=c0mmunity
+#riptide.snmp.config.definitions[0].community=env://RIPTIDE_SNMP_COMMUNITY
 
 # ENRICHER: HOSTNAMES
 riptide.enricher.hostnames.enabled=false

--- a/src/test/java/org/riptide/secrets/SecretRefTest.java
+++ b/src/test/java/org/riptide/secrets/SecretRefTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.secrets;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class SecretRefTest {
+
+    @Test
+    public void parsesEnvRef() {
+        final SecretRef ref = new SecretRef("env://RIPTIDE_SNMP_COMMUNITY");
+        assertThat(ref.getScheme()).isEqualTo("env");
+        assertThat(ref.getValue()).isEqualTo("RIPTIDE_SNMP_COMMUNITY");
+        assertThat(ref.getKey()).isNull();
+    }
+
+    @Test
+    public void parsesFileRef() {
+        final SecretRef ref = new SecretRef("file:///run/secrets/community");
+        assertThat(ref.getScheme()).isEqualTo("file");
+        assertThat(ref.getValue()).isEqualTo("/run/secrets/community");
+        assertThat(ref.getKey()).isNull();
+    }
+
+    @Test
+    public void parsesFileRefWithKey() {
+        final SecretRef ref = new SecretRef("file:///etc/riptide/sec.properties#snmp.community");
+        assertThat(ref.getScheme()).isEqualTo("file");
+        assertThat(ref.getValue()).isEqualTo("/etc/riptide/sec.properties");
+        assertThat(ref.getKey()).isEqualTo("snmp.community");
+    }
+
+    @Test
+    public void fallsBackToPlainForUnschemedValues() {
+        final SecretRef ref = new SecretRef("c0mmunity");
+        assertThat(ref.getScheme()).isEqualTo(SecretRef.SCHEME_PLAIN);
+        assertThat(ref.getValue()).isEqualTo("c0mmunity");
+        assertThat(ref.getKey()).isNull();
+    }
+
+    @Test
+    public void ofIsNullSafe() {
+        assertThat(SecretRef.of(null)).isNull();
+        assertThat(SecretRef.of("env://X")).isNotNull();
+    }
+
+    @Test
+    public void rejectsBlankAndValuelessRefs() {
+        assertThatThrownBy(() -> new SecretRef("")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new SecretRef("  ")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new SecretRef("env://")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void toStringNeverExposesPlainSecrets() {
+        assertThat(new SecretRef("s3cr3t").toString()).doesNotContain("s3cr3t");
+        assertThat(new SecretRef("env://NAME").toString()).isEqualTo("env://NAME");
+        assertThat(new SecretRef("file:///p#k").toString()).isEqualTo("file:///p#k");
+    }
+}

--- a/src/test/java/org/riptide/secrets/SecretResolversTest.java
+++ b/src/test/java/org/riptide/secrets/SecretResolversTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.secrets;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class SecretResolversTest {
+
+    @Test
+    public void resolvesPlainRefs() {
+        assertThat(SecretResolvers.defaults().resolve(SecretRef.of("c0mmunity"))).isEqualTo("c0mmunity");
+    }
+
+    @Test
+    public void nullRefResolvesToNull() {
+        assertThat(SecretResolvers.defaults().resolve(null)).isNull();
+    }
+
+    @Test
+    public void unknownSchemeThrows() {
+        assertThatThrownBy(() -> SecretResolvers.defaults().resolve(SecretRef.of("vault://secret/x#y")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("vault");
+    }
+
+    @Test
+    public void resolvesEnvRefs() {
+        final Map<String, String> env = Map.of("RIPTIDE_SNMP_COMMUNITY", "fr0m-env");
+        final SecretResolvers resolvers = new SecretResolvers(List.of(new EnvSecretResolver(env::get)));
+
+        assertThat(resolvers.resolve(SecretRef.of("env://RIPTIDE_SNMP_COMMUNITY"))).isEqualTo("fr0m-env");
+        assertThatThrownBy(() -> resolvers.resolve(SecretRef.of("env://MISSING")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("MISSING");
+    }
+
+    @Test
+    public void resolvesFileRefs(@TempDir Path tempDir) throws Exception {
+        final Path secretFile = tempDir.resolve("community");
+        Files.writeString(secretFile, "fr0m-file\n");
+
+        final SecretResolvers resolvers = new SecretResolvers(List.of(new FileSecretResolver(List.of())));
+        assertThat(resolvers.resolve(SecretRef.of("file://" + secretFile))).isEqualTo("fr0m-file");
+    }
+
+    @Test
+    public void resolvesFileRefsWithPropertiesKey(@TempDir Path tempDir) throws Exception {
+        final Path secretFile = tempDir.resolve("secrets.properties");
+        Files.writeString(secretFile, "snmp.community=fr0m-props\nother=x\n");
+
+        final SecretResolvers resolvers = new SecretResolvers(List.of(new FileSecretResolver(List.of())));
+        assertThat(resolvers.resolve(SecretRef.of("file://" + secretFile + "#snmp.community"))).isEqualTo("fr0m-props");
+        assertThatThrownBy(() -> resolvers.resolve(SecretRef.of("file://" + secretFile + "#missing.key")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("missing.key");
+    }
+
+    @Test
+    public void fileResolverEnforcesAllowedPaths(@TempDir Path tempDir) throws Exception {
+        final Path allowed = Files.createDirectory(tempDir.resolve("allowed"));
+        final Path outside = Files.createDirectory(tempDir.resolve("outside"));
+        final Path allowedSecret = allowed.resolve("s");
+        final Path outsideSecret = outside.resolve("s");
+        Files.writeString(allowedSecret, "ok");
+        Files.writeString(outsideSecret, "nope");
+
+        final SecretResolvers resolvers = new SecretResolvers(List.of(new FileSecretResolver(List.of(allowed.toString()))));
+        assertThat(resolvers.resolve(SecretRef.of("file://" + allowedSecret))).isEqualTo("ok");
+        assertThatThrownBy(() -> resolvers.resolve(SecretRef.of("file://" + outsideSecret)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("allowed-paths");
+    }
+
+    @Test
+    public void symlinksCannotEscapeAllowedPaths(@TempDir Path tempDir) throws Exception {
+        final Path allowed = Files.createDirectory(tempDir.resolve("allowed"));
+        final Path outside = Files.createDirectory(tempDir.resolve("outside"));
+        final Path target = outside.resolve("s");
+        Files.writeString(target, "nope");
+        final Path escape = allowed.resolve("escape");
+        Files.createSymbolicLink(escape, target);
+
+        final SecretResolvers resolvers = new SecretResolvers(List.of(new FileSecretResolver(List.of(allowed.toString()))));
+        assertThatThrownBy(() -> resolvers.resolve(SecretRef.of("file://" + escape)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("allowed-paths");
+    }
+
+    @Test
+    public void unreadableFileThrows() {
+        final SecretResolvers resolvers = new SecretResolvers(List.of(new FileSecretResolver(List.of())));
+        assertThatThrownBy(() -> resolvers.resolve(SecretRef.of("file:///does/not/exist")))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/org/riptide/snmp/SnmpTest.java
+++ b/src/test/java/org/riptide/snmp/SnmpTest.java
@@ -17,6 +17,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.riptide.secrets.SecretRef;
+import org.riptide.secrets.SecretResolvers;
 import org.snmp4j.fluent.TargetBuilder;
 
 import inet.ipaddr.IPAddressString;
@@ -24,6 +26,7 @@ import inet.ipaddr.IPAddressString;
 public class SnmpTest {
 
     private static final AtomicInteger PORT_COUNTER = new AtomicInteger(12345);
+    private static final SecretResolvers SECRET_RESOLVERS = SecretResolvers.defaults();
     private TestSnmpAgent currentAgent;
 
     @AfterEach
@@ -42,7 +45,7 @@ public class SnmpTest {
         final SnmpDefinition snmpDefinition = new SnmpDefinition();
         snmpDefinition.setPort(port);
         snmpDefinition.setSnmpVersion(SnmpVersion.v1);
-        snmpDefinition.setCommunity(community);
+        snmpDefinition.setCommunity(SecretRef.of(community));
         snmpDefinition.setSecurityName(null);
         snmpDefinition.setAuthProtocol(null);
         snmpDefinition.setAuthPassphrase(null);
@@ -55,7 +58,7 @@ public class SnmpTest {
         final SnmpDefinition snmpDefinition = new SnmpDefinition();
         snmpDefinition.setPort(port);
         snmpDefinition.setSnmpVersion(SnmpVersion.v2c);
-        snmpDefinition.setCommunity(community);
+        snmpDefinition.setCommunity(SecretRef.of(community));
         snmpDefinition.setSecurityName(null);
         snmpDefinition.setAuthProtocol(null);
         snmpDefinition.setAuthPassphrase(null);
@@ -84,7 +87,7 @@ public class SnmpTest {
         snmpDefinition.setCommunity(null);
         snmpDefinition.setSecurityName(securityName);
         snmpDefinition.setAuthProtocol(authProtocol);
-        snmpDefinition.setAuthPassphrase(authPassphrase);
+        snmpDefinition.setAuthPassphrase(SecretRef.of(authPassphrase));
         snmpDefinition.setPrivProtocol(null);
         snmpDefinition.setPrivPassphrase(null);
         return snmpDefinition.createEndpoint(ipAddressString);
@@ -97,9 +100,9 @@ public class SnmpTest {
         snmpDefinition.setCommunity(null);
         snmpDefinition.setSecurityName(securityName);
         snmpDefinition.setAuthProtocol(authProtocol);
-        snmpDefinition.setAuthPassphrase(authPassphrase);
+        snmpDefinition.setAuthPassphrase(SecretRef.of(authPassphrase));
         snmpDefinition.setPrivProtocol(privProtocol);
-        snmpDefinition.setPrivPassphrase(privPassphrase);
+        snmpDefinition.setPrivPassphrase(SecretRef.of(privPassphrase));
         return snmpDefinition.createEndpoint(ipAddressString);
     }
 
@@ -112,7 +115,7 @@ public class SnmpTest {
         currentAgent.registerIfXTable();
 
         final SnmpEndpoint snmpEndpoint = communityV2c(new IPAddressString("127.0.0.1"), port, TestSnmpAgent.COMMUNITY);
-        final Map<Integer, String> ifMap = SnmpUtils.getSnmpInterfaceMap(snmpEndpoint);
+        final Map<Integer, String> ifMap = SnmpUtils.getSnmpInterfaceMap(snmpEndpoint, SECRET_RESOLVERS);
 
         assertThat(ifMap.get(1)).isEqualTo("eth0-x");
         assertThat(ifMap.get(2)).isEqualTo("lo0-x");
@@ -127,7 +130,7 @@ public class SnmpTest {
         currentAgent.registerIfXTable();
 
         final SnmpEndpoint snmpEndpoint = noAuthNoPriv(new IPAddressString("127.0.0.1"), port, TestSnmpAgent.NOAUTHNOPRIV_USERNAME);
-        final Map<Integer, String> ifMap = SnmpUtils.getSnmpInterfaceMap(snmpEndpoint);
+        final Map<Integer, String> ifMap = SnmpUtils.getSnmpInterfaceMap(snmpEndpoint, SECRET_RESOLVERS);
 
         assertThat(ifMap.get(1)).isEqualTo("eth0-x");
         assertThat(ifMap.get(2)).isEqualTo("lo0-x");
@@ -141,7 +144,7 @@ public class SnmpTest {
         currentAgent.registerIfTable();
 
         final SnmpEndpoint snmpEndpoint = noAuthNoPriv(new IPAddressString("127.0.0.1"), port, TestSnmpAgent.NOAUTHNOPRIV_USERNAME);
-        final Map<Integer, String> ifMap = SnmpUtils.getSnmpInterfaceMap(snmpEndpoint);
+        final Map<Integer, String> ifMap = SnmpUtils.getSnmpInterfaceMap(snmpEndpoint, SECRET_RESOLVERS);
 
         assertThat(ifMap.get(1)).isEqualTo("eth0");
         assertThat(ifMap.get(2)).isEqualTo("lo0");
@@ -156,7 +159,7 @@ public class SnmpTest {
         currentAgent.registerIfXTable();
 
         final SnmpEndpoint snmpEndpoint = authNoPriv(new IPAddressString("127.0.0.1"), port, TestSnmpAgent.AUTHNOPRIV_USERNAME, TargetBuilder.AuthProtocol.sha1, TestSnmpAgent.AUTHNOPRIV_AUTH_PASSHRASE);
-        final Map<Integer, String> ifMap = SnmpUtils.getSnmpInterfaceMap(snmpEndpoint);
+        final Map<Integer, String> ifMap = SnmpUtils.getSnmpInterfaceMap(snmpEndpoint, SECRET_RESOLVERS);
 
         assertThat(ifMap.get(1)).isEqualTo("eth0-x");
         assertThat(ifMap.get(2)).isEqualTo("lo0-x");
@@ -171,10 +174,19 @@ public class SnmpTest {
         currentAgent.registerIfXTable();
 
         final SnmpEndpoint snmpEndpoint = authPriv(new IPAddressString("127.0.0.1"), port, TestSnmpAgent.AUTHPRIV_USERNAME, TargetBuilder.AuthProtocol.sha1, TestSnmpAgent.AUTHPRIV_AUTH_PASSHRASE, TargetBuilder.PrivProtocol.aes128, TestSnmpAgent.AUTHPRIV_PRIV_PASSHRASE);
-        final Map<Integer, String> ifMap = SnmpUtils.getSnmpInterfaceMap(snmpEndpoint);
+        final Map<Integer, String> ifMap = SnmpUtils.getSnmpInterfaceMap(snmpEndpoint, SECRET_RESOLVERS);
 
         assertThat(ifMap.get(1)).isEqualTo("eth0-x");
         assertThat(ifMap.get(2)).isEqualTo("lo0-x");
+    }
+
+    @Test
+    public void unresolvableSecretRefDegradesToEmptyInsteadOfThrowing() {
+        // a broken secret reference must yield an unenriched flow, never fail the pipeline
+        final SnmpService snmpService = new DefaultSnmpService(SECRET_RESOLVERS);
+        final SnmpEndpoint snmpEndpoint = communityV2c(new IPAddressString("127.0.0.1"), getNextPort(), "env://RIPTIDE_TEST_MISSING_VAR");
+
+        assertThat(snmpService.getIfName(snmpEndpoint, 1)).isInstanceOf(Optional.class).isEmpty();
     }
 
     @Test
@@ -183,7 +195,7 @@ public class SnmpTest {
         final SnmpCacheConfig snmpCacheConfig = new SnmpCacheConfig();
         snmpCacheConfig.retentionMs = 600000;
 
-        final SnmpService snmpCache = new CachingSnmpService(new DefaultSnmpService(), snmpCacheConfig);
+        final SnmpService snmpCache = new CachingSnmpService(new DefaultSnmpService(SECRET_RESOLVERS), snmpCacheConfig);
         final SnmpEndpoint snmpEndpoint = communityV2c(new IPAddressString("127.0.0.1"), port, TestSnmpAgent.COMMUNITY);
 
         assertThat(snmpCache.getIfName(snmpEndpoint, 1)).isInstanceOf(Optional.class).isEmpty();


### PR DESCRIPTION
## Summary

Phase 1 of the lightweight node model epic (#153): SNMP credentials become **secret references**, never plaintext values.

- **`SecretRef`** — URI-style reference (`env://NAME`, `file:///path`, `file:///path#key`) with a plain-literal fallback for migration/test fixtures. Binds directly from Spring config via its single-String constructor. `toString()` redacts plain values, so `SnmpDefinition`/`SnmpEndpoint` log lines no longer leak credentials.
- **`SecretResolver` SPI** + `env:`/`file:` resolvers, dispatched by scheme (`SecretResolvers`). Modeled on Kafka's `ConfigProvider` `${provider:path:key}` indirection. `vault:`/`sops:` follow in Phase 2 (#155) behind the same SPI.
- **`file:` sandbox** — optional `riptide.secrets.allowed-paths` restriction with symlink-safe `toRealPath()` checks.
- **Resolution at the consumption point** — `SnmpVersion.getTarget(...)`, where SNMP4J actually receives community/auth/priv values (not `createEndpoint`, which never touches credentials).
- **Graceful degradation** — an unresolvable reference logs a warning and yields an unenriched flow; it does not fail the enrichment future and drop the whole batch in `Pipeline.process`.

## Review

Self-review (medium) found and fixed two issues, both locked with tests:
1. Resolution failures originally propagated unchecked → `FlowException` → dropped flow batches. Now degrade like the existing IOException path.
2. allowed-paths check was `normalize()`-only → symlinks could escape the sandbox. Now `toRealPath()` on both sides.

## Testing

- `mvn clean test` green: 16 new secrets tests (`SecretRefTest`, `SecretResolversTest`) + extended `SnmpTest` (degrade path) — existing `SnmpEnricherTest` passes unchanged, proving plain-string Spring binding still works through the converter.

Part of #153. Closes #154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
