### PR TITLE
feat(pipeline): ExporterIdentity with observation-domain scoping

### DIFF
--- a/src/main/java/org/riptide/flows/parser/ParserBase.java
+++ b/src/main/java/org/riptide/flows/parser/ParserBase.java
@@ -146,7 +146,7 @@ public abstract class ParserBase implements Parser {
             final Runnable dispatch = () -> {
                 log.trace("Received flow: {}", flow);
 
-                this.dispatcher.accept(new Source(this.location, session.getRemoteAddress()), flow);
+                this.dispatcher.accept(new Source(this.location, session.getRemoteAddress(), packet.getObservationDomainId()), flow);
 
                 this.recordsDispatched.mark();
             };

--- a/src/main/java/org/riptide/flows/parser/netflow5/proto/Packet.java
+++ b/src/main/java/org/riptide/flows/parser/netflow5/proto/Packet.java
@@ -59,7 +59,8 @@ public final class Packet implements Iterable<Record>, FlowPacket {
 
     @Override
     public long getObservationDomainId() {
-        return ((long) this.header.engineType) << 8L + ((long) this.header.engineId);
+        // parenthesized: '+' binds tighter than '<<', which used to shift by (8 + engineId)
+        return (((long) this.header.engineType) << 8) + ((long) this.header.engineId);
     }
 
     @Override

--- a/src/main/java/org/riptide/pipeline/EnrichedFlow.java
+++ b/src/main/java/org/riptide/pipeline/EnrichedFlow.java
@@ -7,6 +7,7 @@ package org.riptide.pipeline;
 
 import lombok.Builder;
 import lombok.Data;
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.NullValueCheckStrategy;
@@ -93,6 +94,8 @@ public class EnrichedFlow {
 
         @Mapping(target = ".", source = "source")
         @Mapping(target = ".", source = "flow")
+        // used for node lookup only; not persisted on the flow (yet)
+        @BeanMapping(ignoreUnmappedSourceProperties = {"observationDomain"})
         public abstract EnrichedFlow enrichedFlow(Source source, Flow flow);
 
         protected String address(final InetAddress address) {

--- a/src/main/java/org/riptide/pipeline/ExporterIdentity.java
+++ b/src/main/java/org/riptide/pipeline/ExporterIdentity.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.pipeline;
+
+import java.net.InetAddress;
+
+/**
+ * Identifies the device a flow record came from. NetFlow v9 and IPFIX scope an exporter by
+ * source address plus a 32-bit observation domain (RFC 7011; called Source ID in NetFlow v9),
+ * so a single exporter IP can host several independent export streams. NetFlow v5 has no such
+ * concept — its engine type/ID are mapped onto the domain, {@code 0} when absent.
+ *
+ * <p>Sealed on purpose: sFlow identifies an agent by the in-payload agent address plus
+ * sub-agent ID, <em>not</em> the UDP source address. When sFlow support lands, it becomes a
+ * new variant here and the compiler surfaces every place that must handle it.</p>
+ */
+public sealed interface ExporterIdentity {
+
+    record NetflowIpfix(InetAddress source, long observationDomain) implements ExporterIdentity {
+    }
+}

--- a/src/main/java/org/riptide/pipeline/Source.java
+++ b/src/main/java/org/riptide/pipeline/Source.java
@@ -22,4 +22,15 @@ public class Source {
 
     @NonNull
     private final InetAddress exporterAddr;
+
+    /** Observation domain (IPFIX) / source ID (NetFlow v9); {@code 0} when the protocol has none. */
+    private final long observationDomain;
+
+    public Source(final String location, final InetAddress exporterAddr) {
+        this(location, exporterAddr, 0);
+    }
+
+    public ExporterIdentity identity() {
+        return new ExporterIdentity.NetflowIpfix(this.exporterAddr, this.observationDomain);
+    }
 }

--- a/src/main/java/org/riptide/snmp/SnmpConfiguration.java
+++ b/src/main/java/org/riptide/snmp/SnmpConfiguration.java
@@ -7,9 +7,9 @@ package org.riptide.snmp;
 
 import inet.ipaddr.IPAddressString;
 import lombok.Data;
+import org.riptide.pipeline.ExporterIdentity;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -19,17 +19,29 @@ import java.util.Optional;
 public class SnmpConfiguration {
     public List<SnmpDefinition> definitions = new ArrayList<>();
 
-    public Optional<SnmpEndpoint> lookup(final InetAddress host) {
-        return lookup(host.getHostAddress());
-    }
+    /**
+     * Selects the SNMP definition for an exporter. Definitions pinned to the flow's
+     * observation domain win over wildcard definitions (no {@code observation-domain});
+     * within each group the subnet match keeps the existing first-match order.
+     */
+    public Optional<SnmpEndpoint> lookup(final ExporterIdentity identity) {
+        // instanceof instead of an exhaustive switch pattern only because checkstyle 9.3
+        // cannot parse switch record patterns; new ExporterIdentity variants (sFlow, #159)
+        // must be handled here.
+        if (identity instanceof ExporterIdentity.NetflowIpfix netflowIpfix) {
+            final IPAddressString ipAddressString = new IPAddressString(netflowIpfix.source().getHostAddress());
+            final List<SnmpDefinition> subnetMatches = this.definitions.stream()
+                    .filter(definition -> definition.getSubnetAddress().contains(ipAddressString))
+                    .toList();
 
-    public Optional<SnmpEndpoint> lookup(final String host) {
-        final IPAddressString ipAddressString = new IPAddressString(host);
-        for (final SnmpDefinition snmpDefinition : this.definitions) {
-            if (snmpDefinition.getSubnetAddress().contains(ipAddressString)) {
-                return Optional.of(snmpDefinition.createEndpoint(ipAddressString));
-            }
+            return subnetMatches.stream()
+                    .filter(definition -> definition.getObservationDomain() != null && definition.getObservationDomain() == netflowIpfix.observationDomain())
+                    .findFirst()
+                    .or(() -> subnetMatches.stream()
+                            .filter(definition -> definition.getObservationDomain() == null)
+                            .findFirst())
+                    .map(definition -> definition.createEndpoint(ipAddressString));
         }
-        return Optional.empty();
+        throw new IllegalStateException("Unhandled exporter identity: " + identity);
     }
 }

--- a/src/main/java/org/riptide/snmp/SnmpDefinition.java
+++ b/src/main/java/org/riptide/snmp/SnmpDefinition.java
@@ -29,6 +29,9 @@ public class SnmpDefinition {
 
     private SnmpVersion snmpVersion;
 
+    /** Restricts this definition to one observation domain / source ID; {@code null} matches any. */
+    private Long observationDomain;
+
     private int timeout = 500;
 
     private int retries = 1;

--- a/src/main/java/org/riptide/snmp/SnmpEnricher.java
+++ b/src/main/java/org/riptide/snmp/SnmpEnricher.java
@@ -28,7 +28,7 @@ public class SnmpEnricher implements Enricher {
     @Override
     public CompletableFuture<Void> enrich(final Source source, final List<EnrichedFlow> flows) {
         return CompletableFuture.supplyAsync(() -> {
-            this.snmpConfiguration.lookup(source.getExporterAddr()).ifPresent(snmpEndpoint -> {
+            this.snmpConfiguration.lookup(source.identity()).ifPresent(snmpEndpoint -> {
                 for (final EnrichedFlow flow : flows) {
                     this.snmpService.getIfName(snmpEndpoint, flow.getInputSnmp()).ifPresent(flow::setInputSnmpIfName);
                     this.snmpService.getIfName(snmpEndpoint, flow.getOutputSnmp()).ifPresent(flow::setOutputSnmpIfName);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -44,6 +44,9 @@ riptide.snmp.cache.retentionMs=600000
 #riptide.snmp.config.definitions[0].port=161
 #riptide.snmp.config.definitions[0].snmp-version=v2c
 #riptide.snmp.config.definitions[0].community=env://RIPTIDE_SNMP_COMMUNITY
+# Optionally pin a definition to one observation domain (IPFIX) / source ID (NetFlow v9);
+# pinned definitions win over wildcard ones for the same subnet:
+#riptide.snmp.config.definitions[0].observation-domain=42
 
 # ENRICHER: HOSTNAMES
 riptide.enricher.hostnames.enabled=false

--- a/src/test/java/org/riptide/flows/netflow5/NetflowPacketTest.java
+++ b/src/test/java/org/riptide/flows/netflow5/NetflowPacketTest.java
@@ -89,6 +89,27 @@ public class NetflowPacketTest {
     }
 
     @Test
+    public void observationDomainIdCombinesEngineTypeAndEngineId() throws InvalidPacketException {
+        final ByteBuf buffer = Unpooled.buffer();
+        buffer.writeShort(0x0005);      // version
+        buffer.writeShort(1);           // count
+        buffer.writeInt(0);             // sysUptime
+        buffer.writeInt(0);             // unixSecs
+        buffer.writeInt(0);             // unixNSecs
+        buffer.writeInt(0);             // flowSequence
+        buffer.writeByte(1);            // engineType
+        buffer.writeByte(1);            // engineId
+        buffer.writeShort(0);           // sampling
+        buffer.writeZero(Record.SIZE);  // one empty record
+
+        final Header header = new Header(buffer);
+        final Packet packet = new Packet(header, buffer);
+
+        // (engineType << 8) + engineId — a precedence bug used to shift by (8 + engineId)
+        assertThat(packet.getObservationDomainId()).isEqualTo(257L);
+    }
+
+    @Test
     public void canReadInvalidNetflow5_01() throws InvalidPacketException {
         Assertions.assertThatThrownBy(() -> {
             execute("/flows/netflow5_test_invalid01.dat", flowPacket -> {

--- a/src/test/java/org/riptide/snmp/SnmpConfigurationTest.java
+++ b/src/test/java/org/riptide/snmp/SnmpConfigurationTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.snmp;
+
+import inet.ipaddr.IPAddressString;
+import org.junit.jupiter.api.Test;
+import org.riptide.pipeline.ExporterIdentity;
+import org.riptide.secrets.SecretRef;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SnmpConfigurationTest {
+
+    private static SnmpDefinition definition(final String subnet, final Long observationDomain, final String community) {
+        final SnmpDefinition definition = new SnmpDefinition();
+        definition.setSubnetAddress(new IPAddressString(subnet));
+        definition.setObservationDomain(observationDomain);
+        definition.setSnmpVersion(SnmpVersion.v2c);
+        definition.setCommunity(SecretRef.of(community));
+        return definition;
+    }
+
+    private static ExporterIdentity identity(final String host, final long observationDomain) throws UnknownHostException {
+        return new ExporterIdentity.NetflowIpfix(InetAddress.getByName(host), observationDomain);
+    }
+
+    private static String communityOf(final SnmpEndpoint endpoint) {
+        return endpoint.getSnmpDefinition().getCommunity().getValue();
+    }
+
+    @Test
+    public void observationDomainPinnedDefinitionWinsOverWildcard() throws Exception {
+        final SnmpConfiguration configuration = new SnmpConfiguration();
+        configuration.setDefinitions(List.of(
+                definition("10.0.0.0/24", null, "wildcard"),
+                definition("10.0.0.0/24", 42L, "pinned")));
+
+        assertThat(configuration.lookup(identity("10.0.0.1", 42))).map(SnmpConfigurationTest::communityOf).hasValue("pinned");
+        assertThat(configuration.lookup(identity("10.0.0.1", 7))).map(SnmpConfigurationTest::communityOf).hasValue("wildcard");
+    }
+
+    @Test
+    public void pinnedOnlyConfigurationDoesNotMatchOtherDomains() throws Exception {
+        final SnmpConfiguration configuration = new SnmpConfiguration();
+        configuration.setDefinitions(List.of(definition("10.0.0.0/24", 42L, "pinned")));
+
+        assertThat(configuration.lookup(identity("10.0.0.1", 42))).isPresent();
+        assertThat(configuration.lookup(identity("10.0.0.1", 7))).isEmpty();
+    }
+
+    @Test
+    public void subnetMissYieldsEmpty() throws Exception {
+        final SnmpConfiguration configuration = new SnmpConfiguration();
+        configuration.setDefinitions(List.of(definition("10.0.0.0/24", null, "wildcard")));
+
+        assertThat(configuration.lookup(identity("192.168.1.1", 0))).isEmpty();
+    }
+
+    @Test
+    public void firstSubnetMatchOrderIsKeptWithinAGroup() throws Exception {
+        final SnmpConfiguration configuration = new SnmpConfiguration();
+        configuration.setDefinitions(List.of(
+                definition("10.0.0.0/16", null, "first"),
+                definition("10.0.0.0/24", null, "second")));
+
+        assertThat(configuration.lookup(identity("10.0.0.1", 0))).map(SnmpConfigurationTest::communityOf).hasValue("first");
+    }
+}


### PR DESCRIPTION
## Summary

Phase 3 of the lightweight node model epic (#153): the **`ExporterIdentity`** abstraction — flows now resolve to their SNMP definition by **(source IP, observation domain)**, not source IP alone.

- **`ExporterIdentity`** — sealed interface, `NetflowIpfix(source, observationDomain)` variant (RFC 7011 observation domain / NetFlow v9 source ID / v5 engine type+ID). Sealed deliberately: the future sFlow `(agent_address, sub_agent_id)` variant (#159) will surface every match site at compile time.
- **`Source`** gains the observation domain — every parser already decoded it (`FlowPacket.getObservationDomainId()` fed sequence tracking); it just never reached `Source`. One-line plumbing in `ParserBase`.
- **`SnmpConfiguration.lookup(ExporterIdentity)`** — definitions may pin `observation-domain`; pinned beats wildcard for the same subnet; subnet stays the coarse fallback with first-match order preserved. MapStruct explicitly ignores the new Source property (not persisted — schema untouched until Phase 5).

## Review (medium, self) — 1 finding, fixed

**Pre-existing NetFlow v5 precedence bug promoted by this change:** `getObservationDomainId()` computed `engineType << (8 + engineId)` (`+` binds tighter than `<<`), i.e. garbage whenever `engineId ≠ 0`. Previously it only mis-scoped sequence tracking; with this PR it would have fed node matching. Fixed to `(engineType << 8) + engineId`, locked with a synthetic-packet regression test (asserts 257, old code produced 512).

Also verified: `Long == long` unboxes (no reference-equality trap); removed `lookup(InetAddress/String)` had a single caller (`SnmpEnricher`, updated); checkstyle 9.3 can't parse switch record patterns, so the lookup uses an `instanceof` binding with a comment pointing future variants at the match site.

## Testing

`mvn clean test` green — new `SnmpConfigurationTest` (pinned-beats-wildcard, pinned-only isolation, subnet miss, first-match order) + v5 regression test; all existing suites (blackbox parsers, enrichers, secrets) unchanged and passing.

Part of #153. Closes #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
