### PR TITLE
feat(node)!: nodes become a name-keyed map with order-free matching

### DIFF
--- a/docs/docs/configuration/nodes-and-snmp.md
+++ b/docs/docs/configuration/nodes-and-snmp.md
@@ -5,32 +5,50 @@ title: Nodes & SNMP
 
 # Nodes & SNMP
 
-The node model (`riptide.nodes[]`) matches exporters and carries the SNMP agent
+The node model (`riptide.nodes.<name>`) matches exporters and carries the SNMP agent
 configuration used to enrich their flows. It is deliberately thin: interface metadata is
 held in a TTL cache, never on the node.
 
 ## Node shape
 
+Nodes are a **name-keyed map** — the same idiom as receivers. The name is the node's
+identity in logs and error messages (kebab-case: letters, digits, dashes):
+
 ```properties
-riptide.nodes[0].label=core-router          # optional; defaults to the subnet
-riptide.nodes[0].subnet-address=10.20.30.0/24
-riptide.nodes[0].observation-domain=42      # optional pin; omit = matches any domain
-riptide.nodes[0].snmp.port=161              # default 161
-riptide.nodes[0].snmp.timeout=500           # ms, default 500
-riptide.nodes[0].snmp.retries=1             # default 1
+riptide.nodes.core-router.subnet-address=10.20.30.0/24
+riptide.nodes.core-router.observation-domain=42   # optional pin; omit = matches any domain
+riptide.nodes.core-router.snmp.port=161           # default 161
+riptide.nodes.core-router.snmp.timeout=500        # ms, default 500
+riptide.nodes.core-router.snmp.retries=1          # default 1
 ```
 
-**Matching rule:** a node pinned to the flow's observation domain beats a wildcard node
-for the same subnet; otherwise the first subnet match in list order wins. A node without
-an `snmp` block matches flows but is not polled.
+**Matching is order-free** (think routing table):
+
+1. a node **pinned** to the flow's observation domain beats a wildcard node
+2. among the remaining candidates the **longest subnet prefix wins** (`/24` beats `/16`;
+   a bare host address is most specific)
+3. a **true tie** — two nodes with the same subnet and the same pinning — fails startup
+   with both node names; declaration order never decides anything
+
+A node without an `snmp` block matches flows but is not polled.
+
+:::tip Keep the inventory in its own file
+
+Stock Spring lets you split the node map out of the main configuration:
+
+```properties
+spring.config.import=optional:file:/etc/riptide/nodes.yaml
+```
+
+:::
 
 ## SNMP v1 / v2c
 
 Community-based — two settings:
 
 ```properties
-riptide.nodes[0].snmp.snmp-version=v2c      # or: v1
-riptide.nodes[0].snmp.community=env://RIPTIDE_SNMP_COMMUNITY
+riptide.nodes.access-switches.snmp.snmp-version=v2c      # or: v1
+riptide.nodes.access-switches.snmp.community=env://RIPTIDE_SNMP_COMMUNITY
 ```
 
 ## SNMP v3 (USM)
@@ -40,22 +58,22 @@ The security level is **implicit** in which credentials you configure:
 **noAuthNoPriv** — security name only:
 
 ```properties
-riptide.nodes[1].snmp.snmp-version=v3
-riptide.nodes[1].snmp.security-name=monitoring
+riptide.nodes.core-router.snmp.snmp-version=v3
+riptide.nodes.core-router.snmp.security-name=monitoring
 ```
 
 **authNoPriv** — add authentication:
 
 ```properties
-riptide.nodes[1].snmp.auth-protocol=hmac192sha256
-riptide.nodes[1].snmp.auth-passphrase=vault://secret/snmp/core-router#authPassphrase
+riptide.nodes.core-router.snmp.auth-protocol=hmac192sha256
+riptide.nodes.core-router.snmp.auth-passphrase=vault://secret/snmp/core-router#authPassphrase
 ```
 
 **authPriv** — add privacy on top:
 
 ```properties
-riptide.nodes[1].snmp.priv-protocol=aes256
-riptide.nodes[1].snmp.priv-passphrase=vault://secret/snmp/core-router#privPassphrase
+riptide.nodes.core-router.snmp.priv-protocol=aes256
+riptide.nodes.core-router.snmp.priv-passphrase=vault://secret/snmp/core-router#privPassphrase
 ```
 
 The **engine ID is never configured** — it is discovered at runtime (RFC 3414).
