### PR TITLE
build(deps): bump caffeine, dnsjava, guava, ipaddress, annotations, snmp4j

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,11 @@ updates:
       include: "scope"
     schedule:
       interval: "weekly"
+    ignore:
+      # Testcontainers 2.x is a module/API migration (see the migration issue);
+      # majors are ignored until it lands.
+      - dependency-name: "org.testcontainers:*"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "npm" # Docusaurus documentation site
     directory: "/docs"
     target-branch: "main"
@@ -29,3 +34,8 @@ updates:
       docusaurus:
         patterns:
           - "@docusaurus/*"
+    ignore:
+      # TS 7 removed baseUrl, which @docusaurus/tsconfig still sets; blocked
+      # until the Docusaurus toolchain supports TypeScript 7 (see PR #171).
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]

--- a/pom.xml
+++ b/pom.xml
@@ -17,14 +17,14 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <caffeine.version>3.2.3</caffeine.version>
+        <caffeine.version>3.2.4</caffeine.version>
         <common-csv.version>1.14.1</common-csv.version>
-        <dnsjava.version>3.6.4</dnsjava.version>
-        <guava.version>33.5.0-jre</guava.version>
-        <ipaddress.version>5.6.1</ipaddress.version>
+        <dnsjava.version>3.6.5</dnsjava.version>
+        <guava.version>33.6.0-jre</guava.version>
+        <ipaddress.version>5.6.2</ipaddress.version>
         <jakarta-xml-bind-api.version>4.0.5</jakarta-xml-bind-api.version>
         <java.version>25</java.version>
-        <jetbrains-annotations.version>26.0.2</jetbrains-annotations.version>
+        <jetbrains-annotations.version>26.1.0</jetbrains-annotations.version>
         <lombok.version>1.18.46</lombok.version>
         <mapstruct.version>1.6.3</mapstruct.version>
         <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
@@ -33,8 +33,8 @@
         <netty-all.version>4.2.10.Final</netty-all.version>
         <org-eclipse-persistence-moxy.version>4.0.9</org-eclipse-persistence-moxy.version>
         <resilience4j.version>2.4.0</resilience4j.version>
-        <snmp4j.version>3.9.7</snmp4j.version>
-        <snmp4j-agent.version>3.8.3</snmp4j-agent.version>
+        <snmp4j.version>3.12.2</snmp4j.version>
+        <snmp4j-agent.version>3.9.1</snmp4j-agent.version>
         <spring-vault.version>4.1.0</spring-vault.version>
         <dropwizard-metrics.version>4.2.38</dropwizard-metrics.version>
         <jquick.version>1.10.1</jquick.version>

--- a/src/main/java/org/riptide/snmp/SnmpVersion.java
+++ b/src/main/java/org/riptide/snmp/SnmpVersion.java
@@ -22,6 +22,9 @@ enum SnmpVersion {
         @Override
         SnmpBuilder getSnmpBuilder() throws IOException {
             return new SnmpBuilder()
+                    // SNMP4J 3.10+ forbids reusing the builder after build() without this;
+                    // getTarget() configures the target on the built builder (see SnmpUtils)
+                    .allowIncrementalConfigAfterBuild()
                     .securityProtocols(SecurityProtocols.SecurityProtocolSet.maxCompatibility)
                     .udp()
                     .v1()
@@ -44,6 +47,9 @@ enum SnmpVersion {
         @Override
         SnmpBuilder getSnmpBuilder() throws IOException {
             return new SnmpBuilder()
+                    // SNMP4J 3.10+ forbids reusing the builder after build() without this;
+                    // getTarget() configures the target on the built builder (see SnmpUtils)
+                    .allowIncrementalConfigAfterBuild()
                     .securityProtocols(SecurityProtocols.SecurityProtocolSet.maxCompatibility)
                     .udp()
                     .v2c()
@@ -66,6 +72,9 @@ enum SnmpVersion {
         @Override
         SnmpBuilder getSnmpBuilder() throws IOException {
             return new SnmpBuilder()
+                    // SNMP4J 3.10+ forbids reusing the builder after build() without this;
+                    // getTarget() configures the target on the built builder (see SnmpUtils)
+                    .allowIncrementalConfigAfterBuild()
                     .securityProtocols(SecurityProtocols.SecurityProtocolSet.maxCompatibility)
                     .udp()
                     .v3()


### PR DESCRIPTION
Batch of the remaining **safe same-major** updates from `versions:display-property-updates` (complementing Dependabot's #169/#172/#173/#174):

| Property | From | To |
|---|---|---|
| caffeine | 3.2.3 | 3.2.4 |
| dnsjava | 3.6.4 | 3.6.5 |
| guava | 33.5.0-jre | 33.6.0-jre |
| ipaddress | 5.6.1 | 5.6.2 |
| jetbrains-annotations | 26.0.2 | 26.1.0 |
| **snmp4j** | 3.9.7 | **3.12.2** |
| snmp4j-agent | 3.8.3 | 3.9.1 |

**SNMP4J 3.10 behavior change handled:** the fluent `SnmpBuilder` may no longer be reconfigured after `build()` — our `getTarget()` does exactly that, so the builders now call `allowIncrementalConfigAfterBuild()` (the migration path the 3.10 exception message names). `SnmpTest` (v1/v2c/v3 against the real snmp4j-agent) covers the bump.

**Skipped deliberately (pre-release/major):** clickhouse 0.10.0-rc1 · jakarta.xml.bind-api 4.1.0-M1 · mapstruct 1.7.0.Beta2 · maven-compiler-plugin 4.0.0-beta-4 · netty 5.0.0.Alpha2 (abandoned alpha line) · moxy 5.x. Testcontainers 2.x (#170) and TypeScript 7 (#171) get separate evaluation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)