### PR TITLE
feat(enrichment): static interface mapping with per-field pin

### DIFF
--- a/docs/docs/configuration/nodes-and-snmp.md
+++ b/docs/docs/configuration/nodes-and-snmp.md
@@ -30,7 +30,21 @@ riptide.nodes.core-router.snmp.retries=1          # default 1
 3. a **true tie** — two nodes with the same subnet and the same pinning — fails startup
    with both node names; declaration order never decides anything
 
-A node without an `snmp` block matches flows but is not polled.
+A node without an `snmp` block matches flows but is not polled — it can still enrich
+interfaces statically via the `interfaces` map (see below).
+
+## Static interface mapping
+
+Nodes may pin interface metadata without (or in addition to) SNMP:
+
+```properties
+riptide.nodes.core-router.interfaces.10.name=eth0
+riptide.nodes.core-router.interfaces.10.alias=Uplink to AS64500
+riptide.nodes.core-router.interfaces.10.high-speed=10000
+```
+
+Fields set here **override** live SNMP values per field; SNMP fills the rest
+([enrichment ladder](../enrichment.md#the-enrichment-ladder)).
 
 :::tip Keep the inventory in its own file
 

--- a/docs/docs/enrichment.md
+++ b/docs/docs/enrichment.md
@@ -9,6 +9,41 @@ Every flow passes an asynchronous enrichment pipeline before persistence. Enrich
 never blocks or drops flows: failures degrade to an unenriched flow with a logged
 warning.
 
+## The enrichment ladder
+
+Riptide enriches each flow as well as the environment allows and **degrades
+gracefully** — in the worst case a flow carries exactly what the packets said:
+
+| Layer | Source | Needs |
+|---|---|---|
+| 2 — live | SNMP IF-MIB, reverse DNS | reachable agents/resolvers |
+| 1 — static | operator mapping files (node `interfaces`, routing mapping) | a config file |
+| 0 — packet | ifIndex numbers, exporter-sent AS numbers, addresses, next hop | nothing — always available |
+
+**Precedence is per-field pin**: a field set in a static mapping overrides the live
+value; live sources fill the fields the file doesn't set; packet data is the floor.
+For AS numbers, a **nonzero exporter-provided value always wins** — the routing mapping
+only fills zeros.
+
+## Static interface mapping
+
+A node may carry its own interface table — the middle rung, for devices without
+(reachable) SNMP:
+
+```yaml
+riptide:
+  nodes:
+    core-router:
+      subnet-address: 10.20.30.0/24
+      interfaces:
+        "10": { name: eth0, alias: "Uplink to AS64500", high-speed: 10000 }
+        "12": { name: eth2 }
+```
+
+With an `snmp` block present too, file fields pin and SNMP fills the rest — e.g. a
+pinned `alias` with live `name`/`high-speed`. `high-speed` is Mbit/s, matching
+`ifHighSpeed`.
+
 ## SNMP interface data
 
 When a flow's exporter matches a [node](configuration/nodes-and-snmp.md) with SNMP

--- a/src/main/java/org/riptide/node/NodeDefinition.java
+++ b/src/main/java/org/riptide/node/NodeDefinition.java
@@ -7,7 +7,11 @@ package org.riptide.node;
 
 import inet.ipaddr.IPAddressString;
 import lombok.Data;
+import org.riptide.snmp.IfInfo;
 import org.riptide.snmp.SnmpDefinition;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A configured node: how to <em>match</em> an exporter (subnet, optionally pinned to one
@@ -27,4 +31,11 @@ public class NodeDefinition {
 
     /** SNMP agent configuration; {@code null} if this node is not polled. */
     private SnmpDefinition snmp;
+
+    /**
+     * Static interface mapping (ifIndex → name/alias/high-speed) — the enrichment
+     * ladder's middle rung. Fields set here pin over live SNMP values; SNMP fills the
+     * rest. Works without any {@code snmp} block.
+     */
+    private Map<Integer, IfInfo> interfaces = new HashMap<>();
 }

--- a/src/main/java/org/riptide/snmp/IfInfo.java
+++ b/src/main/java/org/riptide/snmp/IfInfo.java
@@ -12,4 +12,22 @@ package org.riptide.snmp;
  * when the agent only serves the legacy ifTable ({@code name} is ifDescr in that case).
  */
 public record IfInfo(String name, String alias, Long highSpeed) {
+
+    /**
+     * Per-field pin: fields of {@code pinned} (the operator's static mapping) win where
+     * present; {@code fallback} (live SNMP) fills the rest. Either side may be
+     * {@code null}.
+     */
+    public static IfInfo merge(final IfInfo pinned, final IfInfo fallback) {
+        if (pinned == null) {
+            return fallback;
+        }
+        if (fallback == null) {
+            return pinned;
+        }
+        return new IfInfo(
+                pinned.name != null ? pinned.name : fallback.name,
+                pinned.alias != null ? pinned.alias : fallback.alias,
+                pinned.highSpeed != null ? pinned.highSpeed : fallback.highSpeed);
+    }
 }

--- a/src/main/java/org/riptide/snmp/SnmpEnricher.java
+++ b/src/main/java/org/riptide/snmp/SnmpEnricher.java
@@ -15,8 +15,15 @@ import org.riptide.pipeline.Source;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
+/**
+ * Resolves flow interface indexes against the matched node: the static interface
+ * mapping pins per field, live SNMP fills the rest (enrichment-ladder semantics).
+ * A node without an SNMP block enriches purely statically.
+ */
 @Component
 @RequiredArgsConstructor
 public class SnmpEnricher implements Enricher {
@@ -30,14 +37,15 @@ public class SnmpEnricher implements Enricher {
     @Override
     public CompletableFuture<Void> enrich(final Source source, final List<EnrichedFlow> flows) {
         return CompletableFuture.supplyAsync(() -> {
-            this.nodeRegistry.lookup(source.identity()).flatMap(Node::snmpEndpoint).ifPresent(snmpEndpoint -> {
+            this.nodeRegistry.lookup(source.identity()).ifPresent(node -> {
+                final Optional<SnmpEndpoint> snmpEndpoint = node.snmpEndpoint();
                 for (final EnrichedFlow flow : flows) {
-                    this.snmpService.getIfInfo(snmpEndpoint, flow.getInputSnmp()).ifPresent(ifInfo -> {
+                    apply(node, snmpEndpoint, flow.getInputSnmp(), ifInfo -> {
                         flow.setInputSnmpIfName(ifInfo.name());
                         flow.setInputSnmpIfAlias(ifInfo.alias());
                         flow.setInputSnmpIfSpeed(ifInfo.highSpeed());
                     });
-                    this.snmpService.getIfInfo(snmpEndpoint, flow.getOutputSnmp()).ifPresent(ifInfo -> {
+                    apply(node, snmpEndpoint, flow.getOutputSnmp(), ifInfo -> {
                         flow.setOutputSnmpIfName(ifInfo.name());
                         flow.setOutputSnmpIfAlias(ifInfo.alias());
                         flow.setOutputSnmpIfSpeed(ifInfo.highSpeed());
@@ -47,5 +55,17 @@ public class SnmpEnricher implements Enricher {
 
             return null;
         });
+    }
+
+    private void apply(final Node node, final Optional<SnmpEndpoint> snmpEndpoint, final int ifIndex,
+                       final Consumer<IfInfo> setter) {
+        final IfInfo pinned = node.definition().getInterfaces().get(ifIndex);
+        final IfInfo live = snmpEndpoint
+                .flatMap(endpoint -> this.snmpService.getIfInfo(endpoint, ifIndex))
+                .orElse(null);
+        final IfInfo merged = IfInfo.merge(pinned, live);
+        if (merged != null) {
+            setter.accept(merged);
+        }
     }
 }

--- a/src/test/java/org/riptide/snmp/IfInfoTest.java
+++ b/src/test/java/org/riptide/snmp/IfInfoTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.snmp;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IfInfoTest {
+
+    @Test
+    public void pinnedFieldsWinPerField() {
+        final IfInfo pinned = new IfInfo(null, "Uplink to AS64500", null);
+        final IfInfo live = new IfInfo("eth0", "tmp-patched", 10000L);
+
+        final IfInfo merged = IfInfo.merge(pinned, live);
+
+        assertThat(merged.name()).isEqualTo("eth0");                  // live fills
+        assertThat(merged.alias()).isEqualTo("Uplink to AS64500");    // pinned wins
+        assertThat(merged.highSpeed()).isEqualTo(10000L);             // live fills
+    }
+
+    @Test
+    public void fileOnlyAndSnmpOnlyPassThrough() {
+        final IfInfo only = new IfInfo("eth0", null, null);
+
+        assertThat(IfInfo.merge(only, null)).isEqualTo(only);
+        assertThat(IfInfo.merge(null, only)).isEqualTo(only);
+    }
+
+    @Test
+    public void neitherYieldsNull() {
+        assertThat(IfInfo.merge(null, null)).isNull();
+    }
+
+    @Test
+    public void fullyPinnedIgnoresLive() {
+        final IfInfo pinned = new IfInfo("eth9", "pinned", 42L);
+        final IfInfo live = new IfInfo("eth0", "live", 10000L);
+
+        assertThat(IfInfo.merge(pinned, live)).isEqualTo(pinned);
+    }
+}

--- a/src/test/java/org/riptide/snmp/StaticInterfaceEnricherTest.java
+++ b/src/test/java/org/riptide/snmp/StaticInterfaceEnricherTest.java
@@ -5,10 +5,8 @@
 
 package org.riptide.snmp;
 
-
 import com.codahale.metrics.MetricRegistry;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.mapstruct.factory.Mappers;
 import org.mockito.Mockito;
 import org.riptide.flows.parser.data.Flow;
@@ -22,21 +20,23 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.net.InetAddress;
-import java.nio.file.Path;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+/**
+ * The enrichment ladder's middle rung on its own: a node with a static interface map
+ * and no SNMP block enriches without any reachable agent.
+ */
 @SpringBootTest(properties = {
-        "riptide.nodes.test-agent.subnet-address=127.0.0.1/24",
-        "riptide.nodes.test-agent.snmp.port=12345",
-        "riptide.nodes.test-agent.snmp.snmp-version=v2c",
-        "riptide.nodes.test-agent.snmp.community=" + TestSnmpAgent.COMMUNITY,
-        // enrichment-ladder per-field pin: static alias overrides SNMP, rest is live
-        "riptide.nodes.test-agent.interfaces.1.alias=Uplink pinned by file"
+        "riptide.nodes.static-only.subnet-address=127.0.0.1/24",
+        "riptide.nodes.static-only.interfaces.1.name=eth0",
+        "riptide.nodes.static-only.interfaces.1.alias=Uplink to AS64500",
+        "riptide.nodes.static-only.interfaces.1.high-speed=10000",
+        "riptide.nodes.static-only.interfaces.2.name=lo0"
 })
-public class SnmpEnricherTest {
+public class StaticInterfaceEnricherTest {
 
     private final MetricRegistry metricRegistry = new MetricRegistry();
 
@@ -49,12 +49,7 @@ public class SnmpEnricherTest {
     private final EnrichedFlow.FlowMapper flowMapper = Mappers.getMapper(EnrichedFlow.FlowMapper.class);
 
     @Test
-    public void testEnrichment(@TempDir Path temporaryFolder) throws Exception {
-        final TestSnmpAgent snmpAgent = new TestSnmpAgent("127.0.0.1/12345", temporaryFolder);
-        snmpAgent.start();
-        snmpAgent.registerIfTable();
-        snmpAgent.registerIfXTable();
-
+    public void staticMappingEnrichesWithoutSnmp() throws Exception {
         final var enrichers = List.<Enricher>of(new SnmpEnricher(this.snmpService, this.nodeRegistry));
         final var repository = new TestRepository(metricRegistry);
         final var pipeline = new Pipeline(enrichers, repository.asPersister(), this.metricRegistry, this.flowMapper);
@@ -65,23 +60,15 @@ public class SnmpEnricherTest {
         when(flow.getInputSnmp()).thenReturn(1);
         when(flow.getOutputSnmp()).thenReturn(2);
 
-        final var source = new Source("here", InetAddress.getByName("127.0.0.1"));
-
-        pipeline.process(source, List.of(flow));
-
-        snmpAgent.stop();
+        pipeline.process(new Source("here", InetAddress.getByName("127.0.0.1")), List.of(flow));
 
         assertThat(repository.count()).isEqualTo(1);
         assertThat(repository.flows()).allSatisfy(enrichedFlow -> {
-            assertThat(enrichedFlow.getInputSnmp()).isEqualTo(1);
-            assertThat(enrichedFlow.getOutputSnmp()).isEqualTo(2);
-            assertThat(enrichedFlow.getInputSnmpIfName()).isEqualTo("eth0-x");
-            assertThat(enrichedFlow.getInputSnmpIfAlias()).isEqualTo("Uplink pinned by file");
-            assertThat(enrichedFlow.getInputSnmpIfSpeed()).isEqualTo(14L);
-            assertThat(enrichedFlow.getOutputSnmpIfName()).isEqualTo("lo0-x");
-            assertThat(enrichedFlow.getOutputSnmpIfAlias()).isEqualTo("My loopback interface");
-            assertThat(enrichedFlow.getOutputSnmpIfSpeed()).isEqualTo(34L);
+            assertThat(enrichedFlow.getInputSnmpIfName()).isEqualTo("eth0");
+            assertThat(enrichedFlow.getInputSnmpIfAlias()).isEqualTo("Uplink to AS64500");
+            assertThat(enrichedFlow.getInputSnmpIfSpeed()).isEqualTo(10000L);
+            assertThat(enrichedFlow.getOutputSnmpIfName()).isEqualTo("lo0");
+            assertThat(enrichedFlow.getOutputSnmpIfAlias()).isNull();
         });
     }
 }
-


### PR DESCRIPTION
First rung of the **enrichment ladder** (epic #195, `enrichment-ladder` OpenSpec change).

## What
- `riptide.nodes.<name>.interfaces.<ifIndex> = {name, alias, high-speed}` — static interface metadata on the node
- **Per-field pin** (`IfInfo.merge`): file fields override live SNMP where present, SNMP fills the rest, raw ifIndex stays the floor
- Works **without** an `snmp` block — the middle rung for SNMP-less environments
- Docs: the ladder as a documented degradation contract + precedence table

## Verified
- `SnmpEnricherTest` (real snmp4j agent): pinned alias from file + name/speed from live SNMP in one flow
- `StaticInterfaceEnricherTest`: full pipeline, no agent, static values persist
- `IfInfoTest`: merge matrix (file-only / live-only / per-field / neither)
- Full `mvn verify` green (all gates)

Closes #196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)