@@ -76,7 +94,7 @@ SHA-1.
 ```yaml
 riptide:
   nodes:
-    - label: core-router
+    core-router:
       subnet-address: 10.20.30.0/24
       observation-domain: 42
       snmp:
@@ -86,15 +104,21 @@ riptide:
         auth-passphrase: vault://secret/snmp/core-router#authPassphrase
         priv-protocol: aes256
         priv-passphrase: vault://secret/snmp/core-router#privPassphrase
-    - label: access-switches       # v2c wildcard fallback for the same address space
+    access-switches:               # v2c fallback: the /16 matches wherever no /24 does
       subnet-address: 10.20.0.0/16
       snmp:
         snmp-version: v2c
         community: env://RIPTIDE_SNMP_COMMUNITY
 ```
 
-## Migration from `riptide.snmp.config`
+Environment variables work too (`RIPTIDE_NODES_COREROUTER_SNMP_COMMUNITY`), with one
+caveat: Spring flattens map keys arriving from the environment (case and dashes are
+lost), so prefer file-based definition for nodes.
 
-The pre-0.1.0 `riptide.snmp.config.definitions[*]` tree has moved to `riptide.nodes[*]`
-(SNMP settings nested under `snmp.`). Legacy keys are ignored and Riptide logs an
-explicit error at startup when it finds them.
+## Migration from earlier shapes
+
+- The pre-0.1.0 `riptide.snmp.config.definitions[*]` tree moved to `riptide.nodes`
+  (SNMP settings nested under `snmp.`) — legacy keys log an explicit startup error.
+- The interim indexed list form (`riptide.nodes[0].…`) moved to the name-keyed map —
+  indexed keys **fail startup** with an explicit error (they would otherwise half-bind
+  into a node named after the index).

