### PR TITLE
ci: Add github-actions ecosystem to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,15 @@
 
 version: 2
 updates:
+  - package-ecosystem: "github-actions" # keeps SHA pins + semver comments current
+    directory: "/"
+    target-branch: "main"
+    labels:
+      - "dependency update"
+    commit-message:
+      prefix: "ci"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "maven" # See documentation for possible values
     directory: "/" # Location of package manifests
     target-branch: "main"


### PR DESCRIPTION
Adds the `github-actions` ecosystem so Dependabot keeps the SHA-pinned actions and their semver comments current. Motivated by the Node.js 20 deprecation warnings from the docker actions during the v0.1.0 release run — those pins are behind.

Reviewed inline (config-only change): ecosystem/directory/prefix all check out against the Dependabot schema; `ci` prefix matches Conventional Commits for workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)