### PR TITLE
test: sFlow e2e attribution case + docs (#159, phase D)

### DIFF
--- a/docs/docs/configuration/nodes-and-snmp.md
+++ b/docs/docs/configuration/nodes-and-snmp.md
@@ -16,7 +16,7 @@ identity in logs and error messages (kebab-case: letters, digits, dashes):
 
 ```properties
 riptide.nodes.core-router.subnet-address=10.20.30.0/24
-riptide.nodes.core-router.observation-domain=42   # optional pin; omit = matches any domain
+riptide.nodes.core-router.observation-domain=42   # optional pin (observation domain / sFlow sub-agent ID); omit = matches any
 riptide.nodes.core-router.snmp.port=161           # default 161
 riptide.nodes.core-router.snmp.timeout=500        # ms, default 500
 riptide.nodes.core-router.snmp.retries=1          # default 1
@@ -29,6 +29,11 @@ riptide.nodes.core-router.snmp.retries=1          # default 1
    a bare host address is most specific)
 3. a **true tie** — two nodes with the same subnet and the same pinning — fails startup
    with both node names; declaration order never decides anything
+
+For NetFlow/IPFIX the matched address is the UDP source and the pin is the observation
+domain (source ID). For **sFlow** both come from the datagram payload: subnets match
+the `agent_address` — which may differ from the UDP source — and `observation-domain`
+pins the `sub_agent_id`.
 
 A node without an `snmp` block matches flows but is not polled — it can still enrich
 interfaces statically via the `interfaces` map (see below).

--- a/docs/docs/configuration/receivers.md
+++ b/docs/docs/configuration/receivers.md
@@ -13,9 +13,13 @@ Each receiver has a free-form name and three settings:
 
 | Setting | Values |
 |---|---|
-| `type` | `netflow5` · `netflow9` · `ipfix` |
+| `type` | `netflow5` · `netflow9` · `ipfix` · `sflow` · `multi` |
 | `host` | bind address, e.g. `0.0.0.0` |
-| `port` | UDP port (IPFIX also listens on TCP) |
+| `port` | UDP port (IPFIX also listens on TCP; sFlow's conventional port is 6343) |
+
+A `multi` receiver parses all four protocols on one port, telling them apart by their
+version words; per-protocol flags (`netflow5`, `netflow9`, `ipfix`, `sflow`, all
+defaulting to `true`) switch individual parsers off.
 
 ```properties
 riptide.receivers.ipfix.type=ipfix
@@ -49,3 +53,18 @@ Flows are attributed to their exporter by **source address plus observation doma
 exporter IP are distinct identities. NetFlow v5 has no such concept; its engine type/ID
 are mapped onto the domain. The identity drives node matching — see
 [Nodes & SNMP](nodes-and-snmp.md).
+
+**sFlow identity lives in the payload**: the datagram's `agent_address` plus
+`sub_agent_id` — *not* the UDP source address, which may be a different management IP
+entirely (or a shared socket in front of many agents). Node matching runs against the
+agent address, and the node `observation-domain` key pins sub-agent IDs.
+
+## sFlow semantics
+
+sFlow v5 is packet sampling, not a flow cache. Each flow sample becomes one flow whose
+volume is the statistical estimate (`bytes = frame length × sampling rate`,
+`packets = sampling rate`) and whose first/last-switched collapse to the receive time.
+Sampled headers are decoded down to addresses, ports, and TCP flags; whatever a
+truncated or non-IP header doesn't reveal stays at its floor value and the flow is
+still persisted (see [Enrichment](../enrichment.md)). Counter samples are skipped —
+riptide does not interpret them.

--- a/docs/docs/enrichment.md
+++ b/docs/docs/enrichment.md
@@ -25,6 +25,11 @@ value; live sources fill the fields the file doesn't set; packet data is the flo
 For AS numbers, a **nonzero exporter-provided value always wins** — the routing mapping
 only fills zeros.
 
+The floor extends into parsing: an sFlow sample whose raw packet header cannot be
+decoded (truncated by the sampler, non-IP payload) still becomes a flow carrying the
+sample-level data — bytes, packets, interfaces — with the undecodable fields simply
+absent. Undecodable is not an error.
+
 ## Static interface mapping
 
 A node may carry its own interface table — the middle rung, for devices without

--- a/src/test/java/org/riptide/e2e/Nl6FlowIngestionIT.java
+++ b/src/test/java/org/riptide/e2e/Nl6FlowIngestionIT.java
@@ -23,7 +23,7 @@ import static org.riptide.e2e.E2eTestSupport.await;
 import static org.riptide.e2e.E2eTestSupport.freeUdpPort;
 
 /**
- * End-to-end: nl6-simulated devices export NetFlow v5 / v9 / IPFIX over real
+ * End-to-end: nl6-simulated devices export NetFlow v5 / v9, IPFIX, and sFlow v5 over real
  * UDP into riptide's listeners (running in this JVM), through parsing,
  * enrichment, and classification, into a real ClickHouse. Assertions
  * reconcile ClickHouse row counts against nl6's per-collector ledger.
@@ -49,6 +49,7 @@ public class Nl6FlowIngestionIT {
     private static final int NETFLOW5_PORT = freeUdpPort();
     private static final int NETFLOW9_PORT = freeUdpPort();
     private static final int IPFIX_PORT = freeUdpPort();
+    private static final int SFLOW_PORT = freeUdpPort();
 
     private static final Instant TEST_START = Instant.now();
 
@@ -78,6 +79,17 @@ public class Nl6FlowIngestionIT {
         registry.add("riptide.receivers.ipfix.type", () -> "ipfix");
         registry.add("riptide.receivers.ipfix.host", () -> "0.0.0.0");
         registry.add("riptide.receivers.ipfix.port", () -> IPFIX_PORT);
+
+        registry.add("riptide.receivers.sf.type", () -> "sflow");
+        registry.add("riptide.receivers.sf.host", () -> "0.0.0.0");
+        registry.add("riptide.receivers.sf.port", () -> SFLOW_PORT);
+
+        // A node matching the sFlow devices' agent addresses (payload-derived; the
+        // shared-socket UDP source is the nl6 container, which this subnet does NOT
+        // cover) with static interface names — enrichment proves node attribution.
+        registry.add("riptide.nodes.sflow-agents.subnet-address", () -> "10.42.3.0/24");
+        registry.add("riptide.nodes.sflow-agents.interfaces.1.name", () -> "sfl-in");
+        registry.add("riptide.nodes.sflow-agents.interfaces.2.name", () -> "sfl-out");
     }
 
     @BeforeAll
@@ -92,6 +104,7 @@ public class Nl6FlowIngestionIT {
         NL6.createDevices("10.42.0.1", 3, "netflow5", NETFLOW5_PORT);
         NL6.createDevices("10.42.1.1", 3, "netflow9", NETFLOW9_PORT);
         NL6.createDevices("10.42.2.1", 3, "ipfix", IPFIX_PORT);
+        NL6.createDevices("10.42.3.1", 3, "sflow", SFLOW_PORT);
     }
 
     @Test
@@ -109,6 +122,29 @@ public class Nl6FlowIngestionIT {
     void verifyIpfixReachesClickhouse() throws Exception {
         reconcile("ipfix", "IPFIX", TEMPLATE_EPSILON);
         verifyTimestampsSane("IPFIX");
+    }
+
+    /**
+     * sFlow runs in nl6's shared-socket mode (the container default), so the UDP
+     * source address is the nl6 container — NOT a device. The assertions prove
+     * payload-derived attribution: persisted exporters are the in-datagram agent
+     * addresses, and static interface enrichment fires on the node that only a
+     * device agent address can match.
+     */
+    @Test
+    void verifySflowReachesClickhouseAttributedByAgentAddress() throws Exception {
+        reconcile("sflow", "SFLOW", 0.0);
+        verifyTimestampsSane("SFLOW");
+
+        final var exporters = queryClient.queryAll(
+                "SELECT DISTINCT exporterAddr FROM flows WHERE flowProtocol = 'SFLOW'");
+        Assertions.assertThat(exporters).isNotEmpty().allSatisfy(row ->
+                Assertions.assertThat(row.getString("exporterAddr")).startsWith("10.42.3."));
+
+        await(Duration.ofMinutes(1), "sFlow rows enriched via the agent-address-matched node",
+                () -> queryClient.queryAll(
+                        "SELECT count() AS c FROM flows WHERE flowProtocol = 'SFLOW' AND inputSnmpIfName = 'sfl-in'")
+                        .getFirst().getLong("c") > 0);
     }
 
     /**


### PR DESCRIPTION
Final phase of the `sflow-support` plan.

- **e2e**: sFlow devices join `Nl6FlowIngestionIT` — ledger reconciliation (epsilon 0: no templates), timestamp sanity, and the attribution proof: nl6's default here is **shared-socket mode**, so the UDP source is the container IP while `agent_address` is the device — persisted exporters must be `10.42.3.*`, and `inputSnmpIfName = 'sfl-in'` proves `NodeRegistry` matched the node by agent address (its subnet covers only devices). Verified locally: 4/4 ITs in 23s against real nl6 v0.15.1 datagrams.
- **Docs**: `sflow` receiver type + `multi` flag, payload-derived identity and sampling semantics (receivers.md), sub-agent pinning via `observation-domain` (nodes-and-snmp.md), the parsing floor note (enrichment.md). Docs production build green.
- D.1 residuals resolved: sFlow confirmed in the pinned nl6 v0.15.1; nl6 emits `header_protocol = 11` (raw IPv4) — e2e covers the direct-IPv4 path, Ethernet/VLAN stays fixture-tested.

Reviewed (medium, inline): no findings. `make jar` → 592 tests, all gates green.

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)