### PR TITLE
ci: add SpotBugs as a PR gate; fix the findings it caught

### DIFF
--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ SPDX-License-Identifier: GPL-3.0-or-later
+-->
+<FindBugsFilter>
+    <!-- MapStruct-generated mapper implementations -->
+    <Match>
+        <Class name="~.*MapperImpl.*"/>
+    </Match>
+
+    <!-- Guards against finalizer attacks on partially-constructed objects; finalization is
+         deprecated for removal since Java 18 and this codebase's parser constructors throw
+         InvalidPacketException by design (66 findings, all of this shape). -->
+    <Match>
+        <Bug pattern="CT_CONSTRUCTOR_THROW"/>
+    </Match>
+
+    <!-- Lombok @Data-style config/value classes intentionally expose mutable fields via
+         generated accessors; internal objects, not API surface. -->
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
+    </Match>
+
+    <!-- Baseline (pre-existing, deliberate):
+         Classifier is sorted by rule position; identity equality is intended and instances
+         are never used as map/set keys mixed with compareTo semantics. -->
+    <Match>
+        <Class name="org.riptide.classification.internal.decision.Classifier"/>
+        <Bug pattern="EQ_COMPARETO_USE_OBJECT_EQUALS"/>
+    </Match>
+
+    <!-- Baseline (pre-existing, deliberate):
+         Tree.EMPTY references subclass Leaf during static init. The Tree/Leaf class pair is
+         always initialized on the same thread (Spring context startup); restructuring the
+         classification tree API is out of scope for gate introduction. -->
+    <Match>
+        <Class name="org.riptide.classification.internal.decision.Tree"/>
+        <Bug pattern="IC_SUPERCLASS_USES_SUBCLASS_DURING_INITIALIZATION"/>
+    </Match>
+</FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <org-eclipse-persistence-moxy.version>5.0.1</org-eclipse-persistence-moxy.version>
         <resilience4j.version>2.4.0</resilience4j.version>
         <snmp4j.version>3.12.2</snmp4j.version>
+        <spotbugs-maven-plugin.version>4.10.2.0</spotbugs-maven-plugin.version>
         <snmp4j-agent.version>3.9.1</snmp4j-agent.version>
         <spring-vault.version>4.1.0</spring-vault.version>
         <dropwizard-metrics.version>4.2.39</dropwizard-metrics.version>
@@ -281,6 +282,23 @@
                     <execution>
                         <id>validate</id>
                         <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>${spotbugs-maven-plugin.version}</version>
+                <configuration>
+                    <effort>Max</effort>
+                    <excludeFilterFile>config/spotbugs-exclude.xml</excludeFilterFile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>check</id>
                         <goals>
                             <goal>check</goal>
                         </goals>

