### PR TITLE
fix(routing): canonicalize prefix keys and fail fast on duplicate blocks

### DIFF
--- a/docs/docs/configuration/routing.md
+++ b/docs/docs/configuration/routing.md
@@ -27,9 +27,13 @@ riptide:
   `srcAsOrg`/`dstAsOrg`.
 - **`as-names`** names whatever AS number the flow ends up with — exporter-provided or
   prefix-filled. It never overwrites an org the prefix table already set.
-- Longest prefix wins, IPv4 and IPv6 alike; duplicate prefixes are impossible (map keys).
+- Longest prefix wins, IPv4 and IPv6 alike. Keys are canonicalized to their prefix
+  block at startup (`10.0.0.5/24` means `10.0.0.0/24`); two keys resolving to the same
+  block fail startup with both keys named.
 - An invalid prefix fails startup with the offending key named.
 - With neither map configured the enricher is a no-op.
+- In `.properties` form, prefix keys contain dots and need bracket escaping:
+  `riptide.routing.prefixes.[203.0.113.0/24].asn=64500` — prefer YAML for this section.
 
 Use `prefixes` when your exporters don't fill AS fields; use `as-names` when they do and
 you just want readable names in dashboards.

--- a/src/main/java/org/riptide/routing/RoutingConfig.java
+++ b/src/main/java/org/riptide/routing/RoutingConfig.java
@@ -5,9 +5,11 @@
 
 package org.riptide.routing;
 
+import inet.ipaddr.IPAddress;
 import inet.ipaddr.IPAddressString;
 import jakarta.annotation.PostConstruct;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.ArrayList;
@@ -21,18 +23,23 @@ import java.util.Optional;
  * Static BGP/routing mapping — the enrichment ladder's middle rung for AS data.
  *
  * <p>{@code prefixes} maps CIDR prefixes to AS number and organisation (longest prefix
- * wins; map keys are unique, so ambiguity cannot arise). {@code as-names} maps AS
- * numbers to names for exporters that already fill AS fields. The two compose: prefix
- * fill first, then names apply to whatever number the flow ends up with.</p>
+ * wins). Keys are canonicalized to their prefix block at startup — the host form
+ * {@code 10.0.0.5/24} means the same as {@code 10.0.0.0/24} — and two keys resolving to
+ * the same block fail startup. {@code as-names} maps AS numbers to names for exporters
+ * that already fill AS fields. The two compose: prefix fill first, then names apply to
+ * whatever number the flow ends up with.</p>
  */