--- a/docs/docs/deploy/plain-jar.md
+++ b/docs/docs/deploy/plain-jar.md
@@ -46,11 +46,12 @@ binding): uppercase, dots and dashes become underscores, list indexes become `_0
 |---|---|
 | `riptide.clickhouse.endpoint` | `RIPTIDE_CLICKHOUSE_ENDPOINT` |
 | `riptide.receivers.ipfix.port` | `RIPTIDE_RECEIVERS_IPFIX_PORT` |
-| `riptide.nodes[0].subnet-address` | `RIPTIDE_NODES_0_SUBNETADDRESS` |
-| `riptide.nodes[0].snmp.community` | `RIPTIDE_NODES_0_SNMP_COMMUNITY` |
+| `riptide.nodes.core-router.subnet-address` | `RIPTIDE_NODES_COREROUTER_SUBNETADDRESS` |
+| `riptide.nodes.core-router.snmp.community` | `RIPTIDE_NODES_COREROUTER_SNMP_COMMUNITY` |
 
 Environment variables suit flat settings and containerized deployments (the compose stack
-configures ClickHouse this way); prefer the config file for larger node lists.
+configures ClickHouse this way). Prefer the config file for nodes — Spring flattens map
+keys arriving from the environment (case and dashes are lost).
 
 Secret references (`env://`, `file://`, `vault://`, `sops://`) work the same in both —
 see [Secret references](../configuration/secret-references.md).

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -24,7 +24,7 @@ UDP/TCP ingest (NetFlow v5 · NetFlow v9 · IPFIX)
 - **Flow protocols:** NetFlow v5, NetFlow v9, and IPFIX (UDP; IPFIX also via TCP).
   sFlow support is planned for v0.2.0
   ([#159](https://github.com/Riptide-Labs/riptide/issues/159)).
-- **Node model:** a thin registry (`riptide.nodes[]`) matches exporters by subnet —
+- **Node model:** a thin registry (`riptide.nodes.<name>`) matches exporters by subnet —
   optionally pinned to one observation domain — and carries the SNMP agent
   configuration used to enrich that device's flows. See
   [Nodes & SNMP](configuration/nodes-and-snmp.md).

--- a/src/main/java/org/riptide/node/Node.java
+++ b/src/main/java/org/riptide/node/Node.java
@@ -11,13 +11,13 @@ import org.riptide.snmp.SnmpEndpoint;
 import java.util.Optional;
 
 /**
- * A matched node: the {@link NodeDefinition} an exporter identity resolved to, bound to the
- * concrete exporter address of the flow.
+ * A matched node: the {@link NodeDefinition} an exporter identity resolved to, bound to
+ * the concrete exporter address of the flow. {@code name} is the configuration map key.
  */
-public record Node(NodeDefinition definition, IPAddressString address) {
+public record Node(String name, NodeDefinition definition, IPAddressString address) {
 
     public String label() {
-        return this.definition.label();
+        return this.name;
     }
 
     /** The SNMP endpoint to poll this node, if it has SNMP agent configuration. */

--- a/src/main/java/org/riptide/node/NodeDefinition.java
+++ b/src/main/java/org/riptide/node/NodeDefinition.java
@@ -11,16 +11,14 @@ import org.riptide.snmp.SnmpDefinition;
 
 /**
  * A configured node: how to <em>match</em> an exporter (subnet, optionally pinned to one
- * observation domain) and how to <em>talk</em> to it (optional SNMP agent config).
+ * observation domain) and how to <em>talk</em> to it (optional SNMP agent config). The
+ * node's name is its key in the {@code riptide.nodes} map.
  *
  * <p>Deliberately thin — interface metadata, hostnames, and other enrichment results live in
  * TTL caches keyed by the matched node, never on the node itself.</p>
  */
 @Data
 public class NodeDefinition {
-
-    /** Optional human-readable name; defaults to the subnet when unset. */
-    private String label;
 
     private IPAddressString subnetAddress;
 
@@ -29,8 +27,4 @@ public class NodeDefinition {
 
     /** SNMP agent configuration; {@code null} if this node is not polled. */
     private SnmpDefinition snmp;
-
-    public String label() {
-        return this.label != null ? this.label : String.valueOf(this.subnetAddress);
-    }
 }

--- a/src/main/java/org/riptide/node/NodeRegistry.java
+++ b/src/main/java/org/riptide/node/NodeRegistry.java
@@ -6,28 +6,32 @@
 package org.riptide.node;
 
 import inet.ipaddr.IPAddressString;
+import jakarta.annotation.PostConstruct;
 import lombok.Data;
 import org.riptide.pipeline.ExporterIdentity;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
- * The node model: matches exporter identities to configured {@link NodeDefinition}s
- * (successor of the former {@code riptide.snmp.config.definitions}).
+ * The node model: matches exporter identities to configured {@link NodeDefinition}s.
+ * Nodes are configured as a name-keyed map ({@code riptide.nodes.<name>.…}, same idiom
+ * as receivers); the key is the node's identity in logs and error messages.
  */
 @Data
 @ConfigurationProperties(prefix = "riptide")
 public class NodeRegistry {
 
-    private List<NodeDefinition> nodes = new ArrayList<>();
+    private Map<String, NodeDefinition> nodes = new HashMap<>();
 
     /**
-     * Nodes pinned to the flow's observation domain win over wildcard nodes (no
-     * {@code observation-domain}); within each group the subnet match keeps
-     * first-match order.
+     * Matching is order-free: nodes pinned to the flow's observation domain beat
+     * wildcard nodes; among the remaining candidates the longest subnet prefix wins.
+     * True ties are rejected at startup by {@link #validate()}.
      */
     public Optional<Node> lookup(final ExporterIdentity identity) {
         // instanceof instead of an exhaustive switch pattern only because checkstyle 9.3
@@ -35,18 +39,60 @@ public class NodeRegistry {
         // must be handled here.
         if (identity instanceof ExporterIdentity.NetflowIpfix netflowIpfix) {
             final IPAddressString ipAddressString = new IPAddressString(netflowIpfix.source().getHostAddress());
-            final List<NodeDefinition> subnetMatches = this.nodes.stream()
-                    .filter(node -> node.getSubnetAddress().contains(ipAddressString))
+            final List<Map.Entry<String, NodeDefinition>> subnetMatches = this.nodes.entrySet().stream()
+                    .filter(node -> node.getValue().getSubnetAddress().contains(ipAddressString))
                     .toList();
 
-            return subnetMatches.stream()
-                    .filter(node -> node.getObservationDomain() != null && node.getObservationDomain() == netflowIpfix.observationDomain())
-                    .findFirst()
-                    .or(() -> subnetMatches.stream()
-                            .filter(node -> node.getObservationDomain() == null)
-                            .findFirst())
-                    .map(node -> new Node(node, ipAddressString));
+            final List<Map.Entry<String, NodeDefinition>> pinned = subnetMatches.stream()
+                    .filter(node -> node.getValue().getObservationDomain() != null
+                            && node.getValue().getObservationDomain() == netflowIpfix.observationDomain())
+                    .toList();
+            final List<Map.Entry<String, NodeDefinition>> pool = !pinned.isEmpty()
+                    ? pinned
+                    : subnetMatches.stream().filter(node -> node.getValue().getObservationDomain() == null).toList();
+
+            return pool.stream()
+                    .max(Comparator.comparingInt(node -> prefixLength(node.getValue().getSubnetAddress())))
+                    .map(node -> new Node(node.getKey(), node.getValue(), ipAddressString));
         }
         throw new IllegalStateException("Unhandled exporter identity: " + identity);
+    }
+
+    /**
+     * Fails startup on ambiguous configuration. Equal-length CIDR prefixes are either
+     * identical or disjoint, so a true tie is exactly two nodes with the same subnet and
+     * the same pinning state — detection is complete, not heuristic.
+     */
+    @PostConstruct
+    void validate() {
+        final Map<String, String> seen = new HashMap<>();
+        for (final Map.Entry<String, NodeDefinition> node : this.nodes.entrySet()) {
+            if (node.getValue().getSubnetAddress() == null) {
+                throw new IllegalStateException("Node '%s' has no subnet-address — every node needs one to match exporters."
+                        .formatted(node.getKey()));
+            }
+            final String key = canonicalSubnet(node.getValue().getSubnetAddress())
+                    + "@" + (node.getValue().getObservationDomain() != null ? node.getValue().getObservationDomain() : "wildcard");
+            final String other = seen.putIfAbsent(key, node.getKey());
+            if (other != null) {
+                throw new IllegalStateException(("Ambiguous node configuration: '%s' and '%s' declare the same subnet "
+                        + "with the same observation-domain pinning — matching between them would be arbitrary. "
+                        + "Merge them or distinguish them by subnet or observation-domain.")
+                        .formatted(other, node.getKey()));
+            }
+        }
+    }
+
+    private static int prefixLength(final IPAddressString subnet) {
+        final Integer prefix = subnet.getNetworkPrefixLength();
+        if (prefix != null) {
+            return prefix;
+        }
+        // a bare host address is the most specific match possible
+        return subnet.getAddress() != null ? subnet.getAddress().getBitCount() : 0;
+    }
+
+    private static String canonicalSubnet(final IPAddressString subnet) {
+        return subnet.getAddress() != null ? subnet.getAddress().toPrefixBlock().toString() : String.valueOf(subnet);
     }
 }

--- a/src/main/java/org/riptide/node/NodesConfigMigrationCheck.java
+++ b/src/main/java/org/riptide/node/NodesConfigMigrationCheck.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.node;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.core.env.AbstractEnvironment;
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * The pre-0.1.0 {@code riptide.nodes[<n>]} indexed list moved to the name-keyed
+ * {@code riptide.nodes.<name>} map. Indexed keys would half-bind into a node named
+ * after the index — this check fails startup loudly instead.
+ */
+@Component
+public class NodesConfigMigrationCheck {
+
+    private static final Pattern LEGACY_KEY = Pattern.compile("^riptide\\.nodes\\[\\d+]");
+
+    private final Environment environment;
+
+    public NodesConfigMigrationCheck(final Environment environment) {
+        this.environment = Objects.requireNonNull(environment);
+    }
+
+    @PostConstruct
+    void failOnLegacyIndexedNodes() {
+        if (!(this.environment instanceof AbstractEnvironment abstractEnvironment)) {
+            return;
+        }
+        for (final var source : abstractEnvironment.getPropertySources()) {
+            if (source instanceof EnumerablePropertySource<?> enumerable) {
+                for (final String name : enumerable.getPropertyNames()) {
+                    if (LEGACY_KEY.matcher(name).find()) {
+                        throw new IllegalStateException(("Legacy node configuration found ('%s'): riptide.nodes is a "
+                                + "name-keyed map — configure riptide.nodes.<name>.subnet-address etc. instead of "
+                                + "indexed riptide.nodes[0] entries (see the Nodes & SNMP documentation).")
+                                .formatted(name));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/riptide/snmp/SnmpConfigMigrationWarning.java
+++ b/src/main/java/org/riptide/snmp/SnmpConfigMigrationWarning.java
@@ -28,7 +28,7 @@ public class SnmpConfigMigrationWarning {
     void warnAboutLegacyConfiguration() {
         if (!this.definitions.isEmpty()) {
             log.error("riptide.snmp.config.definitions has moved and is IGNORED: configure nodes via "
-                    + "riptide.nodes[].{label,subnet-address,observation-domain,snmp.*} instead "
+                    + "riptide.nodes.<name>.{subnet-address,observation-domain,snmp.*} instead "
                     + "(see the NODES EXAMPLE in application.properties). SNMP enrichment is NOT "
                     + "active for the {} legacy definition(s).", this.definitions.size());
         }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,9 +25,9 @@ riptide.clickhouse.database=riptide
 riptide.snmp.cache.retentionMs=600000
 
 # NODES EXAMPLE
-# A node matches exporters by subnet (optionally pinned to one observation domain /
-# source ID; pinned nodes win over wildcard ones) and optionally carries the SNMP
-# agent configuration used to enrich its flows.
+# Nodes are a name-keyed map. A node matches exporters by subnet (optionally pinned
+# to one observation domain / source ID); pinned nodes beat wildcard ones and the
+# longest subnet prefix wins — declaration order never matters.
 # SNMP credentials (community, auth-passphrase, priv-passphrase) are secret
 # references, resolved at poll time — never put plaintext secrets here:
 #   env://NAME                                          environment variable
@@ -35,12 +35,11 @@ riptide.snmp.cache.retentionMs=600000
 #   file:///etc/riptide/sec.properties#snmp.community   key in a properties file
 #   vault://secret/snmp/core-router#community           HashiCorp Vault KV v2 (<mount>/<path>#<key>)
 #   sops:///etc/riptide/secrets.yaml#snmp.community     SOPS-encrypted YAML/JSON (decrypted via the sops binary)
-#riptide.nodes[0].label=core-router
-#riptide.nodes[0].subnet-address=10.20.30.0/24
-#riptide.nodes[0].observation-domain=42
-#riptide.nodes[0].snmp.port=161
-#riptide.nodes[0].snmp.snmp-version=v2c
-#riptide.nodes[0].snmp.community=env://RIPTIDE_SNMP_COMMUNITY
+#riptide.nodes.core-router.subnet-address=10.20.30.0/24
+#riptide.nodes.core-router.observation-domain=42
+#riptide.nodes.core-router.snmp.port=161
+#riptide.nodes.core-router.snmp.snmp-version=v2c
+#riptide.nodes.core-router.snmp.community=env://RIPTIDE_SNMP_COMMUNITY
 # Optionally restrict file:// access:
 #riptide.secrets.allowed-paths=/run/secrets,/etc/riptide
 # Vault (enables the vault:// resolver; token e.g. from a Vault Agent sink):

--- a/src/test/java/org/riptide/e2e/Nl6SnmpEnrichmentIT.java
+++ b/src/test/java/org/riptide/e2e/Nl6SnmpEnrichmentIT.java
@@ -83,10 +83,10 @@ public class Nl6SnmpEnrichmentIT {
         registry.add("riptide.receivers.nf9.host", () -> "0.0.0.0");
         registry.add("riptide.receivers.nf9.port", () -> NETFLOW9_PORT);
 
-        registry.add("riptide.nodes[0].subnet-address", () -> "10.42.0.0/16");
-        registry.add("riptide.nodes[0].snmp.port", () -> 161);
-        registry.add("riptide.nodes[0].snmp.snmp-version", () -> "v2c");
-        registry.add("riptide.nodes[0].snmp.community", () -> "public");
+        registry.add("riptide.nodes.nl6-devices.subnet-address", () -> "10.42.0.0/16");
+        registry.add("riptide.nodes.nl6-devices.snmp.port", () -> 161);
+        registry.add("riptide.nodes.nl6-devices.snmp.snmp-version", () -> "v2c");
+        registry.add("riptide.nodes.nl6-devices.snmp.community", () -> "public");
     }
 
     @BeforeAll

--- a/src/test/java/org/riptide/node/NodeRegistryTest.java
+++ b/src/test/java/org/riptide/node/NodeRegistryTest.java
@@ -13,15 +13,16 @@ import org.riptide.snmp.SnmpDefinition;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class NodeRegistryTest {
 
-    private static NodeDefinition node(final String label, final String subnet, final Long observationDomain, final String community) {
+    private static NodeDefinition node(final String subnet, final Long observationDomain, final String community) {
         final NodeDefinition node = new NodeDefinition();
-        node.setLabel(label);
         node.setSubnetAddress(new IPAddressString(subnet));
         node.setObservationDomain(observationDomain);
         if (community != null) {
@@ -36,25 +37,56 @@ public class NodeRegistryTest {
         return new ExporterIdentity.NetflowIpfix(InetAddress.getByName(host), observationDomain);
     }
 
-    private static NodeRegistry registry(final NodeDefinition... nodes) {
+    @SafeVarargs
+    private static NodeRegistry registry(final Map.Entry<String, NodeDefinition>... nodes) {
+        final Map<String, NodeDefinition> map = new LinkedHashMap<>();
+        for (final var entry : nodes) {
+            map.put(entry.getKey(), entry.getValue());
+        }
         final NodeRegistry registry = new NodeRegistry();
-        registry.setNodes(List.of(nodes));
+        registry.setNodes(map);
+        registry.validate();
         return registry;
     }
 
     @Test
     public void observationDomainPinnedNodeWinsOverWildcard() throws Exception {
         final NodeRegistry registry = registry(
-                node("wildcard", "10.0.0.0/24", null, "wildcard"),
-                node("pinned", "10.0.0.0/24", 42L, "pinned"));
+                Map.entry("wildcard", node("10.0.0.0/24", null, "wildcard")),
+                Map.entry("pinned", node("10.0.0.0/24", 42L, "pinned")));
 
         assertThat(registry.lookup(identity("10.0.0.1", 42))).map(Node::label).hasValue("pinned");
         assertThat(registry.lookup(identity("10.0.0.1", 7))).map(Node::label).hasValue("wildcard");
     }
 
     @Test
+    public void longestPrefixWinsInEitherDeclarationOrder() throws Exception {
+        final NodeRegistry coarseFirst = registry(
+                Map.entry("coarse", node("10.20.0.0/16", null, "a")),
+                Map.entry("fine", node("10.20.30.0/24", null, "b")));
+        final NodeRegistry fineFirst = registry(
+                Map.entry("fine", node("10.20.30.0/24", null, "b")),
+                Map.entry("coarse", node("10.20.0.0/16", null, "a")));
+
+        assertThat(coarseFirst.lookup(identity("10.20.30.5", 0))).map(Node::label).hasValue("fine");
+        assertThat(fineFirst.lookup(identity("10.20.30.5", 0))).map(Node::label).hasValue("fine");
+        // outside the /24, the /16 still matches
+        assertThat(coarseFirst.lookup(identity("10.20.99.5", 0))).map(Node::label).hasValue("coarse");
+    }
+
+    @Test
+    public void bareHostAddressIsMostSpecific() throws Exception {
+        final NodeRegistry registry = registry(
+                Map.entry("subnet", node("10.0.0.0/24", null, "a")),
+                Map.entry("host", node("10.0.0.7", null, "b")));
+
+        assertThat(registry.lookup(identity("10.0.0.7", 0))).map(Node::label).hasValue("host");
+        assertThat(registry.lookup(identity("10.0.0.8", 0))).map(Node::label).hasValue("subnet");
+    }
+
+    @Test
     public void pinnedOnlyRegistryDoesNotMatchOtherDomains() throws Exception {
-        final NodeRegistry registry = registry(node("pinned", "10.0.0.0/24", 42L, "pinned"));
+        final NodeRegistry registry = registry(Map.entry("pinned", node("10.0.0.0/24", 42L, "pinned")));
 
         assertThat(registry.lookup(identity("10.0.0.1", 42))).isPresent();
         assertThat(registry.lookup(identity("10.0.0.1", 7))).isEmpty();
@@ -62,33 +94,47 @@ public class NodeRegistryTest {
 
     @Test
     public void subnetMissYieldsEmpty() throws Exception {
-        final NodeRegistry registry = registry(node("wildcard", "10.0.0.0/24", null, "wildcard"));
+        final NodeRegistry registry = registry(Map.entry("wildcard", node("10.0.0.0/24", null, "wildcard")));
 
         assertThat(registry.lookup(identity("192.168.1.1", 0))).isEmpty();
     }
 
     @Test
-    public void firstSubnetMatchOrderIsKeptWithinAGroup() throws Exception {
-        final NodeRegistry registry = registry(
-                node("first", "10.0.0.0/16", null, "first"),
-                node("second", "10.0.0.0/24", null, "second"));
+    public void trueTieFailsValidation() {
+        assertThatThrownBy(() -> registry(
+                Map.entry("site-a", node("10.20.30.0/24", null, "a")),
+                Map.entry("backup", node("10.20.30.0/24", null, "b"))))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("site-a")
+                .hasMessageContaining("backup");
+    }
 
-        assertThat(registry.lookup(identity("10.0.0.1", 0))).map(Node::label).hasValue("first");
+    @Test
+    public void samePinnedDomainSameSubnetFailsValidation() {
+        assertThatThrownBy(() -> registry(
+                Map.entry("one", node("10.20.30.0/24", 42L, "a")),
+                Map.entry("two", node("10.20.30.0/24", 42L, "b"))))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void sameSubnetDifferentPinningIsNotATie() throws Exception {
+        final NodeRegistry registry = registry(
+                Map.entry("pinned", node("10.20.30.0/24", 42L, "a")),
+                Map.entry("wildcard", node("10.20.30.0/24", null, "b")),
+                Map.entry("other-domain", node("10.20.30.0/24", 7L, "c")));
+
+        assertThat(registry.lookup(identity("10.20.30.5", 42))).map(Node::label).hasValue("pinned");
+        assertThat(registry.lookup(identity("10.20.30.5", 7))).map(Node::label).hasValue("other-domain");
+        assertThat(registry.lookup(identity("10.20.30.5", 1))).map(Node::label).hasValue("wildcard");
     }
 
     @Test
     public void nodeWithoutSnmpConfigHasNoEndpoint() throws Exception {
-        final NodeRegistry registry = registry(node("bare", "10.0.0.0/24", null, null));
+        final NodeRegistry registry = registry(Map.entry("bare", node("10.0.0.0/24", null, null)));
 
         final var match = registry.lookup(identity("10.0.0.1", 0));
         assertThat(match).isPresent();
         assertThat(match.get().snmpEndpoint()).isEmpty();
-    }
-
-    @Test
-    public void labelDefaultsToSubnet() throws Exception {
-        final NodeRegistry registry = registry(node(null, "10.0.0.0/24", null, "c"));
-
-        assertThat(registry.lookup(identity("10.0.0.1", 0))).map(Node::label).hasValue("10.0.0.0/24");
     }
 }

--- a/src/test/java/org/riptide/node/NodesConfigMigrationCheckTest.java
+++ b/src/test/java/org/riptide/node/NodesConfigMigrationCheckTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.node;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class NodesConfigMigrationCheckTest {
+
+    @Test
+    public void legacyIndexedKeysFailStartup() {
+        final MockEnvironment environment = new MockEnvironment()
+                .withProperty("riptide.nodes[0].subnet-address", "10.20.30.0/24");
+
+        assertThatThrownBy(() -> new NodesConfigMigrationCheck(environment).failOnLegacyIndexedNodes())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("riptide.nodes.<name>");
+    }
+
+    @Test
+    public void mapShapeKeysPass() {
+        final MockEnvironment environment = new MockEnvironment()
+                .withProperty("riptide.nodes.core-router.subnet-address", "10.20.30.0/24");
+
+        assertThatCode(() -> new NodesConfigMigrationCheck(environment).failOnLegacyIndexedNodes())
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/org/riptide/snmp/SnmpEnricherTest.java
+++ b/src/test/java/org/riptide/snmp/SnmpEnricherTest.java
@@ -29,10 +29,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest(properties = {
-        "riptide.nodes[0].subnet-address=127.0.0.1/24",
-        "riptide.nodes[0].snmp.port=12345",
-        "riptide.nodes[0].snmp.snmp-version=v2c",
-        "riptide.nodes[0].snmp.community=" + TestSnmpAgent.COMMUNITY
+        "riptide.nodes.test-agent.subnet-address=127.0.0.1/24",
+        "riptide.nodes.test-agent.snmp.port=12345",
+        "riptide.nodes.test-agent.snmp.snmp-version=v2c",
+        "riptide.nodes.test-agent.snmp.community=" + TestSnmpAgent.COMMUNITY
 })
 public class SnmpEnricherTest {
 


### PR DESCRIPTION
Implements the **node-map-config** OpenSpec change (from today's explore session on friendlier node configuration).

## The shape
`riptide.nodes.<name>.…` — same idiom as receivers. The key is the node's identity (kebab-case); `label` is gone (nothing consumed it). Overrides merge **by name** across config sources instead of Spring's by-index list splicing.

## The semantics — order-free, routing-table style
1. observation-domain **pinned** beats wildcard *(unchanged)*
2. **longest subnet prefix wins** (`/24` beats `/16`; bare host = most specific) *(replaces list order)*
3. **true ties fail startup** with both node names — and detection is *complete*, not heuristic: equal-length CIDR prefixes are either identical or disjoint, so a tie is exactly (same subnet, same pinning). Renaming a node can never change matching.

## Migration courtesy
Legacy `riptide.nodes[0]` keys **fail startup loudly** — they'd otherwise half-bind into a node literally named `0`. The older `snmp.config` warning now points at the map shape too. (Breaking is ~free: `riptide.nodes[]` never shipped in a tagged release.)

## Verified
- `mvn verify` green — all gates, 560+ tests incl. new `NodeRegistryTest` (longest-prefix asserted in **both declaration orders**, tie/pinning matrix, host-specificity) and `NodesConfigMigrationCheckTest`
- `make docs` green; nodes page teaches the precedence rules, env-key flattening caveat, and the `spring.config.import` inventory-file tip
- #163 got the reload-unit + reject-reload-keep-registry design notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)