### PR TITLE
feat: sFlow v5 ingestion (#159, phases B+C)

### DIFF
--- a/src/main/java/org/riptide/config/ReceiverConfig.java
+++ b/src/main/java/org/riptide/config/ReceiverConfig.java
@@ -21,6 +21,7 @@ import java.time.Duration;
         @JsonSubTypes.Type(value = ReceiverConfig.Neflow5Config.class, name = "netflow5"),
         @JsonSubTypes.Type(value = ReceiverConfig.Neflow9Config.class, name = "netflow9"),
         @JsonSubTypes.Type(value = ReceiverConfig.IpfixConfig.class, name = "ipfix"),
+        @JsonSubTypes.Type(value = ReceiverConfig.SflowConfig.class, name = "sflow"),
         @JsonSubTypes.Type(value = ReceiverConfig.MultiConfig.class, name = "multi"),
 })
 @Data
@@ -80,10 +81,21 @@ public abstract sealed class ReceiverConfig {
 
     @Data
     @EqualsAndHashCode(callSuper = true)
+    public static final class SflowConfig extends ReceiverConfig {
+
+        @Override
+        public <T> T accept(final Cases<T> cases) {
+            return cases.match(this);
+        }
+    }
+
+    @Data
+    @EqualsAndHashCode(callSuper = true)
     public static final class MultiConfig extends ReceiverConfig {
         boolean netflow5 = true;
         boolean netflow9 = true;
         boolean ipfix = true;
+        boolean sflow = true;
 
         Duration flowActiveTimeoutFallback = null;
         Duration flowInactiveTimeoutFallback = null;
@@ -101,6 +113,8 @@ public abstract sealed class ReceiverConfig {
         R match(Neflow9Config config);
 
         R match(IpfixConfig config);
+
+        R match(SflowConfig config);
 
         R match(MultiConfig config);
     }

--- a/src/main/java/org/riptide/flows/Daemon.java
+++ b/src/main/java/org/riptide/flows/Daemon.java
@@ -20,6 +20,7 @@ import org.riptide.flows.parser.data.Flow;
 import org.riptide.flows.parser.ipfix.IpfixTcpParser;
 import org.riptide.flows.parser.ipfix.IpfixUdpParser;
 import org.riptide.flows.parser.netflow5.Netflow5UdpParser;
+import org.riptide.flows.parser.sflow.SflowUdpParser;
 import org.riptide.flows.parser.netflow9.Netflow9UdpParser;
 import org.riptide.pipeline.FlowException;
 import org.riptide.pipeline.Pipeline;
@@ -109,11 +110,24 @@ public class Daemon implements ApplicationRunner {
                     }
 
                     @Override
+                    public Listener match(final ReceiverConfig.SflowConfig config) {
+                        final var parser = new SflowUdpParser(e.getKey(), dispatcher, location, metricRegistry);
+
+                        return new UdpListener(e.getKey(), parser, metricRegistry)
+                                .withPort(config.getPort())
+                                .withHost(config.getHost());
+                    }
+
+                    @Override
                     public Listener match(final ReceiverConfig.MultiConfig config) {
                         final var parsers = new HashSet<DispatchableUdpParser>();
 
                         if (config.isNetflow5()) {
                             parsers.add(new Netflow5UdpParser(e.getKey() + ":netflow5", dispatcher, location, metricRegistry));
+                        }
+
+                        if (config.isSflow()) {
+                            parsers.add(new SflowUdpParser(e.getKey() + ":sflow", dispatcher, location, metricRegistry));
                         }
 
                         if (config.isNetflow9()) {

--- a/src/main/java/org/riptide/flows/parser/Protocol.java
+++ b/src/main/java/org/riptide/flows/parser/Protocol.java
@@ -10,7 +10,8 @@ import java.util.Objects;
 public enum Protocol {
     NETFLOW5(org.riptide.flows.parser.netflow5.proto.Header.VERSION, "Netflow v5"),
     NETFLOW9(org.riptide.flows.parser.netflow9.proto.Header.VERSION, "Netflow v9"),
-    IPFIX(org.riptide.flows.parser.ipfix.proto.Header.VERSION, "IPFix");
+    IPFIX(org.riptide.flows.parser.ipfix.proto.Header.VERSION, "IPFix"),
+    SFLOW(org.riptide.flows.parser.sflow.proto.Datagram.VERSION, "sFlow v5");
 
     public final int version;
     public final String description;

--- a/src/main/java/org/riptide/flows/parser/sflow/SflowFlowBuilder.java
+++ b/src/main/java/org/riptide/flows/parser/sflow/SflowFlowBuilder.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.parser.sflow;
+
+import org.riptide.flows.parser.data.Flow;
+import org.riptide.flows.parser.sflow.proto.Datagram;
+import org.riptide.flows.parser.sflow.proto.FlowSample;
+import org.riptide.flows.parser.sflow.proto.PacketInfo;
+
+import java.net.InetAddress;
+import java.time.Instant;
+
+/**
+ * Maps one sFlow flow sample onto the {@link Flow} contract. Samples are point events,
+ * not cache records: first/last switched collapse to the receive time, and volume is
+ * the statistical estimate {@code frame_length × sampling_rate} /
+ * {@code packets = sampling_rate}. Missing decode results leave packet-level fields at
+ * their floor values — the flow is still emitted.
+ */
+public final class SflowFlowBuilder {
+
+    private SflowFlowBuilder() {
+    }
+
+    public static Flow buildFlow(final Instant receivedAt,
+                                 final Datagram datagram,
+                                 final FlowSample sample) {
+        final PacketInfo packet = sample.packet() != null ? sample.packet() : new PacketInfo();
+
+        return new Flow() {
+            @Override
+            public Instant getReceivedAt() {
+                return receivedAt;
+            }
+
+            @Override
+            public Instant getTimestamp() {
+                return receivedAt;
+            }
+
+            @Override
+            public FlowProtocol getFlowProtocol() {
+                return FlowProtocol.SFLOW;
+            }
+
+            @Override
+            public int getFlowRecords() {
+                return datagram.samples.size();
+            }
+
+            @Override
+            public long getFlowSeqNum() {
+                return sample.sequence;
+            }
+
+            @Override
+            public Instant getFirstSwitched() {
+                return receivedAt;
+            }
+
+            @Override
+            public Instant getLastSwitched() {
+                return receivedAt;
+            }
+
+            @Override
+            public int getInputSnmp() {
+                return sample.input.ifIndex();
+            }
+
+            @Override
+            public int getOutputSnmp() {
+                return sample.output.ifIndex();
+            }
+
+            @Override
+            public long getSrcAs() {
+                return sample.extendedGateway() != null ? sample.extendedGateway().srcAs() : 0;
+            }
+
+            @Override
+            public InetAddress getSrcAddr() {
+                return packet.srcAddr;
+            }
+
+            @Override
+            public int getSrcMaskLen() {
+                return sample.extendedRouter() != null ? sample.extendedRouter().srcMaskLen() : 0;
+            }
+
+            @Override
+            public int getSrcPort() {
+                return packet.srcPort != null ? packet.srcPort : 0;
+            }
+
+            @Override
+            public long getDstAs() {
+                return sample.extendedGateway() != null ? sample.extendedGateway().dstAs() : 0;
+            }
+
+            @Override
+            public InetAddress getDstAddr() {
+                return packet.dstAddr;
+            }
+
+            @Override
+            public int getDstMaskLen() {
+                return sample.extendedRouter() != null ? sample.extendedRouter().dstMaskLen() : 0;
+            }
+
+            @Override
+            public int getDstPort() {
+                return packet.dstPort != null ? packet.dstPort : 0;
+            }
+
+            @Override
+            public InetAddress getNextHop() {
+                if (sample.extendedRouter() != null) {
+                    return sample.extendedRouter().nextHop();
+                }
+                return sample.extendedGateway() != null ? sample.extendedGateway().nextHop() : null;
+            }
+
+            @Override
+            public long getBytes() {
+                return sample.frameLength() != null ? sample.frameLength() * sample.samplingRate : 0;
+            }
+
+            @Override
+            public long getPackets() {
+                return sample.samplingRate;
+            }
+
+            @Override
+            public Direction getDirection() {
+                return Direction.UNKNOWN;
+            }
+
+            @Override
+            public int getEngineId() {
+                return (int) datagram.subAgentId;
+            }
+
+            @Override
+            public int getEngineType() {
+                return 0;
+            }
+
+            @Override
+            public int getVlan() {
+                if (sample.extendedSwitch() != null) {
+                    return sample.extendedSwitch().srcVlan();
+                }
+                return packet.vlan != null ? packet.vlan : 0;
+            }
+
+            @Override
+            public int getIpProtocolVersion() {
+                return packet.ipVersion != null ? packet.ipVersion : 0;
+            }
+
+            @Override
+            public int getProtocol() {
+                return packet.protocol != null ? packet.protocol : 0;
+            }
+
+            @Override
+            public int getTcpFlags() {
+                return packet.tcpFlags != null ? packet.tcpFlags : 0;
+            }
+
+            @Override
+            public int getTos() {
+                return packet.tos != null ? packet.tos : 0;
+            }
+
+            @Override
+            public SamplingAlgorithm getSamplingAlgorithm() {
+                return SamplingAlgorithm.RandomNOutOfNSampling;
+            }
+
+            @Override
+            public double getSamplingInterval() {
+                return sample.samplingRate;
+            }
+        };
+    }
+}

--- a/src/main/java/org/riptide/flows/parser/sflow/SflowUdpParser.java
+++ b/src/main/java/org/riptide/flows/parser/sflow/SflowUdpParser.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.parser.sflow;
+
+import com.codahale.metrics.MetricRegistry;
+import io.netty.buffer.ByteBuf;
+import org.riptide.flows.listeners.multi.DispatchableUdpParser;
+import org.riptide.flows.parser.FlowPacket;
+import org.riptide.flows.parser.Protocol;
+import org.riptide.flows.parser.UdpParserBase;
+import org.riptide.flows.parser.data.Flow;
+import org.riptide.flows.parser.netflow9.Netflow9UdpParser;
+import org.riptide.flows.parser.session.Session;
+import org.riptide.flows.parser.session.UdpSessionManager;
+import org.riptide.flows.parser.sflow.proto.Datagram;
+import org.riptide.flows.utils.BufferUtils;
+import org.riptide.pipeline.Source;
+
+import java.net.InetSocketAddress;
+import java.util.function.BiConsumer;
+
+/**
+ * sFlow v5 (sflow.org spec; not RFC 3176 v4). Stateless on the wire — no templates —
+ * but the session still tracks datagram sequence numbers per sub-agent via
+ * {@link Datagram#getObservationDomainId()}.
+ */
+public class SflowUdpParser extends UdpParserBase implements DispatchableUdpParser {
+
+    public SflowUdpParser(final String name,
+                          final BiConsumer<Source, Flow> dispatcher,
+                          final String location,
+                          final MetricRegistry metricRegistry) {
+        super(Protocol.SFLOW, name, dispatcher, location, metricRegistry);
+    }
+
+    @Override
+    public boolean handles(final ByteBuf buffer) {
+        // XDR uint32 version 5: [00 00 00 05] — NetFlow/IPFIX carry uint16 versions,
+        // so their first two bytes are never zero
+        return buffer.readableBytes() >= 4 && BufferUtils.uint32(buffer) == Datagram.VERSION;
+    }
+
+    @Override
+    protected FlowPacket parse(final Session session,
+                               final ByteBuf buffer) throws Exception {
+        return new Datagram(buffer);
+    }
+
+    @Override
+    protected UdpSessionManager.SessionKey buildSessionKey(final InetSocketAddress remoteAddress,
+                                                           final InetSocketAddress localAddress) {
+        return new Netflow9UdpParser.SessionKey(remoteAddress.getAddress(), localAddress);
+    }
+}

--- a/src/main/java/org/riptide/flows/parser/sflow/proto/Datagram.java
+++ b/src/main/java/org/riptide/flows/parser/sflow/proto/Datagram.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.parser.sflow.proto;
+
+import com.google.common.base.MoreObjects;
+import io.netty.buffer.ByteBuf;
+import org.riptide.flows.parser.FlowPacket;
+import org.riptide.flows.parser.exceptions.InvalidPacketException;
+import org.riptide.flows.parser.data.Flow;
+import org.riptide.flows.parser.sflow.SflowFlowBuilder;
+import org.riptide.pipeline.ExporterIdentity;
+
+import java.net.InetAddress;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.riptide.flows.utils.BufferUtils.slice;
+import static org.riptide.flows.utils.BufferUtils.uint32;
+
+/**
+ * An sFlow v5 datagram (sflow_version_5.txt §5.1). Identity is carried in the payload:
+ * {@code agent_address} + {@code sub_agent_id}, not the UDP source. Sample types other
+ * than flow samples — counter samples arrive interleaved on real agents — are skipped
+ * by their XDR length without raising errors.
+ */
+public final class Datagram implements FlowPacket {
+
+    public static final int VERSION = 5;
+
+    /** Standard-enterprise sample formats (§5.3). */
+    private static final int SAMPLE_FLOW = 1;
+    private static final int SAMPLE_FLOW_EXPANDED = 3;
+
+    public final InetAddress agentAddress;
+    public final long subAgentId;
+    public final long sequence;
+    public final long uptime;
+
+    public final List<FlowSample> samples;
+
+    public Datagram(final ByteBuf buffer) throws InvalidPacketException {
+        final long version = uint32(buffer);
+        if (version != VERSION) {
+            throw new InvalidPacketException(buffer, "Invalid version: %d", version);
+        }
+
+        this.agentAddress = ExtendedData.address(buffer);
+        if (this.agentAddress == null) {
+            throw new InvalidPacketException(buffer, "Invalid agent address");
+        }
+        this.subAgentId = uint32(buffer);
+        this.sequence = uint32(buffer);
+        this.uptime = uint32(buffer);
+
+        final long count = uint32(buffer);
+        final List<FlowSample> samples = new ArrayList<>();
+        for (long i = 0; i < count; i++) {
+            if (buffer.readableBytes() < 8) {
+                throw new InvalidPacketException(buffer, "Truncated sample %d of %d", i + 1, count);
+            }
+            final long sampleType = uint32(buffer);
+            final int length = (int) uint32(buffer);
+            if (length < 0 || length > buffer.readableBytes()) {
+                throw new InvalidPacketException(buffer, "Invalid sample length: %d", length);
+            }
+            final ByteBuf sample = slice(buffer, length);
+
+            if ((sampleType >>> 12) != 0) {
+                continue; // vendor-specific sample: skip by length
+            }
+            switch ((int) (sampleType & 0xFFF)) {
+                case SAMPLE_FLOW -> samples.add(new FlowSample(sample, false));
+                case SAMPLE_FLOW_EXPANDED -> samples.add(new FlowSample(sample, true));
+                default -> {
+                    // counter samples and anything else: skip by length
+                }
+            }
+        }
+        this.samples = samples;
+    }
+
+    @Override
+    public Stream<Flow> buildFlows(final Instant receivedAt) {
+        return this.samples.stream()
+                .map(sample -> SflowFlowBuilder.buildFlow(receivedAt, this, sample));
+    }
+
+    @Override
+    public ExporterIdentity identity(final InetAddress remoteAddress) {
+        return new ExporterIdentity.Sflow(this.agentAddress, this.subAgentId);
+    }
+
+    @Override
+    public long getObservationDomainId() {
+        // scopes sequence tracking per sub-agent, mirroring observation domains
+        return this.subAgentId;
+    }
+
+    @Override
+    public long getSequenceNumber() {
+        return this.sequence;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("agentAddress", this.agentAddress)
+                .add("subAgentId", this.subAgentId)
+                .add("sequence", this.sequence)
+                .add("uptime", this.uptime)
+                .add("samples", this.samples)
+                .toString();
+    }
+}

--- a/src/main/java/org/riptide/flows/parser/sflow/proto/ExtendedData.java
+++ b/src/main/java/org/riptide/flows/parser/sflow/proto/ExtendedData.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.parser.sflow.proto;
+
+import io.netty.buffer.ByteBuf;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import static org.riptide.flows.utils.BufferUtils.bytes;
+import static org.riptide.flows.utils.BufferUtils.uint32;
+
+/**
+ * The extended flow-record structures riptide consumes (sflow_version_5.txt §5.2.6):
+ * switch (1001) for VLANs, router (1002) for next hop and masks, gateway (1003) for
+ * BGP AS data — the latter feeds the enrichment ladder's "nonzero exporter AS wins"
+ * rule. Each parses leniently: a malformed record yields {@code null} and the flow
+ * keeps the rest of its data.
+ */
+public final class ExtendedData {
+
+    public record Switch(int srcVlan, int dstVlan) {
+        static Switch parse(final ByteBuf b) {
+            if (b.readableBytes() < 16) {
+                return null;
+            }
+            final int srcVlan = (int) uint32(b);
+            uint32(b); // src priority
+            final int dstVlan = (int) uint32(b);
+            return new Switch(srcVlan, dstVlan);
+        }
+    }
+
+    public record Router(InetAddress nextHop, int srcMaskLen, int dstMaskLen) {
+        static Router parse(final ByteBuf b) {
+            final InetAddress nextHop = address(b);
+            if (nextHop == null || b.readableBytes() < 8) {
+                return null;
+            }
+            return new Router(nextHop, (int) uint32(b), (int) uint32(b));
+        }
+    }
+
+    public record Gateway(InetAddress nextHop, long srcAs, long dstAs) {
+        static Gateway parse(final ByteBuf b) {
+            final InetAddress nextHop = address(b);
+            if (nextHop == null || b.readableBytes() < 12) {
+                return null;
+            }
+            uint32(b); // the router's own AS
+            final long srcAs = uint32(b);
+            uint32(b); // src peer AS
+
+            // dst_as_path: the destination AS is the last hop of the last segment
+            long dstAs = 0;
+            if (b.readableBytes() >= 4) {
+                final long segments = uint32(b);
+                for (long s = 0; s < segments && b.readableBytes() >= 8; s++) {
+                    uint32(b); // segment type (AS_SET / AS_SEQUENCE)
+                    final long count = uint32(b);
+                    for (long i = 0; i < count && b.readableBytes() >= 4; i++) {
+                        dstAs = uint32(b);
+                    }
+                }
+            }
+            return new Gateway(nextHop, srcAs, dstAs);
+        }
+    }
+
+    private ExtendedData() {
+    }
+
+    /** sFlow address: uint32 type discriminator, then 4 (IPv4) or 16 (IPv6) octets. */
+    static InetAddress address(final ByteBuf b) {
+        if (b.readableBytes() < 4) {
+            return null;
+        }
+        final long type = uint32(b);
+        final int size = type == 1 ? 4 : type == 2 ? 16 : -1;
+        if (size < 0 || b.readableBytes() < size) {
+            return null;
+        }
+        try {
+            return InetAddress.getByAddress(bytes(b, size));
+        } catch (final UnknownHostException e) {
+            // unreachable: length is always 4 or 16
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/src/main/java/org/riptide/flows/parser/sflow/proto/FlowSample.java
+++ b/src/main/java/org/riptide/flows/parser/sflow/proto/FlowSample.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.parser.sflow.proto;
+
+import com.google.common.base.MoreObjects;
+import io.netty.buffer.ByteBuf;
+import org.riptide.flows.parser.exceptions.InvalidPacketException;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import static org.riptide.flows.utils.BufferUtils.bytes;
+import static org.riptide.flows.utils.BufferUtils.slice;
+import static org.riptide.flows.utils.BufferUtils.uint32;
+
+/**
+ * One {@code flow_sample} (format 1) or {@code flow_sample_expanded} (format 3),
+ * sflow_version_5.txt §5.3. Flow records the builder doesn't consume are skipped by
+ * their XDR length; malformed extended records degrade to {@code null} fields.
+ */
+public final class FlowSample {
+
+    /** Standard-enterprise flow-record formats we consume. */
+    private static final int RECORD_SAMPLED_HEADER = 1;
+    private static final int RECORD_SAMPLED_IPV4 = 3;
+    private static final int RECORD_SAMPLED_IPV6 = 4;
+    private static final int RECORD_EXTENDED_SWITCH = 1001;
+    private static final int RECORD_EXTENDED_ROUTER = 1002;
+    private static final int RECORD_EXTENDED_GATEWAY = 1003;
+
+    public final long sequence;
+    public final long samplingRate;
+    public final long samplePool;
+    public final long drops;
+    public final InterfaceValue input;
+    public final InterfaceValue output;
+
+    private PacketInfo packet;
+    private Long frameLength;
+
+    private ExtendedData.Switch extendedSwitch;
+    private ExtendedData.Router extendedRouter;
+    private ExtendedData.Gateway extendedGateway;
+
+    /** Decoded sampled packet, when a header/struct record was present. */
+    public PacketInfo packet() {
+        return this.packet;
+    }
+
+    /** Original on-the-wire frame length, when a header/struct record was present. */
+    public Long frameLength() {
+        return this.frameLength;
+    }
+
+    public ExtendedData.Switch extendedSwitch() {
+        return this.extendedSwitch;
+    }
+
+    public ExtendedData.Router extendedRouter() {
+        return this.extendedRouter;
+    }
+
+    public ExtendedData.Gateway extendedGateway() {
+        return this.extendedGateway;
+    }
+
+    public FlowSample(final ByteBuf buffer, final boolean expanded) throws InvalidPacketException {
+        this.sequence = uint32(buffer);
+        if (expanded) {
+            uint32(buffer); // source_id type
+            uint32(buffer); // source_id index
+        } else {
+            uint32(buffer); // source_id (type << 24 | index)
+        }
+        this.samplingRate = uint32(buffer);
+        this.samplePool = uint32(buffer);
+        this.drops = uint32(buffer);
+        if (expanded) {
+            this.input = InterfaceValue.expanded(uint32(buffer), uint32(buffer));
+            this.output = InterfaceValue.expanded(uint32(buffer), uint32(buffer));
+        } else {
+            this.input = InterfaceValue.compact(uint32(buffer));
+            this.output = InterfaceValue.compact(uint32(buffer));
+        }
+
+        final long records = uint32(buffer);
+        for (long i = 0; i < records; i++) {
+            if (buffer.readableBytes() < 8) {
+                throw new InvalidPacketException(buffer, "Truncated flow record %d of %d", i + 1, records);
+            }
+            final long dataFormat = uint32(buffer);
+            final int length = (int) uint32(buffer);
+            if (length < 0 || length > buffer.readableBytes()) {
+                throw new InvalidPacketException(buffer, "Invalid flow record length: %d", length);
+            }
+            this.record(dataFormat, slice(buffer, length));
+        }
+    }
+
+    private void record(final long dataFormat, final ByteBuf b) {
+        final long enterprise = dataFormat >>> 12;
+        if (enterprise != 0) {
+            return; // vendor-specific record: skip by length
+        }
+        switch ((int) (dataFormat & 0xFFF)) {
+            case RECORD_SAMPLED_HEADER -> {
+                if (b.readableBytes() < 16) {
+                    return;
+                }
+                final int headerProtocol = (int) uint32(b);
+                this.frameLength = uint32(b);
+                uint32(b); // stripped octets
+                final int headerLength = (int) uint32(b);
+                this.packet = HeaderDecoder.decode(headerProtocol,
+                        slice(b, Math.min(headerLength, b.readableBytes())));
+            }
+            case RECORD_SAMPLED_IPV4 -> this.sampledIp(b, 4);
+            case RECORD_SAMPLED_IPV6 -> this.sampledIp(b, 6);
+            case RECORD_EXTENDED_SWITCH -> {
+                this.extendedSwitch = ExtendedData.Switch.parse(b);
+            }
+            case RECORD_EXTENDED_ROUTER -> {
+                this.extendedRouter = ExtendedData.Router.parse(b);
+            }
+            case RECORD_EXTENDED_GATEWAY -> {
+                this.extendedGateway = ExtendedData.Gateway.parse(b);
+            }
+            default -> {
+                // unconsumed record type: skip by length
+            }
+        }
+    }
+
+    /** {@code sampled_ipv4}/{@code sampled_ipv6}: the header pre-parsed by the sampler. */
+    private void sampledIp(final ByteBuf b, final int version) {
+        final int addressSize = version == 4 ? 4 : 16;
+        if (b.readableBytes() < 8 + 2 * addressSize + 16) {
+            return;
+        }
+        final PacketInfo info = new PacketInfo();
+        info.ipVersion = version;
+        this.frameLength = uint32(b);
+        info.protocol = (int) uint32(b);
+        info.srcAddr = rawAddress(b, addressSize);
+        info.dstAddr = rawAddress(b, addressSize);
+        info.srcPort = (int) uint32(b);
+        info.dstPort = (int) uint32(b);
+        info.tcpFlags = (int) uint32(b);
+        info.tos = (int) uint32(b); // priority for IPv6 — same slot
+        this.packet = info;
+    }
+
+    private static InetAddress rawAddress(final ByteBuf b, final int size) {
+        try {
+            return InetAddress.getByAddress(bytes(b, size));
+        } catch (final UnknownHostException e) {
+            // unreachable: length is always 4 or 16
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .omitNullValues()
+                .add("sequence", this.sequence)
+                .add("samplingRate", this.samplingRate)
+                .add("input", this.input)
+                .add("output", this.output)
+                .add("packet", this.packet)
+                .add("frameLength", this.frameLength)
+                .add("extendedSwitch", this.extendedSwitch)
+                .add("extendedRouter", this.extendedRouter)
+                .add("extendedGateway", this.extendedGateway)
+                .toString();
+    }
+}

--- a/src/main/java/org/riptide/flows/parser/sflow/proto/HeaderDecoder.java
+++ b/src/main/java/org/riptide/flows/parser/sflow/proto/HeaderDecoder.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.parser.sflow.proto;
+
+import io.netty.buffer.ByteBuf;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import static org.riptide.flows.utils.BufferUtils.bytes;
+import static org.riptide.flows.utils.BufferUtils.uint16;
+import static org.riptide.flows.utils.BufferUtils.uint32;
+import static org.riptide.flows.utils.BufferUtils.uint8;
+
+/**
+ * Decodes a sampled raw packet header: Ethernet (with 802.1Q/QinQ tags) → IPv4/IPv6 →
+ * TCP/UDP. Truncation-tolerant at every layer — the sampler cuts headers (typically at
+ * 128 bytes), so running out of bytes is normal and yields whatever was decoded so far.
+ * Undecodable payloads (ARP, MPLS, …) yield an empty {@link PacketInfo}: the flow
+ * degrades to sample-level data, mirroring the enrichment ladder's floor.
+ */
+public final class HeaderDecoder {
+
+    /** {@code header_protocol} values (sflow_version_5.txt §5.2.4). */
+    public static final int PROTO_ETHERNET = 1;
+    public static final int PROTO_IPV4 = 11;
+    public static final int PROTO_IPV6 = 12;
+
+    private static final int ETHERTYPE_VLAN = 0x8100;
+    private static final int ETHERTYPE_QINQ = 0x88A8;
+    private static final int ETHERTYPE_IPV4 = 0x0800;
+    private static final int ETHERTYPE_IPV6 = 0x86DD;
+
+    private static final int IP_PROTO_TCP = 6;
+    private static final int IP_PROTO_UDP = 17;
+
+    /** Chained IPv6 extension headers we walk through; bounded to defuse crafted loops. */
+    private static final int MAX_IPV6_EXTENSIONS = 8;
+
+    private HeaderDecoder() {
+    }
+
+    public static PacketInfo decode(final int headerProtocol, final ByteBuf header) {
+        final PacketInfo info = new PacketInfo();
+        switch (headerProtocol) {
+            case PROTO_ETHERNET -> ethernet(header, info);
+            case PROTO_IPV4 -> ipv4(header, info);
+            case PROTO_IPV6 -> ipv6(header, info);
+            default -> {
+                // unknown link type: floor flow
+            }
+        }
+        return info;
+    }
+
+    private static void ethernet(final ByteBuf b, final PacketInfo info) {
+        if (b.readableBytes() < 14) {
+            return;
+        }
+        b.skipBytes(12); // dst + src MAC
+        int etherType = uint16(b);
+        while ((etherType == ETHERTYPE_VLAN || etherType == ETHERTYPE_QINQ) && b.readableBytes() >= 4) {
+            final int tag = uint16(b);
+            if (info.vlan == null) { // outer tag wins, matching device-reported VLANs
+                info.vlan = tag & 0x0FFF;
+            }
+            etherType = uint16(b);
+        }
+        if (etherType == ETHERTYPE_IPV4) {
+            ipv4(b, info);
+        } else if (etherType == ETHERTYPE_IPV6) {
+            ipv6(b, info);
+        }
+        // anything else (ARP, MPLS, LLDP, …): keep what we have
+    }
+
+    private static void ipv4(final ByteBuf b, final PacketInfo info) {
+        if (b.readableBytes() < 20) {
+            return;
+        }
+        final int versionAndIhl = uint8(b);
+        if ((versionAndIhl >>> 4) != 4) {
+            return;
+        }
+        final int headerLength = (versionAndIhl & 0x0F) * 4;
+        info.ipVersion = 4;
+        info.tos = uint8(b);
+        b.skipBytes(4); // total length + identification
+        final int flagsAndFragment = uint16(b);
+        b.skipBytes(1); // ttl
+        info.protocol = uint8(b);
+        b.skipBytes(2); // checksum
+        info.srcAddr = address(bytes(b, 4));
+        info.dstAddr = address(bytes(b, 4));
+
+        final int options = headerLength - 20;
+        if (options < 0 || b.readableBytes() < options) {
+            return;
+        }
+        b.skipBytes(options);
+
+        if ((flagsAndFragment & 0x1FFF) != 0) {
+            return; // non-first fragment: no L4 header present
+        }
+        transport(b, info);
+    }
+
+    private static void ipv6(final ByteBuf b, final PacketInfo info) {
+        if (b.readableBytes() < 40) {
+            return;
+        }
+        final long first = uint32(b);
+        if ((first >>> 28) != 6) {
+            return;
+        }
+        info.ipVersion = 6;
+        info.tos = (int) ((first >>> 20) & 0xFF); // traffic class
+        b.skipBytes(2); // payload length
+        int next = uint8(b);
+        b.skipBytes(1); // hop limit
+        info.srcAddr = address(bytes(b, 16));
+        info.dstAddr = address(bytes(b, 16));
+
+        for (int i = 0; i < MAX_IPV6_EXTENSIONS; i++) {
+            if (next == 0 || next == 43 || next == 60) { // hop-by-hop, routing, dest-opts
+                if (b.readableBytes() < 2) {
+                    return;
+                }
+                next = uint8(b);
+                final int length = (uint8(b) + 1) * 8 - 2;
+                if (b.readableBytes() < length) {
+                    return;
+                }
+                b.skipBytes(length);
+            } else if (next == 44) { // fragment
+                if (b.readableBytes() < 8) {
+                    return;
+                }
+                next = uint8(b);
+                b.skipBytes(1);
+                final int fragmentOffset = uint16(b) >>> 3;
+                b.skipBytes(4); // identification
+                if (fragmentOffset != 0) {
+                    return; // non-first fragment: no L4 header present
+                }
+            } else {
+                break;
+            }
+        }
+        info.protocol = next;
+        transport(b, info);
+    }
+
+    private static void transport(final ByteBuf b, final PacketInfo info) {
+        if (info.protocol != null && (info.protocol == IP_PROTO_TCP || info.protocol == IP_PROTO_UDP)) {
+            if (b.readableBytes() < 4) {
+                return;
+            }
+            info.srcPort = uint16(b);
+            info.dstPort = uint16(b);
+            if (info.protocol == IP_PROTO_TCP && b.readableBytes() >= 10) {
+                b.skipBytes(8); // sequence + acknowledgement
+                b.skipBytes(1); // data offset
+                info.tcpFlags = uint8(b);
+            }
+        }
+    }
+
+    private static InetAddress address(final byte[] octets) {
+        try {
+            return InetAddress.getByAddress(octets);
+        } catch (final UnknownHostException e) {
+            // unreachable: length is always 4 or 16
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/src/main/java/org/riptide/flows/parser/sflow/proto/InterfaceValue.java
+++ b/src/main/java/org/riptide/flows/parser/sflow/proto/InterfaceValue.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.parser.sflow.proto;
+
+/**
+ * An sFlow interface value with its 2-bit format selector (sflow_version_5.txt §5.3):
+ * format 0 carries an ifIndex in the low 30 bits ({@code 0x3FFFFFFF} meaning
+ * device-internal/unknown), format 1 a drop reason, format 2 a count of multiple
+ * destinations. Only format 0 with a real index yields an ifIndex — everything else
+ * must never be mistaken for one.
+ */
+public record InterfaceValue(int format, long value) {
+
+    public static final long INTERNAL = 0x3FFFFFFFL;
+
+    /** Decodes the compact single-word form (top 2 bits = format). */
+    public static InterfaceValue compact(final long raw) {
+        return new InterfaceValue((int) (raw >>> 30), raw & INTERNAL);
+    }
+
+    /** The expanded form carries format and value as separate words. */
+    public static InterfaceValue expanded(final long format, final long value) {
+        return new InterfaceValue((int) format, value);
+    }
+
+    /** The ifIndex, or {@code 0} when this value does not denote one. */
+    public int ifIndex() {
+        // the expanded form carries a full 32-bit word: reject values that would
+        // overflow an ifIndex instead of casting them negative
+        if (this.format != 0 || this.value == INTERNAL || this.value > Integer.MAX_VALUE) {
+            return 0;
+        }
+        return (int) this.value;
+    }
+}

--- a/src/main/java/org/riptide/flows/parser/sflow/proto/PacketInfo.java
+++ b/src/main/java/org/riptide/flows/parser/sflow/proto/PacketInfo.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.parser.sflow.proto;
+
+import com.google.common.base.MoreObjects;
+
+import java.net.InetAddress;
+
+/**
+ * What could be decoded from a sampled packet header. Every field is nullable: headers
+ * are truncated at the sampler (typically 128 bytes), so decoding stops wherever the
+ * bytes run out and the flow is built from whatever was recovered — never dropped.
+ */
+public final class PacketInfo {
+
+    public InetAddress srcAddr;
+    public InetAddress dstAddr;
+    public Integer srcPort;
+    public Integer dstPort;
+    public Integer protocol;
+    public Integer tcpFlags;
+    public Integer tos;
+    public Integer vlan;
+    public Integer ipVersion;
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .omitNullValues()
+                .add("srcAddr", this.srcAddr)
+                .add("dstAddr", this.dstAddr)
+                .add("srcPort", this.srcPort)
+                .add("dstPort", this.dstPort)
+                .add("protocol", this.protocol)
+                .add("tcpFlags", this.tcpFlags)
+                .add("tos", this.tos)
+                .add("vlan", this.vlan)
+                .add("ipVersion", this.ipVersion)
+                .toString();
+    }
+}

--- a/src/main/java/org/riptide/node/NodeRegistry.java
+++ b/src/main/java/org/riptide/node/NodeRegistry.java
@@ -11,6 +11,7 @@ import lombok.Data;
 import org.riptide.pipeline.ExporterIdentity;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.net.InetAddress;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -35,27 +36,36 @@ public class NodeRegistry {
      */
     public Optional<Node> lookup(final ExporterIdentity identity) {
         // instanceof instead of an exhaustive switch pattern only because checkstyle 9.3
-        // cannot parse switch record patterns; new ExporterIdentity variants (sFlow, #159)
-        // must be handled here.
+        // cannot parse switch record patterns; new ExporterIdentity variants must be
+        // handled here.
         if (identity instanceof ExporterIdentity.NetflowIpfix netflowIpfix) {
-            final IPAddressString ipAddressString = new IPAddressString(netflowIpfix.source().getHostAddress());
-            final List<Map.Entry<String, NodeDefinition>> subnetMatches = this.nodes.entrySet().stream()
-                    .filter(node -> node.getValue().getSubnetAddress().contains(ipAddressString))
-                    .toList();
-
-            final List<Map.Entry<String, NodeDefinition>> pinned = subnetMatches.stream()
-                    .filter(node -> node.getValue().getObservationDomain() != null
-                            && node.getValue().getObservationDomain() == netflowIpfix.observationDomain())
-                    .toList();
-            final List<Map.Entry<String, NodeDefinition>> pool = !pinned.isEmpty()
-                    ? pinned
-                    : subnetMatches.stream().filter(node -> node.getValue().getObservationDomain() == null).toList();
-
-            return pool.stream()
-                    .max(Comparator.comparingInt(node -> prefixLength(node.getValue().getSubnetAddress())))
-                    .map(node -> new Node(node.getKey(), node.getValue(), ipAddressString));
+            return lookup(netflowIpfix.source(), netflowIpfix.observationDomain());
+        }
+        if (identity instanceof ExporterIdentity.Sflow sflow) {
+            // agent address from the payload, sub-agent ID pins via the same
+            // observation-domain node key
+            return lookup(sflow.agentAddress(), sflow.subAgentId());
         }
         throw new IllegalStateException("Unhandled exporter identity: " + identity);
+    }
+
+    private Optional<Node> lookup(final InetAddress address, final long domain) {
+        final IPAddressString ipAddressString = new IPAddressString(address.getHostAddress());
+        final List<Map.Entry<String, NodeDefinition>> subnetMatches = this.nodes.entrySet().stream()
+                .filter(node -> node.getValue().getSubnetAddress().contains(ipAddressString))
+                .toList();
+
+        final List<Map.Entry<String, NodeDefinition>> pinned = subnetMatches.stream()
+                .filter(node -> node.getValue().getObservationDomain() != null
+                        && node.getValue().getObservationDomain() == domain)
+                .toList();
+        final List<Map.Entry<String, NodeDefinition>> pool = !pinned.isEmpty()
+                ? pinned
+                : subnetMatches.stream().filter(node -> node.getValue().getObservationDomain() == null).toList();
+
+        return pool.stream()
+                .max(Comparator.comparingInt(node -> prefixLength(node.getValue().getSubnetAddress())))
+                .map(node -> new Node(node.getKey(), node.getValue(), ipAddressString));
     }
 
     /**

--- a/src/main/java/org/riptide/pipeline/ExporterIdentity.java
+++ b/src/main/java/org/riptide/pipeline/ExporterIdentity.java
@@ -32,4 +32,15 @@ public sealed interface ExporterIdentity {
             return this.source;
         }
     }
+
+    /**
+     * sFlow v5: identity is carried inside the datagram — {@code agent_address} plus
+     * {@code sub_agent_id} — and may legitimately differ from the UDP source address.
+     */
+    record Sflow(InetAddress agentAddress, long subAgentId) implements ExporterIdentity {
+        @Override
+        public InetAddress deviceAddress() {
+            return this.agentAddress;
+        }
+    }
 }

--- a/src/test/java/org/riptide/flows/parser/sflow/SflowParserTest.java
+++ b/src/test/java/org/riptide/flows/parser/sflow/SflowParserTest.java
@@ -1,0 +1,347 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.parser.sflow;
+
+import com.codahale.metrics.MetricRegistry;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.Test;
+import org.riptide.flows.parser.data.Flow;
+import org.riptide.flows.parser.exceptions.InvalidPacketException;
+import org.riptide.flows.parser.sflow.proto.Datagram;
+import org.riptide.flows.parser.sflow.proto.InterfaceValue;
+import org.riptide.pipeline.ExporterIdentity;
+
+import java.net.InetAddress;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class SflowParserTest {
+
+    private static final Instant NOW = Instant.parse("2026-07-13T12:00:00Z");
+
+    // --- XDR fixture builders -----------------------------------------------------
+
+    private static ByteBuf buf() {
+        return Unpooled.buffer();
+    }
+
+    private static ByteBuf u32(final ByteBuf b, final long... values) {
+        for (final long v : values) {
+            b.writeInt((int) v);
+        }
+        return b;
+    }
+
+    /** Datagram header for an IPv4 agent, followed by pre-encoded samples. */
+    private static ByteBuf datagram(final String agent, final long subAgentId, final ByteBuf... samples) throws Exception {
+        final ByteBuf b = buf();
+        u32(b, 5, 1); // version, agent address type IPv4
+        b.writeBytes(InetAddress.getByName(agent).getAddress());
+        u32(b, subAgentId, 1000 /* sequence */, 123456 /* uptime */, samples.length);
+        for (final ByteBuf sample : samples) {
+            b.writeBytes(sample);
+        }
+        return b;
+    }
+
+    /** Wraps sample payload in the (type, length) TLV. */
+    private static ByteBuf sample(final long type, final ByteBuf payload) {
+        final ByteBuf b = buf();
+        u32(b, type, payload.readableBytes());
+        b.writeBytes(payload);
+        return b;
+    }
+
+    /** Compact flow_sample body up to num_records, followed by pre-encoded records. */
+    private static ByteBuf flowSampleBody(final long rate, final long input, final long output, final ByteBuf... records) {
+        final ByteBuf b = buf();
+        u32(b, 42 /* sequence */, 0x01000005L /* source_id */, rate, 100000 /* pool */, 0 /* drops */, input, output, records.length);
+        for (final ByteBuf record : records) {
+            b.writeBytes(record);
+        }
+        return b;
+    }
+
+    private static ByteBuf record(final long format, final ByteBuf payload) {
+        final ByteBuf b = buf();
+        u32(b, format, payload.readableBytes());
+        b.writeBytes(payload);
+        return b;
+    }
+
+    /** sampled_header record payload wrapping the given raw frame bytes. */
+    private static ByteBuf sampledHeader(final int headerProtocol, final long frameLength, final ByteBuf frame) {
+        final ByteBuf b = buf();
+        u32(b, headerProtocol, frameLength, 4 /* stripped */, frame.readableBytes());
+        b.writeBytes(frame);
+        return b;
+    }
+
+    /** Ethernet frame: optional 802.1Q tags, then an IPv4+TCP header. */
+    private static ByteBuf ethernetIpv4Tcp(final int... vlanTags) throws Exception {
+        final ByteBuf b = buf();
+        b.writeZero(12); // MACs
+        for (final int vlan : vlanTags) {
+            b.writeShort(0x8100);
+            b.writeShort(vlan);
+        }
+        b.writeShort(0x0800);
+        return ipv4Tcp(b);
+    }
+
+    private static ByteBuf ipv4Tcp(final ByteBuf b) throws Exception {
+        b.writeByte(0x45); // version 4, IHL 5
+        b.writeByte(0xB8); // tos
+        b.writeShort(64);  // total length
+        b.writeShort(7);   // identification
+        b.writeShort(0x4000); // DF, fragment offset 0
+        b.writeByte(63);   // ttl
+        b.writeByte(6);    // TCP
+        b.writeShort(0);   // checksum
+        b.writeBytes(InetAddress.getByName("192.0.2.1").getAddress());
+        b.writeBytes(InetAddress.getByName("198.51.100.2").getAddress());
+        b.writeShort(443); // src port
+        b.writeShort(51234); // dst port
+        u32(b, 1, 2);      // seq + ack
+        b.writeByte(0x50); // data offset
+        b.writeByte(0x18); // flags: PSH|ACK
+        return b;
+    }
+
+    private static List<Flow> flows(final ByteBuf datagram) throws InvalidPacketException {
+        return new Datagram(datagram).buildFlows(NOW).toList();
+    }
+
+    // --- tests ---------------------------------------------------------------------
+
+    @Test
+    public void compactFlowSampleDecodesEthernetVlanIpv4Tcp() throws Exception {
+        final var frame = ethernetIpv4Tcp(42);
+        final var body = flowSampleBody(512, 7, 9, record(1, sampledHeader(1, 1500, frame)));
+        final var flow = flows(datagram("10.1.1.1", 0, sample(1, body))).getFirst();
+
+        assertThat(flow.getFlowProtocol()).isEqualTo(Flow.FlowProtocol.SFLOW);
+        assertThat(flow.getSrcAddr()).isEqualTo(InetAddress.getByName("192.0.2.1"));
+        assertThat(flow.getDstAddr()).isEqualTo(InetAddress.getByName("198.51.100.2"));
+        assertThat(flow.getSrcPort()).isEqualTo(443);
+        assertThat(flow.getDstPort()).isEqualTo(51234);
+        assertThat(flow.getProtocol()).isEqualTo(6);
+        assertThat(flow.getTcpFlags()).isEqualTo(0x18);
+        assertThat(flow.getTos()).isEqualTo(0xB8);
+        assertThat(flow.getVlan()).isEqualTo(42);
+        assertThat(flow.getIpProtocolVersion()).isEqualTo(4);
+        assertThat(flow.getInputSnmp()).isEqualTo(7);
+        assertThat(flow.getOutputSnmp()).isEqualTo(9);
+        assertThat(flow.getBytes()).isEqualTo(1500L * 512);
+        assertThat(flow.getPackets()).isEqualTo(512);
+        assertThat(flow.getSamplingInterval()).isEqualTo(512.0);
+        assertThat(flow.getFirstSwitched()).isEqualTo(NOW);
+        assertThat(flow.getLastSwitched()).isEqualTo(NOW);
+    }
+
+    @Test
+    public void identityComesFromThePayloadNotTheSocket() throws Exception {
+        final var body = flowSampleBody(1, 1, 1);
+        final var datagram = new Datagram(datagram("10.1.1.1", 7, sample(1, body)));
+
+        final var identity = datagram.identity(InetAddress.getByName("192.0.2.9"));
+
+        assertThat(identity).isEqualTo(new ExporterIdentity.Sflow(InetAddress.getByName("10.1.1.1"), 7));
+        assertThat(datagram.getObservationDomainId()).isEqualTo(7);
+        assertThat(datagram.getSequenceNumber()).isEqualTo(1000);
+    }
+
+    @Test
+    public void counterAndVendorSamplesAreSkippedSilently() throws Exception {
+        final var counters = buf();
+        u32(counters, 99, 1, 2, 3); // opaque counter payload
+        final var vendor = buf();
+        u32(vendor, 1, 2);
+        final var body = flowSampleBody(1, 1, 1);
+
+        final var flows = flows(datagram("10.1.1.1", 0,
+                sample(2, counters),                 // counters_sample
+                sample((4711L << 12) | 1, vendor),   // vendor enterprise
+                sample(1, body)));
+
+        assertThat(flows).hasSize(1);
+    }
+
+    @Test
+    public void expandedFlowSampleParses() throws Exception {
+        final var b = buf();
+        u32(b, 42, 0, 5 /* source_id type, index */, 256, 100000, 0,
+                0, 7 /* input: format, value */, 1, 3 /* output: drop reason */, 0 /* records */);
+
+        final var flow = flows(datagram("10.1.1.1", 0, sample(3, b))).getFirst();
+
+        assertThat(flow.getInputSnmp()).isEqualTo(7);
+        assertThat(flow.getOutputSnmp()).isEqualTo(0); // drop reason is not an ifIndex
+        assertThat(flow.getPackets()).isEqualTo(256);
+    }
+
+    @Test
+    public void truncatedTcpHeaderKeepsPortsAndDropsFlags() throws Exception {
+        final var frame = ethernetIpv4Tcp();
+        final var truncated = frame.slice(0, frame.readableBytes() - 10); // cut seq/ack/flags
+        final var body = flowSampleBody(2, 1, 1, record(1, sampledHeader(1, 900, buf().writeBytes(truncated))));
+
+        final var flow = flows(datagram("10.1.1.1", 0, sample(1, body))).getFirst();
+
+        assertThat(flow.getSrcPort()).isEqualTo(443);
+        assertThat(flow.getTcpFlags()).isEqualTo(0);
+        assertThat(flow.getBytes()).isEqualTo(1800);
+    }
+
+    @Test
+    public void undecodablePayloadDegradesToFloorFlow() throws Exception {
+        final var arp = buf();
+        arp.writeZero(12);
+        arp.writeShort(0x0806); // ARP
+        arp.writeZero(28);
+        final var body = flowSampleBody(128, 7, 9, record(1, sampledHeader(1, 64, arp)));
+
+        final var flow = flows(datagram("10.1.1.1", 0, sample(1, body))).getFirst();
+
+        assertThat(flow.getSrcAddr()).isNull();
+        assertThat(flow.getDstAddr()).isNull();
+        assertThat(flow.getBytes()).isEqualTo(64L * 128);
+        assertThat(flow.getPackets()).isEqualTo(128);
+        assertThat(flow.getInputSnmp()).isEqualTo(7);
+    }
+
+    @Test
+    public void sampledIpv4StructRecordParses() throws Exception {
+        final var b = buf();
+        u32(b, 800, 17); // length, UDP
+        b.writeBytes(InetAddress.getByName("192.0.2.7").getAddress());
+        b.writeBytes(InetAddress.getByName("198.51.100.8").getAddress());
+        u32(b, 5353, 5353, 0, 0x10); // ports, tcp flags, tos
+        final var body = flowSampleBody(4, 1, 1, record(3, b));
+
+        final var flow = flows(datagram("10.1.1.1", 0, sample(1, body))).getFirst();
+
+        assertThat(flow.getSrcAddr()).isEqualTo(InetAddress.getByName("192.0.2.7"));
+        assertThat(flow.getProtocol()).isEqualTo(17);
+        assertThat(flow.getSrcPort()).isEqualTo(5353);
+        assertThat(flow.getTos()).isEqualTo(0x10);
+        assertThat(flow.getBytes()).isEqualTo(3200);
+    }
+
+    @Test
+    public void extendedRecordsMapToFlowFields() throws Exception {
+        final var sw = buf();
+        u32(sw, 100, 0, 200, 0); // src/dst vlan + priorities
+
+        final var router = buf();
+        u32(router, 1); // IPv4 next hop
+        router.writeBytes(InetAddress.getByName("10.0.0.254").getAddress());
+        u32(router, 24, 16); // masks
+
+        final var gateway = buf();
+        u32(gateway, 1);
+        gateway.writeBytes(InetAddress.getByName("10.0.0.253").getAddress());
+        u32(gateway, 64999 /* own AS */, 64500 /* src AS */, 64998 /* peer */,
+                2 /* path segments */, 2, 2, 65001, 65002 /* seg 1 */, 2, 1, 64999 /* seg 2 */,
+                0 /* communities */, 100 /* localpref */);
+
+        final var body = flowSampleBody(1, 1, 1,
+                record(1001, sw), record(1002, router), record(1003, gateway));
+
+        final var flow = flows(datagram("10.1.1.1", 0, sample(1, body))).getFirst();
+
+        assertThat(flow.getVlan()).isEqualTo(100);
+        assertThat(flow.getNextHop()).isEqualTo(InetAddress.getByName("10.0.0.254"));
+        assertThat(flow.getSrcMaskLen()).isEqualTo(24);
+        assertThat(flow.getDstMaskLen()).isEqualTo(16);
+        assertThat(flow.getSrcAs()).isEqualTo(64500);
+        assertThat(flow.getDstAs()).isEqualTo(64999); // last AS of the last path segment
+    }
+
+    @Test
+    public void ipv6WithExtensionHeaderAndUdpParses() throws Exception {
+        final var frame = buf();
+        frame.writeZero(12);
+        frame.writeShort(0x86DD);
+        u32(frame, (6L << 28) | (0xB8L << 20)); // version 6, traffic class 0xB8
+        frame.writeShort(16); // payload length
+        frame.writeByte(0);   // next: hop-by-hop
+        frame.writeByte(64);  // hop limit
+        frame.writeBytes(InetAddress.getByName("2001:db8::1").getAddress());
+        frame.writeBytes(InetAddress.getByName("2001:db8::2").getAddress());
+        frame.writeByte(17);  // ext: next header UDP
+        frame.writeByte(0);   // ext length: (0+1)*8 bytes total
+        frame.writeZero(6);
+        frame.writeShort(53); // src port
+        frame.writeShort(5300);
+        final var body = flowSampleBody(16, 1, 1, record(1, sampledHeader(1, 120, frame)));
+
+        final var flow = flows(datagram("10.1.1.1", 0, sample(1, body))).getFirst();
+
+        assertThat(flow.getIpProtocolVersion()).isEqualTo(6);
+        assertThat(flow.getSrcAddr()).isEqualTo(InetAddress.getByName("2001:db8::1"));
+        assertThat(flow.getProtocol()).isEqualTo(17);
+        assertThat(flow.getSrcPort()).isEqualTo(53);
+        assertThat(flow.getDstPort()).isEqualTo(5300);
+        assertThat(flow.getTos()).isEqualTo(0xB8);
+    }
+
+    @Test
+    public void qinqOuterTagWins() throws Exception {
+        final var frame = buf();
+        frame.writeZero(12);
+        frame.writeShort(0x88A8);
+        frame.writeShort(300); // outer
+        frame.writeShort(0x8100);
+        frame.writeShort(400); // inner
+        frame.writeShort(0x0800);
+        ipv4Tcp(frame);
+        final var body = flowSampleBody(1, 1, 1, record(1, sampledHeader(1, 64, frame)));
+
+        final var flow = flows(datagram("10.1.1.1", 0, sample(1, body))).getFirst();
+
+        assertThat(flow.getVlan()).isEqualTo(300);
+        assertThat(flow.getSrcAddr()).isEqualTo(InetAddress.getByName("192.0.2.1"));
+    }
+
+    @Test
+    public void interfaceFormatBitBoundaries() {
+        assertThat(InterfaceValue.compact(0).ifIndex()).isEqualTo(0);
+        assertThat(InterfaceValue.compact(7).ifIndex()).isEqualTo(7);
+        assertThat(InterfaceValue.compact(0x3FFFFFFEL).ifIndex()).isEqualTo(0x3FFFFFFE);
+        assertThat(InterfaceValue.compact(0x3FFFFFFFL).ifIndex()).isEqualTo(0); // device-internal
+        assertThat(InterfaceValue.compact(0x40000107L).ifIndex()).isEqualTo(0); // format 1: drop reason
+        assertThat(InterfaceValue.compact(0x80000002L).ifIndex()).isEqualTo(0); // format 2: multiple
+        assertThat(InterfaceValue.expanded(0, 7).ifIndex()).isEqualTo(7);
+        assertThat(InterfaceValue.expanded(1, 7).ifIndex()).isEqualTo(0);
+        assertThat(InterfaceValue.expanded(0, 0xFFFFFFFFL).ifIndex()).isEqualTo(0); // would overflow
+    }
+
+    @Test
+    public void handlesPeeksTheXdrVersionWord() {
+        final var parser = new SflowUdpParser("test", (source, flow) -> { }, "here", new MetricRegistry());
+
+        assertThat(parser.handles(u32(buf(), 5))).isTrue();
+        assertThat(parser.handles(buf().writeShort(0x0005))).isFalse();  // NetFlow v5
+        assertThat(parser.handles(u32(buf(), 0x000A0000L))).isFalse();   // IPFIX-ish
+        assertThat(parser.handles(buf())).isFalse();
+    }
+
+    @Test
+    public void malformedFramingThrows() throws Exception {
+        final var badVersion = u32(buf(), 4, 1);
+
+        assertThatThrownBy(() -> new Datagram(badVersion)).isInstanceOf(InvalidPacketException.class);
+
+        final var truncated = datagram("10.1.1.1", 0); // claims 0 samples — now claim 1
+        truncated.setInt(24, 1); // num_samples word for an IPv4 agent datagram
+        assertThatThrownBy(() -> new Datagram(truncated)).isInstanceOf(InvalidPacketException.class);
+    }
+}

--- a/src/test/java/org/riptide/node/NodeRegistryTest.java
+++ b/src/test/java/org/riptide/node/NodeRegistryTest.java
@@ -137,4 +137,26 @@ public class NodeRegistryTest {
         assertThat(match).isPresent();
         assertThat(match.get().snmpEndpoint()).isEmpty();
     }
+
+    @Test
+    public void sflowMatchesByAgentAddress() throws Exception {
+        final NodeRegistry registry = registry(
+                Map.entry("switch-a", node("10.1.0.0/16", null, "a")));
+
+        final var identity = new ExporterIdentity.Sflow(InetAddress.getByName("10.1.1.1"), 0);
+
+        assertThat(registry.lookup(identity)).map(Node::label).hasValue("switch-a");
+    }
+
+    @Test
+    public void sflowSubAgentPinsViaObservationDomainKey() throws Exception {
+        final NodeRegistry registry = registry(
+                Map.entry("wildcard", node("10.1.0.0/16", null, "w")),
+                Map.entry("pinned", node("10.1.0.0/16", 7L, "p")));
+
+        assertThat(registry.lookup(new ExporterIdentity.Sflow(InetAddress.getByName("10.1.1.1"), 7)))
+                .map(Node::label).hasValue("pinned");
+        assertThat(registry.lookup(new ExporterIdentity.Sflow(InetAddress.getByName("10.1.1.1"), 3)))
+                .map(Node::label).hasValue("wildcard");
+    }
 }


### PR DESCRIPTION
Phases B+C of the `sflow-support` plan (phase C folded in deliberately: the flow builder needs the format-bit decoder from day one, or drop-reason values would persist as fake ifIndexes).

## What's here
- **XDR framing** — `Datagram`/`FlowSample` (compact + expanded); counter samples and vendor-enterprise types skipped by length, silently — nl6 sends counters every tick, so this is load-bearing for e2e
- **Raw-header decoder** — Ethernet + 802.1Q/QinQ → IPv4 (IHL-aware) / IPv6 (bounded ext-header walk, first-fragment aware) → TCP/UDP; truncation-tolerant at every layer; undecodable payloads (ARP etc.) degrade to floor flows, never drop
- **`sampled_ipv4`/`sampled_ipv6`** struct records + **extended records** 1001–1003 (VLAN, next hop/masks, src/dst AS — the gateway AS lands as exporter-provided, so the routing prefix table won't overwrite it)
- **Payload-derived identity** — `ExporterIdentity.Sflow(agentAddress, subAgentId)`; `NodeRegistry` matches subnets against the agent address, sub-agent IDs pin via the existing `observation-domain` key (match core extracted, shared by both variants); per-sub-agent sequence tracking falls out of `getObservationDomainId()`
- **Interface format bits** — top-2-bit selector decoded before any ifIndex use; `0x3FFFFFFF`, drop reasons, multiple-dest and overflowing expanded values all yield 0
- **Receiver config** — new `sflow` type + `multi` gains an sflow flag (default on; XDR `0x00000005` is peek-disjoint from NetFlow/IPFIX uint16 versions)

## Review
Structured medium pass done inline over the branch diff; one finding (expanded-form 32-bit interface value could cast to a negative ifIndex) fixed with a boundary test.

## Verification
`make jar` → **593 tests**, checkstyle/Error Prone/SpotBugs/JaCoCo all green. 13 XDR fixture tests cover: compact+expanded, VLAN/QinQ, IPv6 ext headers, truncation, ARP floor, counter/vendor skip, extended-record mapping, format-bit boundaries, framing errors. e2e (existing protocols) runs in CI. The nl6 sFlow e2e case is phase D.

Refs #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)