-@Data
 @ConfigurationProperties(prefix = "riptide.routing")
 public class RoutingConfig {
 
     /** Prefix → AS number/organisation, e.g. {@code "203.0.113.0/24": {asn: 64500, org: "Example"}}. */
+    @Getter
+    @Setter
     private Map<String, PrefixInfo> prefixes = new HashMap<>();
 
     /** AS number → display name, applied to exporter-provided or prefix-filled numbers. */
+    @Getter
+    @Setter
     private Map<Long, String> asNames = new HashMap<>();
 
     private List<ParsedPrefix> parsed = List.of();
@@ -40,19 +47,31 @@ public class RoutingConfig {
     public record PrefixInfo(Long asn, String org) {
     }
 
-    record ParsedPrefix(IPAddressString prefix, int prefixLength, PrefixInfo info) {
+    private record ParsedPrefix(IPAddressString prefix, int prefixLength, PrefixInfo info) {
     }
 
     @PostConstruct
     void parsePrefixes() {
+        final Map<String, String> seenBlocks = new HashMap<>();
         final List<ParsedPrefix> result = new ArrayList<>(this.prefixes.size());
         for (final Map.Entry<String, PrefixInfo> entry : this.prefixes.entrySet()) {
-            final IPAddressString prefix = new IPAddressString(entry.getKey());
-            if (prefix.getAddress() == null) {
+            final IPAddressString raw = new IPAddressString(entry.getKey());
+            if (raw.getAddress() == null) {
                 throw new IllegalStateException("riptide.routing.prefixes: '%s' is not a valid prefix".formatted(entry.getKey()));
             }
-            final Integer length = prefix.getNetworkPrefixLength();
-            result.add(new ParsedPrefix(prefix, length != null ? length : prefix.getAddress().getBitCount(), entry.getValue()));
+            // canonicalize: the host form 10.0.0.5/24 must match its whole /24 block,
+            // not just itself (IPAddressString.contains treats a host-with-prefix as a
+            // single address)
+            final IPAddress block = raw.getAddress().toPrefixBlock();
+            final IPAddressString canonical = new IPAddressString(block.toString());
+            final String other = seenBlocks.putIfAbsent(block.toString(), entry.getKey());
+            if (other != null) {
+                throw new IllegalStateException(("riptide.routing.prefixes: '%s' and '%s' are the same prefix block (%s) "
+                        + "— matching between them would be arbitrary. Keep one.")
+                        .formatted(other, entry.getKey(), block));
+            }
+            final Integer length = block.getNetworkPrefixLength();
+            result.add(new ParsedPrefix(canonical, length != null ? length : block.getBitCount(), entry.getValue()));
         }
         this.parsed = List.copyOf(result);
     }

--- a/src/test/java/org/riptide/routing/RoutingEnricherTest.java
+++ b/src/test/java/org/riptide/routing/RoutingEnricherTest.java
@@ -122,6 +122,31 @@ public class RoutingEnricherTest {
     }
 
     @Test
+    public void hostFormPrefixMatchesItsWholeBlock() throws Exception {
+        // interface notation pasted from a router config: 10.0.0.5/24 means the /24 block
+        final RoutingConfig config = config(
+                Map.of("10.0.0.5/24", new PrefixInfo(64500L, "Pasted From Router")), Map.of());
+        final EnrichedFlow flow = flow("10.0.0.7", 0L);
+
+        enrich(config, flow);
+
+        assertThat(flow.getSrcAs()).isEqualTo(64500L);
+        assertThat(flow.getSrcAsOrg()).isEqualTo("Pasted From Router");
+    }
+
+    @Test
+    public void duplicateBlocksFailStartupNamingBothKeys() {
+        final Map<String, PrefixInfo> prefixes = new LinkedHashMap<>();
+        prefixes.put("10.0.0.0/24", new PrefixInfo(64500L, "a"));
+        prefixes.put("10.0.0.5/24", new PrefixInfo(64501L, "b"));
+
+        assertThatThrownBy(() -> config(prefixes, Map.of()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("10.0.0.0/24")
+                .hasMessageContaining("10.0.0.5/24");
+    }
+
+    @Test
     public void invalidPrefixFailsStartup() {
         assertThatThrownBy(() -> config(Map.of("not-a-prefix!", new PrefixInfo(1L, "x")), Map.of()))
                 .isInstanceOf(IllegalStateException.class)


### PR DESCRIPTION
Corrections from the retroactive `/code-review medium` on #198/#199 (findings 1–3; finding 4 — per-flow linear scan — stays accepted-by-design per the change's design doc).

## The bug (confirmed with a repro)
`"10.0.0.5/24"` — interface notation operators paste from router configs — passed startup validation but **silently matched only itself**: `IPAddressString.contains()` treats a host-with-prefix as a single address, not its block. Quiet non-enrichment, no error, no log.

## The fix
- **Canonicalize** every prefix key to its block (`toPrefixBlock()`) at parse — `10.0.0.5/24` now means `10.0.0.0/24`, matching operator intent
- **Fail fast on duplicate blocks** with both offending keys named (mirrors `NodeRegistry` validation); the docs' false 'duplicates are impossible' claim corrected
- **Encapsulation**: `RoutingConfig` drops `@Data` — the parsed snapshot is no longer publicly settable (validation bypass) nor in equals/toString
- **Docs**: bracket-escaping note for `.properties` users; YAML recommended

## Verified
Two new regression tests (host-form matches its block · duplicate blocks refused naming both keys); 9/9 routing tests; full `mvn verify` green; spec scenario added to the open `enrichment-ladder` change so the archive promotes it.

Refs #199, #197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)