### PR TITLE
feat(secrets): add Vault and SOPS resolvers behind the SecretRef SPI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <resilience4j.version>2.4.0</resilience4j.version>
         <snmp4j.version>3.9.7</snmp4j.version>
         <snmp4j-agent.version>3.8.3</snmp4j-agent.version>
+        <spring-vault.version>4.1.0</spring-vault.version>
         <dropwizard-metrics.version>4.2.38</dropwizard-metrics.version>
         <jquick.version>1.9.3</jquick.version>
         <clickhouse.version>0.9.7</clickhouse.version>
@@ -170,6 +171,15 @@
             <version>${clickhouse.version}</version>
         </dependency>
 
+        <!-- HashiCorp Vault (SecretRef vault:// resolver). Deliberately spring-vault-core, not
+             spring-cloud-starter-vault-config: SecretRefs resolve at poll time via VaultTemplate,
+             not at boot time via property sources. -->
+        <dependency>
+            <groupId>org.springframework.vault</groupId>
+            <artifactId>spring-vault-core</artifactId>
+            <version>${spring-vault.version}</version>
+        </dependency>
+
         <!-- Test scope -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -190,6 +200,11 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>vault</artifactId>
             <scope>test</scope>
         </dependency>
             <dependency>

--- a/src/main/java/org/riptide/secrets/SopsSecretResolver.java
+++ b/src/main/java/org/riptide/secrets/SopsSecretResolver.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.secrets;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Resolves {@code sops://<file>#<key>} by decrypting the file with the
+ * <a href="https://getsops.io">sops</a> binary and looking up a (dot-separated, nested)
+ * key in the decrypted YAML/JSON document. Without a {@code #key}, the whole decrypted
+ * content (trimmed) is the secret.
+ *
+ * <p>Decrypted files are cached in memory for the lifetime of the process — SOPS is a
+ * boot-time secret source; restart (or touch a config reload, once available) to pick up
+ * re-encrypted values.</p>
+ *
+ * <p>Configuration: {@code riptide.secrets.sops.command} (default {@code sops}) and
+ * {@code riptide.secrets.sops.age-key-file} (sets {@code SOPS_AGE_KEY_FILE} for the
+ * subprocess).</p>
+ */
+@Component
+public class SopsSecretResolver implements SecretResolver {
+
+    private static final long DECRYPT_TIMEOUT_SECONDS = 30;
+
+    private final List<String> command;
+    private final String ageKeyFile;
+    private final Map<Path, DecryptedFile> cache = new ConcurrentHashMap<>();
+
+    public SopsSecretResolver(@Value("${riptide.secrets.sops.command:sops}") final String command,
+                              @Value("${riptide.secrets.sops.age-key-file:}") final String ageKeyFile) {
+        this.command = List.of(command.trim().split("\\s+"));
+        this.ageKeyFile = ageKeyFile;
+    }
+
+    private record DecryptedFile(String raw, Map<String, String> values) {
+    }
+
+    @Override
+    public String scheme() {
+        return "sops";
+    }
+
+    @Override
+    public String resolve(final SecretRef ref) {
+        final Path path;
+        try {
+            path = Path.of(ref.getValue()).toRealPath();
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Cannot read secret ref " + ref, e);
+        }
+
+        final DecryptedFile decrypted = this.cache.computeIfAbsent(path, p -> decrypt(p, ref));
+
+        if (ref.getKey() == null) {
+            return decrypted.raw().trim();
+        }
+        final String value = decrypted.values().get(ref.getKey());
+        if (value == null) {
+            throw new IllegalArgumentException("Key '" + ref.getKey() + "' not found for secret ref " + ref);
+        }
+        return value;
+    }
+
+    private DecryptedFile decrypt(final Path path, final SecretRef ref) {
+        final List<String> commandLine = new ArrayList<>(this.command);
+        commandLine.add("-d");
+        commandLine.add(path.toString());
+
+        final ProcessBuilder processBuilder = new ProcessBuilder(commandLine);
+        if (!this.ageKeyFile.isBlank()) {
+            processBuilder.environment().put("SOPS_AGE_KEY_FILE", this.ageKeyFile);
+        }
+
+        final String stdout;
+        try {
+            final Process process = processBuilder.start();
+            // no interactive prompts (e.g. for a missing key) — fail instead
+            process.getOutputStream().close();
+            if (!process.waitFor(DECRYPT_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                process.destroyForcibly();
+                throw new IllegalArgumentException("Decrypting secret ref " + ref + " timed out after " + DECRYPT_TIMEOUT_SECONDS + "s");
+            }
+            stdout = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            if (process.exitValue() != 0) {
+                final String stderr = new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
+                throw new IllegalArgumentException("Decrypting secret ref " + ref + " failed (exit " + process.exitValue() + "): " + stderr.trim());
+            }
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Cannot run '" + String.join(" ", this.command) + "' for secret ref " + ref, e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalArgumentException("Interrupted while decrypting secret ref " + ref, e);
+        }
+
+        return new DecryptedFile(stdout, flatten(stdout));
+    }
+
+    private static Map<String, String> flatten(final String document) {
+        final Object parsed;
+        try {
+            parsed = new Yaml().load(document);
+        } catch (RuntimeException e) {
+            // not a YAML/JSON document (e.g. sops binary format) — only whole-content refs work
+            return Map.of();
+        }
+        final Map<String, String> flat = new ConcurrentHashMap<>();
+        if (parsed instanceof Map<?, ?> map) {
+            flatten("", map, flat);
+        }
+        return flat;
+    }
+
+    private static void flatten(final String prefix, final Map<?, ?> map, final Map<String, String> into) {
+        for (final Map.Entry<?, ?> entry : map.entrySet()) {
+            final String key = prefix.isEmpty() ? String.valueOf(entry.getKey()) : prefix + "." + entry.getKey();
+            if (entry.getValue() instanceof Map<?, ?> nested) {
+                flatten(key, nested, into);
+            } else if (entry.getValue() != null) {
+                into.put(key, String.valueOf(entry.getValue()));
+            }
+        }
+    }
+}

--- a/src/main/java/org/riptide/secrets/VaultSecretResolver.java
+++ b/src/main/java/org/riptide/secrets/VaultSecretResolver.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.secrets;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.vault.authentication.TokenAuthentication;
+import org.springframework.vault.client.VaultEndpoint;
+import org.springframework.vault.core.VaultKeyValueOperationsSupport.KeyValueBackend;
+import org.springframework.vault.core.VaultOperations;
+import org.springframework.vault.core.VaultTemplate;
+import org.springframework.vault.support.VaultResponse;
+
+import java.net.URI;
+
+/**
+ * Resolves {@code vault://<mount>/<path>#<key>} from a HashiCorp Vault KV v2 secrets engine,
+ * e.g. {@code vault://secret/snmp/core-router#community}.
+ *
+ * <p>Registered only when {@code riptide.secrets.vault.uri} is configured. Authentication is
+ * token-based ({@code riptide.secrets.vault.token}); with a Vault Agent sidecar, point the
+ * token at the agent's sink (e.g. {@code ${VAULT_TOKEN}}).</p>
+ */
+@Component
+@ConditionalOnProperty("riptide.secrets.vault.uri")
+public class VaultSecretResolver implements SecretResolver {
+
+    private final VaultOperations vault;
+
+    @Autowired
+    public VaultSecretResolver(@Value("${riptide.secrets.vault.uri}") final URI uri,
+                               @Value("${riptide.secrets.vault.token:}") final String token) {
+        this(createTemplate(uri, token));
+    }
+
+    public VaultSecretResolver(final VaultOperations vault) {
+        this.vault = vault;
+    }
+
+    private static VaultTemplate createTemplate(final URI uri, final String token) {
+        if (token.isBlank()) {
+            throw new IllegalArgumentException("riptide.secrets.vault.uri is set but riptide.secrets.vault.token is missing");
+        }
+        return new VaultTemplate(VaultEndpoint.from(uri), new TokenAuthentication(token));
+    }
+
+    @Override
+    public String scheme() {
+        return "vault";
+    }
+
+    @Override
+    public String resolve(final SecretRef ref) {
+        if (ref.getKey() == null) {
+            throw new IllegalArgumentException("Secret ref " + ref + " is missing the #key selecting a field of the secret");
+        }
+        final int mountEnd = ref.getValue().indexOf('/');
+        if (mountEnd <= 0 || mountEnd == ref.getValue().length() - 1) {
+            throw new IllegalArgumentException("Secret ref " + ref + " must have the form vault://<mount>/<path>#<key>");
+        }
+        final String mount = ref.getValue().substring(0, mountEnd);
+        final String path = ref.getValue().substring(mountEnd + 1);
+
+        final VaultResponse response;
+        try {
+            response = this.vault.opsForKeyValue(mount, KeyValueBackend.KV_2).get(path);
+        } catch (IllegalArgumentException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            // Vault client errors (server unreachable, auth failure, …) must keep the SPI
+            // contract of IllegalArgumentException so enrichment degrades instead of failing
+            throw new IllegalArgumentException("Cannot resolve secret ref " + ref + " from Vault: " + e.getMessage(), e);
+        }
+        if (response == null || response.getData() == null) {
+            throw new IllegalArgumentException("No secret found for ref " + ref);
+        }
+        final Object value = response.getData().get(ref.getKey());
+        if (value == null) {
+            throw new IllegalArgumentException("Key '" + ref.getKey() + "' not found for secret ref " + ref);
+        }
+        return value.toString();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,8 +30,16 @@ riptide.snmp.cache.retentionMs=600000
 #   env://NAME                                          environment variable
 #   file:///run/secrets/community                       file content (trimmed)
 #   file:///etc/riptide/sec.properties#snmp.community   key in a properties file
+#   vault://secret/snmp/core-router#community           HashiCorp Vault KV v2 (<mount>/<path>#<key>)
+#   sops:///etc/riptide/secrets.yaml#snmp.community     SOPS-encrypted YAML/JSON (decrypted via the sops binary)
 # Optionally restrict file:// access:
 #riptide.secrets.allowed-paths=/run/secrets,/etc/riptide
+# Vault (enables the vault:// resolver; token e.g. from a Vault Agent sink):
+#riptide.secrets.vault.uri=https://vault.example.com:8200
+#riptide.secrets.vault.token=${VAULT_TOKEN}
+# SOPS (age key for decryption; command defaults to `sops` on the PATH):
+#riptide.secrets.sops.command=sops
+#riptide.secrets.sops.age-key-file=/etc/riptide/age.key
 #riptide.snmp.config.definitions[0].subnet-address=10.20.30.0/24
 #riptide.snmp.config.definitions[0].port=161
 #riptide.snmp.config.definitions[0].snmp-version=v2c

--- a/src/test/java/org/riptide/e2e/VaultSecretResolverIT.java
+++ b/src/test/java/org/riptide/e2e/VaultSecretResolverIT.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.e2e;
+
+import org.junit.jupiter.api.Test;
+import org.riptide.secrets.SecretRef;
+import org.riptide.secrets.VaultSecretResolver;
+import org.springframework.vault.authentication.TokenAuthentication;
+import org.springframework.vault.client.VaultEndpoint;
+import org.springframework.vault.core.VaultTemplate;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.vault.VaultContainer;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Testcontainers
+public class VaultSecretResolverIT {
+
+    private static final String ROOT_TOKEN = "riptide-test-root";
+
+    @Container
+    private static final VaultContainer<?> VAULT = new VaultContainer<>("hashicorp/vault:1.20")
+            .withVaultToken(ROOT_TOKEN)
+            // dev mode mounts a KV v2 engine at secret/
+            .withInitCommand("kv put secret/snmp/core-router community=v4ult-c0mmunity auth=v4ult-auth");
+
+    private VaultSecretResolver resolver() {
+        final VaultTemplate template = new VaultTemplate(
+                VaultEndpoint.from(URI.create(VAULT.getHttpHostAddress())),
+                new TokenAuthentication(ROOT_TOKEN));
+        return new VaultSecretResolver(template);
+    }
+
+    @Test
+    public void resolvesKvV2Secrets() {
+        final VaultSecretResolver resolver = resolver();
+
+        assertThat(resolver.resolve(SecretRef.of("vault://secret/snmp/core-router#community"))).isEqualTo("v4ult-c0mmunity");
+        assertThat(resolver.resolve(SecretRef.of("vault://secret/snmp/core-router#auth"))).isEqualTo("v4ult-auth");
+    }
+
+    @Test
+    public void missingKeyOrSecretThrows() {
+        final VaultSecretResolver resolver = resolver();
+
+        assertThatThrownBy(() -> resolver.resolve(SecretRef.of("vault://secret/snmp/core-router#nope")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("nope");
+        assertThatThrownBy(() -> resolver.resolve(SecretRef.of("vault://secret/snmp/unknown-device#community")))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void refWithoutKeyOrMountThrows() {
+        final VaultSecretResolver resolver = resolver();
+
+        assertThatThrownBy(() -> resolver.resolve(SecretRef.of("vault://secret/snmp/core-router")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("#key");
+        assertThatThrownBy(() -> resolver.resolve(SecretRef.of("vault://secretonly#k")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("vault://<mount>/<path>#<key>");
+    }
+}

--- a/src/test/java/org/riptide/secrets/SopsSecretResolverTest.java
+++ b/src/test/java/org/riptide/secrets/SopsSecretResolverTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.secrets;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests the resolver against fake decrypt commands so they run without a sops binary;
+ * the subprocess handling, parsing, key lookup, and caching are what is under test.
+ */
+@DisabledOnOs(OS.WINDOWS)
+public class SopsSecretResolverTest {
+
+    private static final String YAML = """
+            snmp:
+              community: fr0m-sops
+              auth-passphrase: s3cret
+            top: level
+            """;
+
+    private Path fakeSops(final Path dir, final String script) throws IOException {
+        final Path command = dir.resolve("fake-sops.sh");
+        Files.writeString(command, "#!/bin/sh\n" + script);
+        Files.setPosixFilePermissions(command, PosixFilePermissions.fromString("rwxr-xr-x"));
+        return command;
+    }
+
+    private Path secretsFile(final Path dir) throws IOException {
+        // content is irrelevant — the fake command produces the "decrypted" output
+        final Path file = dir.resolve("secrets.sops.yaml");
+        Files.writeString(file, "encrypted");
+        return file;
+    }
+
+    @Test
+    public void resolvesNestedAndTopLevelKeys(@TempDir Path dir) throws Exception {
+        final Path command = fakeSops(dir, "cat <<'EOF'\n" + YAML + "EOF\n");
+        final Path file = secretsFile(dir);
+        final SopsSecretResolver resolver = new SopsSecretResolver(command.toString(), "");
+
+        assertThat(resolver.resolve(SecretRef.of("sops://" + file + "#snmp.community"))).isEqualTo("fr0m-sops");
+        assertThat(resolver.resolve(SecretRef.of("sops://" + file + "#snmp.auth-passphrase"))).isEqualTo("s3cret");
+        assertThat(resolver.resolve(SecretRef.of("sops://" + file + "#top"))).isEqualTo("level");
+    }
+
+    @Test
+    public void missingKeyThrows(@TempDir Path dir) throws Exception {
+        final Path command = fakeSops(dir, "cat <<'EOF'\n" + YAML + "EOF\n");
+        final Path file = secretsFile(dir);
+        final SopsSecretResolver resolver = new SopsSecretResolver(command.toString(), "");
+
+        assertThatThrownBy(() -> resolver.resolve(SecretRef.of("sops://" + file + "#missing.key")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("missing.key");
+    }
+
+    @Test
+    public void withoutKeyReturnsWholeContent(@TempDir Path dir) throws Exception {
+        final Path command = fakeSops(dir, "printf 'raw-secret\\n'\n");
+        final Path file = secretsFile(dir);
+        final SopsSecretResolver resolver = new SopsSecretResolver(command.toString(), "");
+
+        assertThat(resolver.resolve(SecretRef.of("sops://" + file))).isEqualTo("raw-secret");
+    }
+
+    @Test
+    public void decryptionRunsOncePerFile(@TempDir Path dir) throws Exception {
+        final Path counter = dir.resolve("invocations");
+        final Path command = fakeSops(dir, "echo x >> " + counter + "\ncat <<'EOF'\n" + YAML + "EOF\n");
+        final Path file = secretsFile(dir);
+        final SopsSecretResolver resolver = new SopsSecretResolver(command.toString(), "");
+
+        resolver.resolve(SecretRef.of("sops://" + file + "#snmp.community"));
+        resolver.resolve(SecretRef.of("sops://" + file + "#top"));
+
+        assertThat(Files.readAllLines(counter)).hasSize(1);
+    }
+
+    @Test
+    public void failingCommandThrowsWithStderr(@TempDir Path dir) throws Exception {
+        final Path command = fakeSops(dir, "echo 'no key found' >&2\nexit 1\n");
+        final Path file = secretsFile(dir);
+        final SopsSecretResolver resolver = new SopsSecretResolver(command.toString(), "");
+
+        assertThatThrownBy(() -> resolver.resolve(SecretRef.of("sops://" + file + "#snmp.community")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("no key found");
+    }
+
+    @Test
+    public void missingCommandThrows(@TempDir Path dir) throws Exception {
+        final Path file = secretsFile(dir);
+        final SopsSecretResolver resolver = new SopsSecretResolver(dir.resolve("does-not-exist").toString(), "");
+
+        assertThatThrownBy(() -> resolver.resolve(SecretRef.of("sops://" + file + "#snmp.community")))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void missingFileThrows(@TempDir Path dir) throws Exception {
+        final Path command = fakeSops(dir, "exit 0\n");
+        final SopsSecretResolver resolver = new SopsSecretResolver(command.toString(), "");
+
+        assertThatThrownBy(() -> resolver.resolve(SecretRef.of("sops://" + dir.resolve("nope.yaml") + "#k")))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void ageKeyFileIsPassedToSubprocess(@TempDir Path dir) throws Exception {
+        final Path command = fakeSops(dir, "printf 'key-file: %s\\n' \"$SOPS_AGE_KEY_FILE\"\n");
+        final Path file = secretsFile(dir);
+        final SopsSecretResolver resolver = new SopsSecretResolver(command.toString(), "/etc/riptide/age.key");
+
+        assertThat(resolver.resolve(SecretRef.of("sops://" + file + "#key-file"))).isEqualTo("/etc/riptide/age.key");
+    }
+}

--- a/src/test/java/org/riptide/secrets/VaultSecretResolverSpringTest.java
+++ b/src/test/java/org/riptide/secrets/VaultSecretResolverSpringTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.secrets;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Locks Spring wiring of the conditional vault resolver: the bean must be constructible
+ * from properties (constructor selection), and a resolve against an unreachable server
+ * must keep the SPI's IllegalArgumentException contract so enrichment degrades instead
+ * of failing the pipeline. No Vault server is involved.
+ */
+@SpringBootTest(properties = {
+        "riptide.secrets.vault.uri=http://127.0.0.1:1",
+        "riptide.secrets.vault.token=dummy-token"
+})
+public class VaultSecretResolverSpringTest {
+
+    @Autowired
+    SecretResolvers secretResolvers;
+
+    @Autowired
+    VaultSecretResolver vaultSecretResolver;
+
+    @Test
+    public void vaultResolverIsRegisteredWhenUriIsConfigured() {
+        assertThat(this.vaultSecretResolver).isNotNull();
+    }
+
+    @Test
+    public void unreachableVaultDegradesToIllegalArgumentException() {
+        assertThatThrownBy(() -> this.secretResolvers.resolve(SecretRef.of("vault://secret/snmp/core#community")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cannot resolve secret ref");
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the lightweight node model epic (#153): `vault:` and `sops:` resolvers behind the `SecretResolver` SPI from #160 — SNMP credentials now come from a single secure store, pluggably.

- **`VaultSecretResolver`** — `vault://<mount>/<path>#<key>` against KV v2 via **spring-vault-core 4.1.0** (`VaultTemplate` at poll time; deliberately *not* spring-cloud-vault property sources, which are boot-time only). Conditional on `riptide.secrets.vault.uri`; token auth works with a Vault Agent sink token.
- **`SopsSecretResolver`** — `sops://<file>#<dot.key>` shells out to the `sops` binary (configurable `riptide.secrets.sops.command`, optional `age-key-file` → `SOPS_AGE_KEY_FILE`), parses decrypted YAML/JSON with snakeyaml (already on the classpath), flattens nested keys, caches per file for the process lifetime. Prompt-proof subprocess handling: stdin closed, 30s hard timeout, stderr surfaced in errors.

## Review (medium, self)

Two findings fixed and locked with tests:
1. **Vault client exceptions escaped the SPI contract** (`VaultException` ≠ `IllegalArgumentException`) → would drop flow batches when Vault is unreachable, the exact failure mode #160 fixed for env/file. Now wrapped; `VaultSecretResolverSpringTest` asserts the degrade path.
2. **Two public constructors, none `@Autowired`** → Spring couldn't instantiate the bean exactly when `vault.uri` is set (startup crash in production only). Fixed; the Spring context test would fail without it.

## Testing

- `mvn clean test` green — 8 fake-binary SOPS tests (no sops needed), 2 Spring wiring tests, all Phase 1 tests unchanged.
- `mvn -Pe2e verify -Dit.test=VaultSecretResolverIT` green locally — **real Vault 1.20 container**, KV v2 put/get through the resolver (3 tests, 14.6s).

## Note

A committed age-encrypted fixture (per #155) requires the `sops` binary to generate; neither the dev machine nor CI has it. The fake-binary tests cover our whole subprocess/parse/lookup path; the real-binary fixture test is deferred until sops lands in the toolchain — tracked in the issue.

Part of #153. Closes #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
