### PR TITLE
build(deps): remove unused jqwik dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,6 @@
         <snmp4j-agent.version>3.9.1</snmp4j-agent.version>
         <spring-vault.version>4.1.0</spring-vault.version>
         <dropwizard-metrics.version>4.2.39</dropwizard-metrics.version>
-        <jquick.version>1.10.1</jquick.version>
         <clickhouse.version>0.9.8</clickhouse.version>
         <jmh.version>1.37</jmh.version>
         <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
@@ -205,12 +204,6 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers-vault</artifactId>
-            <scope>test</scope>
-        </dependency>
-            <dependency>
-            <groupId>net.jqwik</groupId>
-            <artifactId>jqwik</artifactId>
-            <version>${jquick.version}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
jqwik ≥1.10 deliberately prints an anti-AI prompt-injection clause into every test run ([maintainer's write-up](https://blog.johanneslink.net/2026/06/09/the-jqwik-anti-ai-affair/), [LWN](https://lwn.net/Articles/1075317/)) — 1.10.1 landed here via #173 and the clause immediately showed up in build output (it targets exactly the AI-assisted log processing this repo uses).

Independent justification: **the dependency is unused** — zero test sources import it (established during #158 scoping; its property tests were deferred to #159). Removing it deletes an unused dep, silences the injection, and honors the maintainer's stated wish.

Also removes the tracked `.jqwik-database` state file.

**Verified:** 556 tests green, `grep` for the clause in build output: 0 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)