### PR TITLE
feat(enrichment): static BGP/routing mapping fills and names AS data

### DIFF
--- a/docs/docs/configuration/routing.md
+++ b/docs/docs/configuration/routing.md
@@ -1,0 +1,35 @@
+---
+sidebar_position: 5
+title: Routing & AS mapping
+---
+
+# Routing & AS mapping
+
+A static BGP/routing mapping — the [enrichment ladder's](../enrichment.md#the-enrichment-ladder)
+middle rung for AS data. Two composable shapes:
+
+```yaml
+riptide:
+  routing:
+    prefixes:                    # longest prefix wins, over src AND dst addresses
+      "203.0.113.0/24": { asn: 64500, org: "Example Carrier" }
+      "2001:db8::/32":  { asn: 64501, org: "Example IX" }
+    as-names:                    # names for AS numbers, wherever they came from
+      64500: "Example Carrier"
+      65001: "Peering Partner"
+```
+
+## Semantics
+
+- **`prefixes`** fills `srcAs`/`dstAs` **only when the exporter sent `0` or nothing** —
+  a nonzero exporter-provided AS number always wins (the router's own BGP view is
+  authoritative when it speaks). The matched entry's `org` is persisted as
+  `srcAsOrg`/`dstAsOrg`.
+- **`as-names`** names whatever AS number the flow ends up with — exporter-provided or
+  prefix-filled. It never overwrites an org the prefix table already set.
+- Longest prefix wins, IPv4 and IPv6 alike; duplicate prefixes are impossible (map keys).
+- An invalid prefix fails startup with the offending key named.
+- With neither map configured the enricher is a no-op.
+
+Use `prefixes` when your exporters don't fill AS fields; use `as-names` when they do and
+you just want readable names in dashboards.

--- a/docs/docs/enrichment.md
+++ b/docs/docs/enrichment.md
@@ -78,6 +78,12 @@ riptide.enricher.hostnames.enabled=true
 The enricher is on unless disabled; the bundled `application.properties` ships with it
 set to `false`.
 
+## AS numbers and names
+
+The static [routing mapping](configuration/routing.md) fills `srcAs`/`dstAs` when the
+exporter sent zeros (nonzero exporter values always win) and resolves AS names/orgs
+into `srcAsOrg`/`dstAsOrg`.
+
 ## Classification
 
 Flows are classified by a rule engine (application naming). The rule source is any

--- a/src/main/java/org/riptide/pipeline/EnrichedFlow.java
+++ b/src/main/java/org/riptide/pipeline/EnrichedFlow.java
@@ -32,6 +32,7 @@ public class EnrichedFlow {
     private InetAddress dstAddr;
     private String dstAddrHostname;
     private Long dstAs;
+    private String dstAsOrg;
     private Integer dstMaskLen;
     private Integer dstPort;
     private Integer engineId;
@@ -53,6 +54,7 @@ public class EnrichedFlow {
     private InetAddress srcAddr;
     private String srcAddrHostname;
     private Long srcAs;
+    private String srcAsOrg;
     private Integer srcMaskLen;
     private Integer srcPort;
     private Integer tcpFlags;
@@ -96,6 +98,8 @@ public class EnrichedFlow {
         @Mapping(target = "outputSnmpIfName", ignore = true)
         @Mapping(target = "outputSnmpIfAlias", ignore = true)
         @Mapping(target = "outputSnmpIfSpeed", ignore = true)
+        @Mapping(target = "srcAsOrg", ignore = true)
+        @Mapping(target = "dstAsOrg", ignore = true)
         @Mapping(target = "srcAddrHostname", ignore = true)
         @Mapping(target = "dstAddrHostname", ignore = true)
         @Mapping(target = "nextHopHostname", ignore = true)

--- a/src/main/java/org/riptide/repository/clickhouse/ClickhouseFlow.java
+++ b/src/main/java/org/riptide/repository/clickhouse/ClickhouseFlow.java
@@ -38,12 +38,14 @@ public class ClickhouseFlow {
     private Long outputSnmpIfSpeed;
 
     private long srcAs;
+    private String srcAsOrg;
     private Inet6Address srcAddr;
     private int srcMaskLen;
     private String srcAddrHostname;
     private int srcPort;
 
     private long dstAs;
+    private String dstAsOrg;
     private Inet6Address dstAddr;
     private int dstMaskLen;
     private String dstAddrHostname;

--- a/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
+++ b/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
@@ -103,12 +103,14 @@ public class ClickhouseRepository implements FlowRepository {
             outputSnmpIfSpeed Nullable(UInt32),
     
             srcAs UInt64,
+            srcAsOrg Nullable(String),
             srcAddr IPv6,
             srcMaskLen UInt8,
             srcAddrHostname Nullable(String),
             srcPort UInt16,
     
             dstAs UInt64,
+            dstAsOrg Nullable(String),
             dstAddr IPv6,
             dstMaskLen UInt8,
             dstAddrHostname Nullable(String),

--- a/src/main/java/org/riptide/routing/RoutingConfig.java
+++ b/src/main/java/org/riptide/routing/RoutingConfig.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.routing;
+
+import inet.ipaddr.IPAddressString;
+import jakarta.annotation.PostConstruct;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Static BGP/routing mapping — the enrichment ladder's middle rung for AS data.
+ *
+ * <p>{@code prefixes} maps CIDR prefixes to AS number and organisation (longest prefix
+ * wins; map keys are unique, so ambiguity cannot arise). {@code as-names} maps AS
+ * numbers to names for exporters that already fill AS fields. The two compose: prefix
+ * fill first, then names apply to whatever number the flow ends up with.</p>
+ */
+@Data
+@ConfigurationProperties(prefix = "riptide.routing")
+public class RoutingConfig {
+
+    /** Prefix → AS number/organisation, e.g. {@code "203.0.113.0/24": {asn: 64500, org: "Example"}}. */
+    private Map<String, PrefixInfo> prefixes = new HashMap<>();
+
+    /** AS number → display name, applied to exporter-provided or prefix-filled numbers. */
+    private Map<Long, String> asNames = new HashMap<>();
+
+    private List<ParsedPrefix> parsed = List.of();
+
+    public record PrefixInfo(Long asn, String org) {
+    }
+
+    record ParsedPrefix(IPAddressString prefix, int prefixLength, PrefixInfo info) {
+    }
+
+    @PostConstruct
+    void parsePrefixes() {
+        final List<ParsedPrefix> result = new ArrayList<>(this.prefixes.size());
+        for (final Map.Entry<String, PrefixInfo> entry : this.prefixes.entrySet()) {
+            final IPAddressString prefix = new IPAddressString(entry.getKey());
+            if (prefix.getAddress() == null) {
+                throw new IllegalStateException("riptide.routing.prefixes: '%s' is not a valid prefix".formatted(entry.getKey()));
+            }
+            final Integer length = prefix.getNetworkPrefixLength();
+            result.add(new ParsedPrefix(prefix, length != null ? length : prefix.getAddress().getBitCount(), entry.getValue()));
+        }
+        this.parsed = List.copyOf(result);
+    }
+
+    /** Longest-prefix match, same routing-table semantics as node matching. */
+    Optional<PrefixInfo> lookupPrefix(final IPAddressString address) {
+        return this.parsed.stream()
+                .filter(entry -> entry.prefix().contains(address))
+                .max(Comparator.comparingInt(ParsedPrefix::prefixLength))
+                .map(ParsedPrefix::info);
+    }
+
+    Optional<String> lookupAsName(final Long asn) {
+        return Optional.ofNullable(asn).map(this.asNames::get);
+    }
+
+    boolean isEmpty() {
+        return this.parsed.isEmpty() && this.asNames.isEmpty();
+    }
+}

--- a/src/main/java/org/riptide/routing/RoutingEnricher.java
+++ b/src/main/java/org/riptide/routing/RoutingEnricher.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.routing;
+
+import inet.ipaddr.IPAddressString;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.riptide.pipeline.EnrichedFlow;
+import org.riptide.pipeline.Enricher;
+import org.riptide.pipeline.Source;
+import org.springframework.stereotype.Component;
+
+import java.net.InetAddress;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Fills and names AS data from the static routing mapping. A <b>nonzero</b>
+ * exporter-provided AS number always wins — the prefix mapping only fills zeros/absent
+ * values. Names apply to the resulting number regardless of its origin. Without any
+ * configured mapping this enricher is a no-op.
+ */
+@Component
+@RequiredArgsConstructor
+public class RoutingEnricher extends Enricher.Single {
+
+    @NonNull
+    private final RoutingConfig routingConfig;
+
+    @Override
+    protected CompletableFuture<Void> enrich(final Source source, final EnrichedFlow flow) {
+        if (!this.routingConfig.isEmpty()) {
+            enrichSide(flow.getSrcAddr(), flow::getSrcAs, flow::setSrcAs, flow::getSrcAsOrg, flow::setSrcAsOrg);
+            enrichSide(flow.getDstAddr(), flow::getDstAs, flow::setDstAs, flow::getDstAsOrg, flow::setDstAsOrg);
+        }
+        return CompletableFuture.completedFuture(null);
+    }
+
+    private void enrichSide(final InetAddress address, final Supplier<Long> getAs,
+                            final Consumer<Long> setAs, final Supplier<String> getOrg, final Consumer<String> setOrg) {
+        // 1. fill AS number and org from the prefix table — only when the exporter sent 0/absent
+        if (address != null && (getAs.get() == null || getAs.get() == 0)) {
+            this.routingConfig.lookupPrefix(new IPAddressString(address.getHostAddress())).ifPresent(info -> {
+                if (info.asn() != null) {
+                    setAs.accept(info.asn());
+                }
+                if (info.org() != null) {
+                    setOrg.accept(info.org());
+                }
+            });
+        }
+        // 2. name whatever number the flow ends up with (exporter-provided or just
+        // filled) — a prefix-provided org is not overwritten
+        final Long effective = getAs.get();
+        if (effective != null && effective != 0 && getOrg.get() == null) {
+            this.routingConfig.lookupAsName(effective).ifPresent(setOrg);
+        }
+    }
+}

--- a/src/test/java/org/riptide/routing/RoutingEnricherTest.java
+++ b/src/test/java/org/riptide/routing/RoutingEnricherTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.routing;
+
+import org.junit.jupiter.api.Test;
+import org.riptide.pipeline.EnrichedFlow;
+import org.riptide.pipeline.Source;
+import org.riptide.routing.RoutingConfig.PrefixInfo;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class RoutingEnricherTest {
+
+    private static RoutingConfig config(final Map<String, PrefixInfo> prefixes, final Map<Long, String> asNames) {
+        final RoutingConfig config = new RoutingConfig();
+        config.setPrefixes(prefixes);
+        config.setAsNames(asNames);
+        config.parsePrefixes();
+        return config;
+    }
+
+    private static EnrichedFlow flow(final String src, final Long srcAs) throws UnknownHostException {
+        return EnrichedFlow.builder()
+                .srcAddr(InetAddress.getByName(src))
+                .dstAddr(InetAddress.getByName("198.51.100.1"))
+                .srcAs(srcAs)
+                .build();
+    }
+
+    private static void enrich(final RoutingConfig config, final EnrichedFlow flow) throws Exception {
+        new RoutingEnricher(config)
+                .enrich(new Source("here", InetAddress.getByName("127.0.0.1")), flow)
+                .get();
+    }
+
+    @Test
+    public void exporterZeroIsFilledFromPrefix() throws Exception {
+        final RoutingConfig config = config(
+                Map.of("203.0.113.0/24", new PrefixInfo(64500L, "Example Carrier")), Map.of());
+        final EnrichedFlow flow = flow("203.0.113.7", 0L);
+
+        enrich(config, flow);
+
+        assertThat(flow.getSrcAs()).isEqualTo(64500L);
+        assertThat(flow.getSrcAsOrg()).isEqualTo("Example Carrier");
+    }
+
+    @Test
+    public void exporterProvidedAsWinsAndGetsNamed() throws Exception {
+        final RoutingConfig config = config(
+                Map.of("203.0.113.0/24", new PrefixInfo(64500L, "Wrong")),
+                Map.of(65001L, "Exporter Said So"));
+        final EnrichedFlow flow = flow("203.0.113.7", 65001L);
+
+        enrich(config, flow);
+
+        assertThat(flow.getSrcAs()).isEqualTo(65001L);
+        assertThat(flow.getSrcAsOrg()).isEqualTo("Exporter Said So");
+    }
+
+    @Test
+    public void longestPrefixWinsInEitherInsertionOrder() throws Exception {
+        for (final boolean coarseFirst : new boolean[]{true, false}) {
+            final Map<String, PrefixInfo> prefixes = new LinkedHashMap<>();
+            if (coarseFirst) {
+                prefixes.put("10.0.0.0/8", new PrefixInfo(64500L, "coarse"));
+                prefixes.put("10.20.0.0/16", new PrefixInfo(64501L, "fine"));
+            } else {
+                prefixes.put("10.20.0.0/16", new PrefixInfo(64501L, "fine"));
+                prefixes.put("10.0.0.0/8", new PrefixInfo(64500L, "coarse"));
+            }
+            final EnrichedFlow flow = flow("10.20.30.5", 0L);
+
+            enrich(config(prefixes, Map.of()), flow);
+
+            assertThat(flow.getSrcAs()).isEqualTo(64501L);
+        }
+    }
+
+    @Test
+    public void ipv6PrefixesWork() throws Exception {
+        final RoutingConfig config = config(
+                Map.of("2001:db8::/32", new PrefixInfo(64501L, "Example IX")), Map.of());
+        final EnrichedFlow flow = flow("2001:db8::42", null);
+
+        enrich(config, flow);
+
+        assertThat(flow.getSrcAs()).isEqualTo(64501L);
+        assertThat(flow.getSrcAsOrg()).isEqualTo("Example IX");
+    }
+
+    @Test
+    public void prefixOrgIsNotOverwrittenByAsNames() throws Exception {
+        final RoutingConfig config = config(
+                Map.of("203.0.113.0/24", new PrefixInfo(64500L, "From Prefix")),
+                Map.of(64500L, "From As-Names"));
+        final EnrichedFlow flow = flow("203.0.113.7", 0L);
+
+        enrich(config, flow);
+
+        assertThat(flow.getSrcAsOrg()).isEqualTo("From Prefix");
+    }
+
+    @Test
+    public void noConfigurationIsANoOp() throws Exception {
+        final RoutingConfig config = config(Map.of(), Map.of());
+        final EnrichedFlow flow = flow("203.0.113.7", 0L);
+
+        enrich(config, flow);
+
+        assertThat(flow.getSrcAs()).isEqualTo(0L);
+        assertThat(flow.getSrcAsOrg()).isNull();
+    }
+
+    @Test
+    public void invalidPrefixFailsStartup() {
+        assertThatThrownBy(() -> config(Map.of("not-a-prefix!", new PrefixInfo(1L, "x")), Map.of()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("not-a-prefix!");
+    }
+}


### PR DESCRIPTION
Second rung of the **enrichment ladder** (epic #195) — and the answer to #56, open since 2023.

## What
`riptide.routing` with two composable shapes:
- **`prefixes`** — prefix → `{asn, org}`, longest-prefix over src *and* dst (IPv4+IPv6, same routing-table semantics as node matching; duplicate prefixes impossible — map keys). Fills `srcAs`/`dstAs` **only when the exporter sent 0/absent**: a nonzero exporter AS always wins.
- **`as-names`** — asn → name for exporters that already fill AS fields; composes with prefix fill and never overwrites a prefix-provided org.

New persisted columns `srcAsOrg`/`dstAsOrg` (free under `CREATE OR REPLACE`). Invalid prefixes fail startup naming the key; unconfigured = no-op.

## Verified
Seven scenario tests mirroring the `flow-enrichment` spec: fill-zeros · exporter-wins+naming · longest-prefix **in both insertion orders** · IPv6 · prefix-org precedence over as-names · no-op · invalid-prefix startup failure. Full `mvn verify` green (573 tests, all gates). Docs: new *Routing & AS mapping* configuration page + ladder cross-links.

Closes #197. Closes #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)