### PR TITLE
docs: remove duplicate navbar title

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -54,7 +54,7 @@ const config: Config = {
 
   themeConfig: {
     navbar: {
-      title: 'Riptide',
+      // no text title — the logo already carries the "Riptide" wordmark
       logo: {
         alt: 'Riptide logo',
         src: 'img/riptide-logo.png',


### PR DESCRIPTION
The pixel-art logo already says "Riptide" — the navbar's text title rendered it twice, side by side.

- Removes `navbar.title` only; the root `title` (browser tab / `| Riptide` page suffix / SEO) and the logo `alt` text (screen readers) are untouched.
- Verified with `make docs`: build green, no `navbar__title` text in the output, tab title still `Overview | Riptide`.

Bonus assertion for the new rc pipeline: this PR is docs-only, so `Publish RC` should **skip** on merge (`paths-ignore: docs/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)