### PR TITLE
ci: add npm ecosystem to Dependabot for the docs site

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,17 @@ updates:
       include: "scope"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "npm" # Docusaurus documentation site
+    directory: "/docs"
+    target-branch: "main"
+    labels:
+      - "dependency update"
+    commit-message:
+      prefix: "build"
+      include: "scope"
+    schedule:
+      interval: "weekly"
+    groups:
+      docusaurus:
+        patterns:
+          - "@docusaurus/*"


### PR DESCRIPTION
Adds a weekly `npm` Dependabot entry for `/docs` (Docusaurus site from #167), mirroring the Maven entry's labels/commit-message conventions. `@docusaurus/*` packages are grouped into a single PR since they must be upgraded in lock-step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)