### PR TITLE
ci: add coverage floor and CodeQL analysis as PR gates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: CodeQL
+run-name: CodeQL security and quality analysis
+on:
+  workflow_dispatch:
+  push:
+    branches: [ 'main' ]
+    paths-ignore: [ 'docs/**' ]
+  pull_request:
+    branches: [ 'main' ]
+    paths-ignore: [ 'docs/**' ]
+  schedule:
+    - cron: '31 5 * * 1' # weekly, Monday morning
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - name: Set up JDK 25 for x64
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          architecture: x64
+          cache: maven
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@f58f0d11ebf5dedd870fab2f999275f7602cfa46 # codeql-bundle-v2.26.0
+        with:
+          languages: java-kotlin
+          build-mode: none
+          queries: security-and-quality
+      - name: Analyze
+        uses: github/codeql-action/analyze@f58f0d11ebf5dedd870fab2f999275f7602cfa46 # codeql-bundle-v2.26.0
+        with:
+          category: '/language:java-kotlin'

--- a/pom.xml
+++ b/pom.xml
@@ -310,6 +310,34 @@
                             <goal>report</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <!-- floors just below the unit-only baseline
+                                             (66.6% instruction / 57.3% branch, 2026-07-12)
+                                             so coverage cannot silently regress -->
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.65</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.55</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>


### PR DESCRIPTION
First slice of the code-quality PR gates (SpotBugs and Error Prone follow separately):

- **Coverage floor**: `jacoco:check` bound to `verify` — builds fail below **65% instruction / 55% branch** (unit-only baseline today: 66.6% / 57.3%, so ~1.5–2pt headroom). Verified locally: `mvn verify` → *All coverage checks have been met*.
- **CodeQL**: `security-and-quality` query suite, `build-mode: none` (buildless Java scanning — no duplicated `make` in the PR path), on PRs + main + weekly cron. SHA-pinned to `codeql-bundle-v2.26.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)