### PR TITLE
docs: split Getting Started into operator and developer tracks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing to Riptide
+
+Thanks for considering a contribution! 🌊
+
+The contributor guide lives in the documentation:
+
+**https://riptide-labs.github.io/riptide/develop/environment**
+
+In short:
+
+- [Environment](https://riptide-labs.github.io/riptide/develop/environment) — clone, `make`, IDE setup
+- [Run & debug](https://riptide-labs.github.io/riptide/develop/run-and-debug) — local stack, pcap replay, nl6
+- [Testing](https://riptide-labs.github.io/riptide/develop/testing) — unit / e2e / full-mode tiers
+- [Pull requests](https://riptide-labs.github.io/riptide/develop/pull-requests) — CI quality gates,
+  **DCO sign-off (`git commit -s`)**, Conventional Commits
+
+Riptide is licensed [GPL-3.0-or-later](LICENSE).

--- a/deployment/riptide/compose.override.dev.yml
+++ b/deployment/riptide/compose.override.dev.yml
@@ -1,0 +1,9 @@
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Developer override: run the locally built image (`make oci`) instead of the
+# published one:  docker compose -f compose.yml -f compose.override.dev.yml up
+---
+services:
+  riptide:
+    image: riptide:local

--- a/deployment/riptide/compose.override.rc.yml
+++ b/deployment/riptide/compose.override.rc.yml
@@ -1,0 +1,9 @@
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Track main: run the floating rc image (rebuilt on every merge to main):
+#   docker compose -f compose.yml -f compose.override.rc.yml up
+---
+services:
+  riptide:
+    image: ghcr.io/riptide-labs/riptide:rc

--- a/deployment/riptide/compose.yml
+++ b/deployment/riptide/compose.yml
@@ -4,7 +4,7 @@ include:
 
 services:
   riptide:
-    image: riptide:local
+    image: ghcr.io/riptide-labs/riptide:latest
     depends_on:
       clickhouse:
         condition: service_healthy

--- a/docs/docs/configuration/_category_.json
+++ b/docs/docs/configuration/_category_.json
@@ -1,5 +1,5 @@
 {
   "label": "Configuration",
-  "position": 3,
+  "position": 5,
   "collapsed": false
 }

--- a/docs/docs/deploy/_category_.json
+++ b/docs/docs/deploy/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Deploy Riptide",
+  "position": 3,
+  "collapsed": false
+}

--- a/docs/docs/deploy/docker-compose.md
+++ b/docs/docs/deploy/docker-compose.md
@@ -1,0 +1,43 @@
+---
+sidebar_position: 1
+title: Docker Compose
+---
+
+# Deploy with Docker Compose
+
+The fastest way to run Riptide: a compose stack with Riptide, ClickHouse, a ClickHouse
+web UI, and Grafana — using the published image, no build toolchain required.
+
+```bash
+git clone https://github.com/Riptide-Labs/riptide.git   # or copy deployment/ only
+cd riptide/deployment/riptide
+docker compose up -d
+```
+
+This starts, from `ghcr.io/riptide-labs/riptide:latest`:
+
+| Service | Port | Purpose |
+|---|---|---|
+| riptide | `9999/udp` | flow ingest (configure your exporters to send here) |
+| clickhouse | `8123`, `9000` | flow storage |
+| ch-ui | [`:5521`](http://localhost:5521) | browse the `riptide.flows` table |
+| grafana | [`:3000`](http://localhost:3000) | dashboards (ClickHouse datasource provisioned) |
+
+Point a NetFlow v5/v9 or IPFIX exporter at UDP `9999` and watch rows arrive in
+`riptide.flows` via ch-ui. Configure [receivers](../configuration/receivers.md) and
+[nodes](../configuration/nodes-and-snmp.md) through environment variables in the compose
+file (see [Plain JAR](plain-jar.md#environment-variables) for the `RIPTIDE_*` scheme) or
+an external config file.
+
+## Variants
+
+```bash
+# Track main (floating rc image, rebuilt on every merge — not for production):
+docker compose -f compose.yml -f compose.override.rc.yml up -d
+
+# Run a locally built image (after `make oci`):
+docker compose -f compose.yml -f compose.override.dev.yml up -d
+```
+
+A plain `compose.override.yml` is gitignored on purpose — that's your personal,
+auto-loaded slot for local tweaks (timezone, extra ports, …).

--- a/docs/docs/deploy/operations.md
+++ b/docs/docs/deploy/operations.md
@@ -1,0 +1,38 @@
+---
+sidebar_position: 3
+title: Operations
+---
+
+# Operations notes
+
+## Image tags
+
+| Tag | Meaning | Use for |
+|---|---|---|
+| `:<version>` | immutable release | production (pin this) |
+| `:latest` | newest release | quickstarts |
+| `:rc` | floating, rebuilt on **every merge to main** | tracking development — at your own risk |
+
+## Restarts and data
+
+:::warning
+
+Riptide issues `CREATE OR REPLACE TABLE` for its `flows` table at startup — **flow data
+does not survive a Riptide restart** in the current design. Plan retention accordingly
+(e.g. export/aggregate downstream) until schema migration lands.
+
+:::
+
+## Upgrading
+
+Compose: `docker compose pull && docker compose up -d`. Plain JAR: replace the jar,
+restart. Configuration is backward-compatible within a minor line; breaking configuration
+moves are logged loudly at startup (e.g. the pre-0.1.0 `riptide.snmp.config.definitions`
+tree logs an explicit error pointing at `riptide.nodes`).
+
+## Ports
+
+| Port | Protocol | What |
+|---|---|---|
+| `9999/udp` | NetFlow/IPFIX | default flow ingest (container `EXPOSE`; receivers are configurable) |
+| `8123` | HTTP | ClickHouse (stack-internal unless you expose it) |

--- a/docs/docs/deploy/plain-jar.md
+++ b/docs/docs/deploy/plain-jar.md
@@ -1,0 +1,56 @@
+---
+sidebar_position: 2
+title: Plain JAR
+---
+
+# Deploy as a plain JAR
+
+Riptide is a single Spring Boot jar. Requirements: **Java 25** and a reachable ClickHouse.
+
+Download the jar from a [GitHub release](https://github.com/Riptide-Labs/riptide/releases)
+and run it:
+
+```bash
+java -jar riptide-flows-<version>.jar
+```
+
+## Configuration file
+
+Riptide loads an optional external configuration file:
+
+```
+/etc/riptide/config.yaml
+```
+
+Everything from the [configuration chapters](../configuration/receivers.md) goes there —
+receivers, nodes & SNMP, secret references, ClickHouse:
+
+```yaml
+riptide:
+  clickhouse:
+    endpoint: http://clickhouse.example.com:8123
+    database: riptide
+  receivers:
+    ipfix:
+      type: ipfix
+      host: 0.0.0.0
+      port: 4739
+```
+
+## Environment variables
+
+Every `riptide.*` property can also be set as an environment variable (Spring relaxed
+binding): uppercase, dots and dashes become underscores, list indexes become `_0_`:
+
+| Property | Environment variable |
+|---|---|
+| `riptide.clickhouse.endpoint` | `RIPTIDE_CLICKHOUSE_ENDPOINT` |
+| `riptide.receivers.ipfix.port` | `RIPTIDE_RECEIVERS_IPFIX_PORT` |
+| `riptide.nodes[0].subnet-address` | `RIPTIDE_NODES_0_SUBNETADDRESS` |
+| `riptide.nodes[0].snmp.community` | `RIPTIDE_NODES_0_SNMP_COMMUNITY` |
+
+Environment variables suit flat settings and containerized deployments (the compose stack
+configures ClickHouse this way); prefer the config file for larger node lists.
+
+Secret references (`env://`, `file://`, `vault://`, `sops://`) work the same in both —
+see [Secret references](../configuration/secret-references.md).

--- a/docs/docs/develop/_category_.json
+++ b/docs/docs/develop/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Develop & Contribute",
+  "position": 4,
+  "collapsed": false
+}

--- a/docs/docs/develop/environment.md
+++ b/docs/docs/develop/environment.md
@@ -1,0 +1,31 @@
+---
+sidebar_position: 1
+title: Environment
+---
+
+# Development environment
+
+**Requirements:** git, Java 25, Maven, Docker (for integration/e2e tests and `make oci`).
+
+```bash
+git clone https://github.com/Riptide-Labs/riptide.git && cd riptide
+make            # compile with tests → runnable jar in target/
+make help       # all goals
+```
+
+| Goal | What it does |
+|---|---|
+| `make` / `make jar` | full build with tests and all quality gates |
+| `make coverage` | unit suite + JaCoCo report (`target/site/jacoco/`) |
+| `make e2e` | integration/e2e tier (`*IT`, needs Docker) |
+| `make oci` | build the `riptide:local` container image |
+| `make docs` / `make docs-serve` | this documentation site |
+
+## IDE
+
+Import as a Maven project. The build relies on annotation processing (Lombok, MapStruct)
+— enable it in your IDE. `.mvn/jvm.config` (committed) provides the `jdk.compiler`
+exports that Error Prone needs; Maven picks it up automatically, no setup required.
+
+Run/debug the app via `org.riptide.RiptideApplication` — see
+[Run & debug](run-and-debug.md).

--- a/docs/docs/develop/pull-requests.md
+++ b/docs/docs/develop/pull-requests.md
@@ -1,0 +1,47 @@
+---
+sidebar_position: 4
+title: Pull requests
+---
+
+# Pull requests
+
+## Quality gates
+
+Every PR must pass, all wired through `make` in CI:
+
+| Gate | What it enforces |
+|---|---|
+| Checkstyle | formatting/style rules (`config/checkstyle.xml`) — fails on error |
+| Error Prone | compile-time bug patterns (javac plugin; generated sources excluded) |
+| Unit tests | the full suite |
+| SpotBugs | bytecode analysis, `effort=Max` (`config/spotbugs-exclude.xml` documents the deliberate exclusions) |
+| Coverage floor | ≥ 65% instruction / ≥ 55% branch (JaCoCo `check`) |
+| CodeQL | security-and-quality analysis (separate check) |
+| e2e | the nl6 flow-ingestion tier, full mode included |
+
+Run the Maven-side gates locally before pushing: `make` (= `mvn verify`).
+
+## Commits
+
+- **Conventional Commits**: `<type>[scope]: <description>` — `feat`, `fix`, `docs`,
+  `refactor`, `test`, `chore`, `ci`, `build`, … Breaking changes append `!`.
+- **DCO sign-off required**: commit with `git commit -s`. The sign-off certifies the
+  [Developer Certificate of Origin](https://developercertificate.org/) with your own
+  identity.
+
+## License
+
+Riptide is GPL-3.0-or-later. Every new source file starts with the SPDX header used
+throughout the codebase:
+
+```java
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+```
+
+## Flow
+
+Branch from `main`, keep PRs focused, make CI green — reviews happen on GitHub. Bug
+reports with a pcap (see [Run & debug](run-and-debug.md)) are the fastest path to a fix.

--- a/docs/docs/develop/run-and-debug.md
+++ b/docs/docs/develop/run-and-debug.md
@@ -1,0 +1,49 @@
+---
+sidebar_position: 2
+title: Run & debug
+---
+
+# Run & debug locally
+
+The debugging loop: ClickHouse in a container, Riptide in your IDE, real flow packets on
+UDP.
+
+## 1. Start the backing services
+
+```bash
+docker compose -f deployment/clickhouse/compose.yml up -d
+```
+
+ClickHouse on `localhost:8123` (which is the application default), plus
+[ch-ui](http://localhost:5521) to inspect the `flows` table and
+[Grafana](http://localhost:3000).
+
+## 2. Run Riptide under the debugger
+
+Start `org.riptide.RiptideApplication` from your IDE. No receivers are configured by
+default — enable one via program arguments or environment:
+
+```
+--riptide.receivers.nf9.type=netflow9
+--riptide.receivers.nf9.host=0.0.0.0
+--riptide.receivers.nf9.port=9999
+```
+
+Set breakpoints anywhere — parsers (`org.riptide.flows.parser`), enrichers
+(`org.riptide.snmp`, `org.riptide.dns`), or the pipeline.
+
+## 3. Send traffic
+
+**Replay a capture** — reproduce bugs from a pcap with `contrib/reply-pcap.py`
+(needs `pyshark` — which requires `tshark` — plus `click` and `tqdm`):
+
+```bash
+python3 contrib/reply-pcap.py capture.pcap    # replays NetFlow/cflow packets to 127.0.0.1:9999
+```
+
+**Simulate a network** — the [nl6](https://github.com/labmonkeys-space/nl6) simulator
+emits NetFlow v5/v9 and IPFIX from simulated devices; the [e2e tier](testing.md) runs it
+automatically, and `src/test/java/org/riptide/e2e/Nl6Container.java` shows how to run it
+standalone.
+
+Watch enriched rows land in `riptide.flows` via ch-ui.

--- a/docs/docs/develop/testing.md
+++ b/docs/docs/develop/testing.md
@@ -1,0 +1,39 @@
+---
+sidebar_position: 3
+title: Testing
+---
+
+# Testing
+
+Three tiers, separated so the fast loop stays fast:
+
+| Tier | Command | Needs | What runs |
+|---|---|---|---|
+| Unit | `mvn test` (or `make`) | JDK | 550+ tests, no containers |
+| Integration/e2e | `make e2e` | Docker | `*IT` classes: real ClickHouse, real Vault, and nl6-driven NetFlow v5/v9 + IPFIX through the full pipeline with ledger reconciliation |
+| Full mode | see below | Linux | per-device exporter IPs + SNMP enrichment walk-back to simulated agents |
+
+## Full mode (Linux only)
+
+nl6 devices export from their own source IPs and Riptide's SNMP enrichment walks back to
+each device's simulated agent:
+
+```bash
+docker network create --subnet 172.30.42.0/24 nl6-fullmode
+sudo ip route add 10.42.0.0/16 via 172.30.42.10
+RIPTIDE_E2E_FULL_MODE=1 make e2e
+```
+
+Skipped automatically elsewhere (e.g. macOS) — CI runs it on every PR.
+
+## Coverage
+
+```bash
+make coverage    # report: target/site/jacoco/index.html
+```
+
+The build enforces a floor (65% instruction / 55% branch); see
+[Pull requests](pull-requests.md) for all gates.
+
+The nl6 image tag is pinned in `Nl6Container.java` and bumped deliberately — it is a
+wire-format contract, not a Dependabot-managed dependency.

--- a/docs/docs/enrichment.md
+++ b/docs/docs/enrichment.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 6
 title: Enrichment
 ---
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -5,79 +5,29 @@ title: Getting started
 
 # Getting started
 
-## Requirements
+Two paths, depending on what you're here for:
 
-- git
-- Java 25
-- Docker with Docker Compose (for the container image and the e2e test tier)
+## 🚀 I want to run Riptide
 
-## Build from source
+Deploy the published image or jar — no build toolchain needed.
 
-```bash
-git clone https://github.com/Riptide-Labs/riptide.git && cd riptide
-```
+- [**Docker Compose**](deploy/docker-compose.md) — full stack (Riptide + ClickHouse +
+  UI + Grafana) in one `docker compose up`
+- [**Plain JAR**](deploy/plain-jar.md) — `java -jar` with file- or env-var-based
+  configuration
+- [Operations notes](deploy/operations.md) — image tags, restarts, upgrades
 
-Compile with tests and produce a runnable jar in `target/`:
+## 🛠 I want to work on Riptide
 
-```bash
-make
-```
+Build from source, debug locally, send a pull request.
 
-Build a container image into your local registry:
+- [**Environment**](develop/environment.md) — clone, `make`, IDE setup
+- [**Run & debug**](develop/run-and-debug.md) — Riptide under a debugger with real flow
+  traffic (pcap replay, nl6 simulator)
+- [Testing](develop/testing.md) — unit / e2e / full-mode tiers
+- [Pull requests](develop/pull-requests.md) — quality gates, DCO, commit conventions
 
-```bash
-make oci
-```
-
-## Container images
-
-Published images live at `ghcr.io/riptide-labs/riptide` (linux/amd64 + linux/arm64):
-
-| Tag | Meaning |
-|---|---|
-| `:<version>`, `:latest` | releases (`v*` tags) |
-| `:rc` | floating — rebuilt from every merge to `main` |
-
-```bash
-docker pull ghcr.io/riptide-labs/riptide:rc
-```
-
-Render a test coverage report (JaCoCo):
-
-```bash
-make coverage
-```
-
-## Integration and e2e tests
-
-The e2e tier drives real NetFlow v5/v9 and IPFIX traffic from the
-[nl6](https://github.com/labmonkeys-space/nl6) simulator through Riptide into ClickHouse
-(requires Docker):
-
-```bash
-make e2e
-```
-
-An optional **full mode** (Linux only) lets nl6 devices export flows from per-device
-source IPs while Riptide's SNMP enrichment walks back to each device's simulated agent:
-
-```bash
-docker network create --subnet 172.30.42.0/24 nl6-fullmode
-sudo ip route add 10.42.0.0/16 via 172.30.42.10
-RIPTIDE_E2E_FULL_MODE=1 make e2e
-```
-
-## Configuration
-
-Riptide is a Spring Boot application. Besides `application.properties`, it loads an
-optional external configuration file:
-
-```properties
-spring.config.additional-location=optional:file:/etc/riptide/config.yaml
-```
-
-The configuration chapters describe [receivers](configuration/receivers.md),
-[nodes & SNMP](configuration/nodes-and-snmp.md),
+Both paths share the [configuration reference](configuration/receivers.md) —
+receivers, [nodes & SNMP](configuration/nodes-and-snmp.md),
 [secret references](configuration/secret-references.md), and
-[ClickHouse](configuration/clickhouse.md). By default no receivers are configured —
-the daemon starts no listeners until you define them.
+[ClickHouse](configuration/clickhouse.md).

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -41,7 +41,8 @@ Java 25 · Spring Boot · Netty · SNMP4J · ClickHouse. Licensed
 
 ## Where to go next
 
-- [Getting started](getting-started.md) — build and run from source
+- 🚀 [Deploy Riptide](deploy/docker-compose.md) — run the published image (Compose or plain JAR)
+- 🛠 [Develop & Contribute](develop/environment.md) — build, debug, test, send PRs
 - [Receivers](configuration/receivers.md) — configure flow listeners
 - [Nodes & SNMP](configuration/nodes-and-snmp.md) — the node model and SNMP v1/v2c/v3
 - [Secret references](configuration/secret-references.md) — Vault, SOPS, env, file


### PR DESCRIPTION
Implements the **persona-docs** OpenSpec change: the docs' Getting Started was developer content wearing a neutral hat — operators were told to install git and compile before anything else.

## Deploy Riptide (operator)
- **Docker Compose quickstart on the published image** — enabled by flipping `deployment/riptide/compose.yml` to `ghcr.io/riptide-labs/riptide:latest` (**smoke-tested: all four services healthy on `docker compose up`, zero toolchain**). Explicit variants: `compose.override.rc.yml` (track main), `compose.override.dev.yml` (`riptide:local` after `make oci`); plain `compose.override.yml` remains the gitignored personal slot (it was never tracked — exploration originally assumed otherwise).
- **Plain JAR** — external `/etc/riptide/config.yaml` plus first-time documentation of the `RIPTIDE_*` env-var scheme the compose stack already uses.
- **Operations** — tag semantics (`:rc` = at-your-own-risk), the CREATE-OR-REPLACE restart caveat, upgrades.

## Develop & Contribute (developer)
Environment (`make`, IDE, `.mvn/jvm.config`) · Run & debug (ClickHouse compose + `RiptideApplication` under a debugger, traffic via `contrib/reply-pcap.py` — documented for the first time — and nl6) · Testing tiers · Pull requests (the five gates, DCO `-s`, Conventional Commits).

## Wiring
`/getting-started` keeps its URL as the persona chooser (no redirect plugin needed); new thin `CONTRIBUTING.md` points at the developer track; `make docs` green under `onBrokenLinks: throw`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)