### PR TITLE
release: merge v0.1.0 version commits back to main

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.riptide.flows</groupId>
     <artifactId>riptide-flows</artifactId>
-    <version>0.0.4-SNAPSHOT</version>
+    <version>0.1.0</version>
     <name>riptide-flows</name>
     <description>NetFlow analysis engine</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.riptide.flows</groupId>
     <artifactId>riptide-flows</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1-SNAPSHOT</version>
     <name>riptide-flows</name>
     <description>NetFlow analysis engine</description>
 


### PR DESCRIPTION
Brings the two release commits to main: pom 0.1.0 (tagged v0.1.0) and the 0.1.1-SNAPSHOT bump. The `release` branch stays — it is where future releases are cut from (`make release`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)