### PR TITLE
build(deps)!: migrate to Testcontainers 2.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,11 +15,6 @@ updates:
       include: "scope"
     schedule:
       interval: "weekly"
-    ignore:
-      # Testcontainers 2.x is a module/API migration (see the migration issue);
-      # majors are ignored until it lands.
-      - dependency-name: "org.testcontainers:*"
-        update-types: ["version-update:semver-major"]
   - package-ecosystem: "npm" # Docusaurus documentation site
     directory: "/docs"
     target-branch: "main"

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <clickhouse.version>0.9.8</clickhouse.version>
         <jmh.version>1.37</jmh.version>
         <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
-        <testcontainers.version>1.21.4</testcontainers.version>
+        <testcontainers.version>2.0.5</testcontainers.version>
     </properties>
 
     <dependencyManagement>
@@ -199,12 +199,12 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>vault</artifactId>
+            <artifactId>testcontainers-vault</artifactId>
             <scope>test</scope>
         </dependency>
             <dependency>
@@ -331,13 +331,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <systemPropertyVariables>
-                                <!-- docker-java defaults to Docker API 1.32, which modern
-                                     daemons (e.g. OrbStack) reject; 1.44 = Docker 25+ (2024). -->
-                                <api.version>1.44</api.version>
-                            </systemPropertyVariables>
-                        </configuration>
                         <executions>
                             <execution>
                                 <goals>


### PR DESCRIPTION
Migrates `testcontainers-bom` 1.21.4 → **2.0.5** (#176, previously declined as a blind bump in #170).

## What changed
- Artifact renames only: `junit-jupiter` → `testcontainers-junit-jupiter`, `vault` → `testcontainers-vault` (core keeps its name — confirmed against the 2.0.5 BOM's managed artifacts).
- **Zero source changes**: `GenericContainer`, wait strategies, the JUnit 5 annotations, and `VaultContainer` keep their packages; the 2.x relocations only hit module container classes we don't use.
- **Removed the `api.version=1.44` failsafe workaround** — TC2's docker-java negotiates the API version; verified against OrbStack, the exact daemon the workaround was added for (#176 scope item).
- Dropped the now-obsolete Dependabot major-ignore for `org.testcontainers:*`.

## Verification
- Local (macOS/OrbStack): `Nl6FlowIngestionIT` (3/3 incl. the custom nl6 container's NET_ADMIN/SYS_ADMIN/tun requests), `VaultSecretResolverIT` (3/3), `ClickhouseRepositoryIT` — green on 2.0.5, re-run green after removing the workaround.
- **CI e2e is the decisive check** for the Linux-only full-mode path (per-device exporters + SNMP walk-back with seccomp-unconfined) — not runnable on macOS.

Closes #176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)