### PR TITLE
docs: set the wave logo as the social card image

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -53,6 +53,8 @@ const config: Config = {
   ],
 
   themeConfig: {
+    // og:image / social card for links shared to Slack, Mastodon, …
+    image: 'img/favicon.png',
     navbar: {
       // no text title — the logo already carries the "Riptide" wordmark
       logo: {


### PR DESCRIPTION
Sets `themeConfig.image` so shared links get an `og:image` preview — the 8-bit wave, same asset as the favicon. Verified in the built HTML: `og:image` and `twitter:image` meta tags point at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)