--- a/src/main/java/org/riptide/classification/internal/csv/CsvImporter.java
+++ b/src/main/java/org/riptide/classification/internal/csv/CsvImporter.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Objects;
 
 public final class CsvImporter {
-    public static final String[] HEADERS = {"name", "protocol", "srcAddress", "srcPort", "dstAddress", "dstPort", "exporterFilter", "omnidirectional"};
+    private static final String[] HEADERS = {"name", "protocol", "srcAddress", "srcPort", "dstAddress", "dstPort", "exporterFilter", "omnidirectional"};
 
     public List<Rule> parse(final InputStream inputStream, final boolean hasHeader) throws IOException {
         Objects.requireNonNull(inputStream);

--- a/src/main/java/org/riptide/classification/internal/decision/Bound.java
+++ b/src/main/java/org/riptide/classification/internal/decision/Bound.java
@@ -132,7 +132,7 @@ public abstract class Bound<T extends Comparable<T>> {
 
         @Override
         public boolean includes(final T value) {
-            return value.compareTo(value) == 0;
+            return value.compareTo(this.value) == 0;
         }
 
         @Override

--- a/src/main/java/org/riptide/classification/internal/decision/Bounds.java
+++ b/src/main/java/org/riptide/classification/internal/decision/Bounds.java
@@ -14,7 +14,7 @@ import org.riptide.classification.IpAddr;
  */
 public class Bounds {
 
-    public static Bounds ANY = new Bounds(Bound.any(), Bound.any(), Bound.any(), Bound.any(), Bound.any());
+    public static final Bounds ANY = new Bounds(Bound.any(), Bound.any(), Bound.any(), Bound.any(), Bound.any());
 
     public final Bound<Integer> protocol;
     public final Bound<Integer> srcPort, dstPort;

--- a/src/main/java/org/riptide/classification/internal/decision/Tree.java
+++ b/src/main/java/org/riptide/classification/internal/decision/Tree.java
@@ -111,10 +111,10 @@ public abstract class Tree {
     @ToString
     public static class Info {
 
-        public static Info FOR_LEAVE_WITH_0_RULES = new Info(0);
-        public static Info FOR_LEAVE_WITH_1_RULE = new Info(1);
-        public static Info FOR_LEAVE_WITH_2_RULES = new Info(2);
-        public static Info FOR_LEAVE_WITH_3_RULES = new Info(3);
+        public static final Info FOR_LEAVE_WITH_0_RULES = new Info(0);
+        public static final Info FOR_LEAVE_WITH_1_RULE = new Info(1);
+        public static final Info FOR_LEAVE_WITH_2_RULES = new Info(2);
+        public static final Info FOR_LEAVE_WITH_3_RULES = new Info(3);
 
         public static Info forLeaf(int ruleSetSize) {
             switch (ruleSetSize) {

--- a/src/main/java/org/riptide/config/ClickhouseConfig.java
+++ b/src/main/java/org/riptide/config/ClickhouseConfig.java
@@ -11,10 +11,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Data
 @ConfigurationProperties(prefix = "riptide.clickhouse")
 public final class ClickhouseConfig {
-        public String endpoint = "http://localhost:8123";
+        private String endpoint = "http://localhost:8123";
 
-        public String username;
-        public String password;
+        private String username;
+        private String password;
 
-        public String database = "riptide";
+        private String database = "riptide";
 }

--- a/src/main/java/org/riptide/dns/netty/NettyDnsResolver.java
+++ b/src/main/java/org/riptide/dns/netty/NettyDnsResolver.java
@@ -88,7 +88,7 @@ public class NettyDnsResolver implements DnsResolver, DisposableBean {
     static class RoundRobinIterator<T> implements Iterator<T> {
         private final List<T> delegate;
         private int currentIndex = 0;
-        private boolean cleared = false;
+        private volatile boolean cleared = false;
 
         RoundRobinIterator(List<T> list) {
             this.delegate = new CopyOnWriteArrayList<>(list);

--- a/src/main/java/org/riptide/flows/parser/exceptions/InvalidPacketException.java
+++ b/src/main/java/org/riptide/flows/parser/exceptions/InvalidPacketException.java
@@ -27,6 +27,6 @@ public class InvalidPacketException extends Exception {
         // Compute the offset for which this exception had occurred
         final int offset = buffer.readerIndex() + delta;
 
-        return String.format("%s, Offset: [0x%04X], Payload:\n%s", message, offset, ByteBufUtil.prettyHexDump(unwrappedBuffer));
+        return String.format("%s, Offset: [0x%04X], Payload:%n%s", message, offset, ByteBufUtil.prettyHexDump(unwrappedBuffer));
     }
 }

--- a/src/main/java/org/riptide/flows/parser/ipfix/InformationElementProvider.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/InformationElementProvider.java
@@ -116,7 +116,7 @@ class Registry {
     private String id;
 
     @XmlElement(namespace = NAMESPACE, required = true)
-    public String title;
+    private String title;
 
     @XmlElement(namespace = NAMESPACE, required = true)
     private LocalDate created;

--- a/src/main/java/org/riptide/flows/parser/netflow5/proto/Record.java
+++ b/src/main/java/org/riptide/flows/parser/netflow5/proto/Record.java
@@ -87,7 +87,7 @@ public class Record {
         this.srcPort = uint16(buffer);
         this.dstPort = uint16(buffer);
 
-        final int padding1 = uint8(buffer);
+        uint8(buffer); // padding1 is skipped
 
         this.tcpFlags = uint8(buffer);
 

--- a/src/main/java/org/riptide/flows/parser/session/TcpSession.java
+++ b/src/main/java/org/riptide/flows/parser/session/TcpSession.java
@@ -89,7 +89,7 @@ public class TcpSession implements Session {
         @Override
         public boolean equals(final Object o) {
             if (this == o) return true;
-            if (o.getClass() != TemplateKey.class) return false;
+            if (o == null || o.getClass() != TemplateKey.class) return false;
 
             final TemplateKey that = (TemplateKey) o;
             return this.observationDomainId == that.observationDomainId

--- a/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
+++ b/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
@@ -42,10 +42,10 @@ public class ClickhouseRepository implements FlowRepository {
         this.flowMapper = Objects.requireNonNull(flowMapper);
 
         this.client = new Client.Builder()
-                .addEndpoint(config.endpoint)
-                .setUsername(config.username)
-                .setPassword(config.password)
-                .setDefaultDatabase(config.database)
+                .addEndpoint(config.getEndpoint())
+                .setUsername(config.getUsername())
+                .setPassword(config.getPassword())
+                .setDefaultDatabase(config.getDatabase())
                 .compressClientRequest(true)
                 .compressServerResponse(true)
                 .build();

--- a/src/main/java/org/riptide/secrets/VaultSecretResolver.java
+++ b/src/main/java/org/riptide/secrets/VaultSecretResolver.java
@@ -76,10 +76,11 @@ public class VaultSecretResolver implements SecretResolver {
             // contract of IllegalArgumentException so enrichment degrades instead of failing
             throw new IllegalArgumentException("Cannot resolve secret ref " + ref + " from Vault: " + e.getMessage(), e);
         }
-        if (response == null || response.getData() == null) {
+        final java.util.Map<String, Object> data = response != null ? response.getData() : null;
+        if (data == null) {
             throw new IllegalArgumentException("No secret found for ref " + ref);
         }
-        final Object value = response.getData().get(ref.getKey());
+        final Object value = data.get(ref.getKey());
         if (value == null) {
             throw new IllegalArgumentException("Key '" + ref.getKey() + "' not found for secret ref " + ref);
         }

--- a/src/test/java/org/riptide/repository/clickhouse/ClickhouseRepositoryIT.java
+++ b/src/test/java/org/riptide/repository/clickhouse/ClickhouseRepositoryIT.java
@@ -43,18 +43,18 @@ public class ClickhouseRepositoryIT {
     @BeforeAll
     static void setUp() {
         final var config = new ClickhouseConfig();
-        config.endpoint = "http://" + CLICKHOUSE.getHost() + ":" + CLICKHOUSE.getMappedPort(8123);
-        config.username = "riptide";
-        config.password = "riptide";
+        config.setEndpoint("http://" + CLICKHOUSE.getHost() + ":" + CLICKHOUSE.getMappedPort(8123));
+        config.setUsername("riptide");
+        config.setPassword("riptide");
 
         repository = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), config);
         repository.start();
 
         queryClient = new Client.Builder()
-                .addEndpoint(config.endpoint)
-                .setUsername(config.username)
-                .setPassword(config.password)
-                .setDefaultDatabase(config.database)
+                .addEndpoint(config.getEndpoint())
+                .setUsername(config.getUsername())
+                .setPassword(config.getPassword())
+                .setDefaultDatabase(config.getDatabase())
                 .build();
     }
 


### PR DESCRIPTION
Second slice of the quality gates: **SpotBugs 4.10.2** (`effort=Max`, `check` at verify → gates every PR via `make`).

## Triage of the initial 109 findings
- **89 excluded with written rationale** (`config/spotbugs-exclude.xml`): `CT_CONSTRUCTOR_THROW` ×66 (finalizer-attack guard; finalization is deprecated-for-removal and the flow parsers throw from constructors by design), `EI_EXPOSE_REP/2` ×23 (Lombok `@Data` value objects).
- **2 documented per-class baselines**: `Classifier` compareTo-without-equals (identity equality intended), `Tree.EMPTY` subclass-during-init (single-threaded Spring startup).
- **The rest were real — fixed:**
  - 🐛 **`Bound.Eq#includes` compared the parameter with itself** (`value.compareTo(value)`) — an equality bound in the classification decision tree accepted *every* value. Now compares against the bound. Classification suite green.
  - Cross-thread write to non-volatile `cleared` in `NettyDnsResolver`; `TemplateKey#equals(null)` NPE; `VaultSecretResolver` re-fetched `getData()` after null-checking a different invocation; plus encapsulation/final/dead-store/format-string cleanups (see commit).

**Verified:** `mvn verify` green — 556 tests, SpotBugs clean, coverage floor met.

Error Prone follows as the final slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)