### PR TITLE
refactor: Source carries ExporterIdentity (sFlow phase A, #159)

### DIFF
--- a/src/main/java/org/riptide/flows/parser/FlowPacket.java
+++ b/src/main/java/org/riptide/flows/parser/FlowPacket.java
@@ -6,12 +6,23 @@
 package org.riptide.flows.parser;
 
 import org.riptide.flows.parser.data.Flow;
+import org.riptide.pipeline.ExporterIdentity;
 
+import java.net.InetAddress;
 import java.time.Instant;
 import java.util.stream.Stream;
 
 public interface FlowPacket {
     Stream<Flow> buildFlows(Instant receivedAt);
+
+    /**
+     * The exporter identity for the flows in this packet. Defaults to the UDP source
+     * scoped by observation domain; protocols whose identity lives in the payload
+     * (sFlow: agent address + sub-agent ID) override this.
+     */
+    default ExporterIdentity identity(final InetAddress remoteAddress) {
+        return new ExporterIdentity.NetflowIpfix(remoteAddress, this.getObservationDomainId());
+    }
 
     /** Returns the observation domain ID as specified by the underlying packet used to generate these records.
      *

--- a/src/main/java/org/riptide/flows/parser/ParserBase.java
+++ b/src/main/java/org/riptide/flows/parser/ParserBase.java
@@ -146,7 +146,7 @@ public abstract class ParserBase implements Parser {
             final Runnable dispatch = () -> {
                 log.trace("Received flow: {}", flow);
 
-                this.dispatcher.accept(new Source(this.location, session.getRemoteAddress(), packet.getObservationDomainId()), flow);
+                this.dispatcher.accept(new Source(this.location, packet.identity(session.getRemoteAddress())), flow);
 
                 this.recordsDispatched.mark();
             };

--- a/src/main/java/org/riptide/pipeline/EnrichedFlow.java
+++ b/src/main/java/org/riptide/pipeline/EnrichedFlow.java
@@ -7,7 +7,6 @@ package org.riptide.pipeline;
 
 import lombok.Builder;
 import lombok.Data;
-import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.NullValueCheckStrategy;
@@ -106,8 +105,6 @@ public class EnrichedFlow {
 
         @Mapping(target = ".", source = "source")
         @Mapping(target = ".", source = "flow")
-        // used for node lookup only; not persisted on the flow (yet)
-        @BeanMapping(ignoreUnmappedSourceProperties = {"observationDomain"})
         public abstract EnrichedFlow enrichedFlow(Source source, Flow flow);
 
         protected String address(final InetAddress address) {

--- a/src/main/java/org/riptide/pipeline/ExporterIdentity.java
+++ b/src/main/java/org/riptide/pipeline/ExporterIdentity.java
@@ -19,6 +19,17 @@ import java.net.InetAddress;
  */
 public sealed interface ExporterIdentity {
 
+    /**
+     * The address identifying the device — payload-derived where the protocol says so
+     * (sFlow agent address), the UDP source otherwise. Used for classification,
+     * logging, and persistence; node matching uses the full identity.
+     */
+    InetAddress deviceAddress();
+
     record NetflowIpfix(InetAddress source, long observationDomain) implements ExporterIdentity {
+        @Override
+        public InetAddress deviceAddress() {
+            return this.source;
+        }
     }
 }

--- a/src/main/java/org/riptide/pipeline/Source.java
+++ b/src/main/java/org/riptide/pipeline/Source.java
@@ -5,32 +5,38 @@
 
 package org.riptide.pipeline;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.Setter;
-
 import java.net.InetAddress;
+import java.util.Objects;
 
-// TODO fooker: Do we need to source by SocketAddr?
-@Getter
-@Setter
-@AllArgsConstructor
 public class Source {
-    @NonNull
     private final String location;
 
-    @NonNull
-    private final InetAddress exporterAddr;
+    private final ExporterIdentity identity;
 
-    /** Observation domain (IPFIX) / source ID (NetFlow v9); {@code 0} when the protocol has none. */
-    private final long observationDomain;
+    public Source(final String location, final ExporterIdentity identity) {
+        this.location = Objects.requireNonNull(location);
+        this.identity = Objects.requireNonNull(identity);
+    }
 
+    /** Convenience for protocols (and tests) without an observation-domain concept. */
     public Source(final String location, final InetAddress exporterAddr) {
-        this(location, exporterAddr, 0);
+        this(location, new ExporterIdentity.NetflowIpfix(exporterAddr, 0));
+    }
+
+    public String getLocation() {
+        return this.location;
     }
 
     public ExporterIdentity identity() {
-        return new ExporterIdentity.NetflowIpfix(this.exporterAddr, this.observationDomain);
+        return this.identity;
+    }
+
+    /**
+     * Derived from the identity's device address. Kept as a bean getter on purpose:
+     * {@code EnrichedFlow.FlowMapper} maps {@code Source} properties by name, so this
+     * accessor is what populates the persisted {@code exporterAddr} column.
+     */
+    public InetAddress getExporterAddr() {
+        return this.identity.deviceAddress();
     }
 }

--- a/src/test/java/org/riptide/pipeline/FlowMapperTest.java
+++ b/src/test/java/org/riptide/pipeline/FlowMapperTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.pipeline;
+
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import org.riptide.flows.parser.data.Flow;
+
+import java.net.InetAddress;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Pins the name-driven MapStruct mapping of {@link Source} properties into
+ * {@link EnrichedFlow}: {@code exporterAddr} and {@code location} are populated via
+ * property-name matching, so a rename on {@link Source} would otherwise fail silently
+ * (NULL exporterAddr in ClickHouse) instead of loudly.
+ */
+public class FlowMapperTest {
+
+    @Test
+    public void sourcePropertiesMapByName() throws Exception {
+        final var mapper = Mappers.getMapper(EnrichedFlow.FlowMapper.class);
+        final var source = new Source("here", InetAddress.getByName("203.0.113.9"));
+
+        final var enriched = mapper.enrichedFlow(source, mock(Flow.class));
+
+        assertThat(enriched.getExporterAddr()).isEqualTo("203.0.113.9");
+        assertThat(enriched.getLocation()).isEqualTo("here");
+    }
+
+    @Test
+    public void exporterAddrDerivesFromIdentity() throws Exception {
+        final var agent = InetAddress.getByName("10.1.1.1");
+        final var source = new Source("here", new ExporterIdentity.NetflowIpfix(agent, 42));
+
+        assertThat(source.getExporterAddr()).isEqualTo(agent);
+        assertThat(source.identity()).isEqualTo(new ExporterIdentity.NetflowIpfix(agent, 42));
+    }
+}


### PR DESCRIPTION
Phase A of the `sflow-support` plan for #159 — a **behavioral no-op** that unhardwires exporter identity from the UDP socket:

- `Source(location, ExporterIdentity)`; the 2-arg convenience ctor stays (`NetflowIpfix(addr, 0)`) so all existing test call sites compile unchanged
- `FlowPacket.identity(remote)` default method constructs `NetflowIpfix(remote, obsDomain)`; `ParserBase.transmit()` uses it — the future sFlow packet overrides it with payload `(agent_address, sub_agent_id)`
- `ExporterIdentity.deviceAddress()` on the sealed interface; `getExporterAddr()` survives as a derived bean getter because `EnrichedFlow.FlowMapper` maps `Source` properties **by name** — new `FlowMapperTest` pins that contract (silent-NULL landmine documented in the change's design.md)

Reviewed (medium, inline): no findings; removed-behavior audit covered the Lombok annotations and the per-call identity construction.

**Verification:** `make jar` → 577 tests, all gates green. e2e ledger reconciliation (asserts persisted `exporterAddr`) runs in CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)