### PR TITLE
fix: sFlow review findings — sequence scoping, batch-poisoning engineId, DDL off-by-one

### DIFF
--- a/docs/docs/configuration/nodes-and-snmp.md
+++ b/docs/docs/configuration/nodes-and-snmp.md
@@ -35,6 +35,14 @@ domain (source ID). For **sFlow** both come from the datagram payload: subnets m
 the `agent_address` — which may differ from the UDP source — and `observation-domain`
 pins the `sub_agent_id`.
 
+:::warning The pin key is shared across protocols
+`observation-domain: 0` pins *both* NetFlow v5 exporters with engine type/ID 0 (their
+domain maps to `0`) *and* sFlow agents with the near-universal default
+`sub_agent_id = 0` — and a matching pin beats every wildcard node, even a
+more-specific one. If a subnet mixes NetFlow v5 and sFlow devices, avoid pinning `0`;
+distinguish the nodes by subnet instead.
+:::
+
 A node without an `snmp` block matches flows but is not polled — it can still enrich
 interfaces statically via the `interfaces` map (see below).
 

--- a/src/main/java/org/riptide/flows/parser/ParserBase.java
+++ b/src/main/java/org/riptide/flows/parser/ParserBase.java
@@ -134,9 +134,13 @@ public abstract class ParserBase implements Parser {
                                             final FlowPacket packet,
                                             final Session session,
                                             final InetSocketAddress remoteAddress) {
+        // one identity per packet: it scopes sequence tracking (below) and every
+        // dispatched flow's Source
+        final Source source = new Source(this.location, packet.identity(session.getRemoteAddress()));
+
         // Verify that flows sequences are in order
-        if (!session.verifySequenceNumber(packet.getObservationDomainId(), packet.getSequenceNumber())) {
-            log.warn("Error in flow sequence detected: from {}", session.getRemoteAddress());
+        if (!session.verifySequenceNumber(source.identity(), packet.getSequenceNumber())) {
+            log.warn("Error in flow sequence detected: from {}", source.identity());
             this.sequenceErrors.inc();
         }
 
@@ -146,7 +150,7 @@ public abstract class ParserBase implements Parser {
             final Runnable dispatch = () -> {
                 log.trace("Received flow: {}", flow);
 
-                this.dispatcher.accept(new Source(this.location, packet.identity(session.getRemoteAddress())), flow);
+                this.dispatcher.accept(source, flow);
 
                 this.recordsDispatched.mark();
             };

--- a/src/main/java/org/riptide/flows/parser/session/Session.java
+++ b/src/main/java/org/riptide/flows/parser/session/Session.java
@@ -7,6 +7,7 @@ package org.riptide.flows.parser.session;
 
 import org.riptide.flows.parser.exceptions.MissingTemplateException;
 import org.riptide.flows.parser.ie.Value;
+import org.riptide.pipeline.ExporterIdentity;
 
 import java.net.InetAddress;
 import java.util.Collection;
@@ -31,5 +32,10 @@ public interface Session {
 
     InetAddress getRemoteAddress();
 
-    boolean verifySequenceNumber(long observationDomainId, long sequenceNumber);
+    /**
+     * Sequence streams are scoped by the full exporter identity, not just the
+     * observation domain: sFlow agents with distinct payload agent addresses may share
+     * one UDP source, and their independent streams must not interleave in one tracker.
+     */
+    boolean verifySequenceNumber(ExporterIdentity scope, long sequenceNumber);
 }

--- a/src/main/java/org/riptide/flows/parser/session/TcpSession.java
+++ b/src/main/java/org/riptide/flows/parser/session/TcpSession.java
@@ -11,6 +11,7 @@ import org.riptide.flows.parser.ie.Value;
 import org.riptide.flows.parser.state.ExporterState;
 import org.riptide.flows.parser.state.OptionState;
 import org.riptide.flows.parser.state.TemplateState;
+import org.riptide.pipeline.ExporterIdentity;
 
 import java.net.InetAddress;
 import java.util.ArrayList;
@@ -105,7 +106,7 @@ public class TcpSession implements Session {
     private final InetAddress remoteAddress;
     private final Map<TemplateKey, Template> templates = new HashMap<>();
     private final Map<TemplateKey, Map<Set<Value<?>>, List<Value<?>>>> options = new HashMap<>();
-    private final Map<Long, SequenceNumberTracker> sequenceNumbers = new HashMap<>();
+    private final Map<ExporterIdentity, SequenceNumberTracker> sequenceNumbers = new HashMap<>();
 
     private final Supplier<SequenceNumberTracker> sequenceNumberTracker;
 
@@ -149,8 +150,8 @@ public class TcpSession implements Session {
     }
 
     @Override
-    public boolean verifySequenceNumber(long observationDomainId, final long sequenceNumber) {
-        final SequenceNumberTracker tracker = this.sequenceNumbers.computeIfAbsent(observationDomainId, (k) -> this.sequenceNumberTracker.get());
+    public boolean verifySequenceNumber(final ExporterIdentity scope, final long sequenceNumber) {
+        final SequenceNumberTracker tracker = this.sequenceNumbers.computeIfAbsent(scope, (k) -> this.sequenceNumberTracker.get());
         return tracker.verify(sequenceNumber);
     }
 

--- a/src/main/java/org/riptide/flows/parser/session/UdpSessionManager.java
+++ b/src/main/java/org/riptide/flows/parser/session/UdpSessionManager.java
@@ -12,6 +12,7 @@ import org.riptide.flows.parser.state.ExporterState;
 import org.riptide.flows.parser.state.OptionState;
 import org.riptide.flows.parser.state.ParserState;
 import org.riptide.flows.parser.state.TemplateState;
+import org.riptide.pipeline.ExporterIdentity;
 
 import java.net.InetAddress;
 import java.time.Duration;
@@ -34,7 +35,7 @@ import java.util.stream.Collectors;
 public class UdpSessionManager {
     private final ConcurrentMap<TemplateKey, TimeWrapper<TemplateOptions>> templates = new ConcurrentHashMap<>();
 
-    private final Map<DomainKey, SequenceNumberTracker> sequenceNumbers = new ConcurrentHashMap<>();
+    private final Map<TrackerKey, TrackedSequence> sequenceNumbers = new ConcurrentHashMap<>();
 
     private final Duration timeout;
 
@@ -48,6 +49,10 @@ public class UdpSessionManager {
     public void doHousekeeping() {
         final Instant timeout = Instant.now().minus(this.timeout);
         this.removeTemplateIf(e -> e.getValue().time.isBefore(timeout));
+        // sequence trackers have their own lifecycle: templates are re-announced and
+        // re-inserted, trackers are touched on every datagram — evict idle ones so
+        // churning sources (NAT, roaming agents) don't accumulate trackers forever
+        this.sequenceNumbers.entrySet().removeIf(e -> e.getValue().lastSeen.isBefore(timeout));
     }
 
     private void removeTemplateIf(final Predicate<Map.Entry<TemplateKey, TimeWrapper<TemplateOptions>>> predicate) {
@@ -60,10 +65,15 @@ public class UdpSessionManager {
 
     public void drop(final SessionKey sessionKey) {
         removeTemplateIf(e -> Objects.equals(e.getKey().observationDomainId.sessionKey, sessionKey));
+        this.sequenceNumbers.keySet().removeIf(key -> Objects.equals(key.sessionKey(), sessionKey));
     }
 
     public int count() {
         return this.templates.size();
+    }
+
+    int sequenceTrackerCount() {
+        return this.sequenceNumbers.size();
     }
 
     public Object dumpInternalState() {
@@ -173,6 +183,18 @@ public class UdpSessionManager {
         }
     }
 
+    private record TrackerKey(SessionKey sessionKey, ExporterIdentity scope) {
+    }
+
+    private static final class TrackedSequence {
+        private final SequenceNumberTracker tracker;
+        private volatile Instant lastSeen = Instant.now();
+
+        private TrackedSequence(final SequenceNumberTracker tracker) {
+            this.tracker = tracker;
+        }
+    }
+
     public static final class TemplateOptions {
         public final Template template;
         public final Map<Set<Value<?>>, TimeWrapper<List<Value<?>>>> options;
@@ -241,10 +263,12 @@ public class UdpSessionManager {
         }
 
         @Override
-        public boolean verifySequenceNumber(final long observationDomainId, final long sequenceNumber) {
-            final DomainKey key = new DomainKey(this.sessionKey, observationDomainId);
-            final SequenceNumberTracker tracker = UdpSessionManager.this.sequenceNumbers.computeIfAbsent(key, (k) -> UdpSessionManager.this.sequenceNumberTracker.get());
-            return tracker.verify(sequenceNumber);
+        public boolean verifySequenceNumber(final ExporterIdentity scope, final long sequenceNumber) {
+            final TrackerKey key = new TrackerKey(this.sessionKey, scope);
+            final TrackedSequence tracked = UdpSessionManager.this.sequenceNumbers.computeIfAbsent(key,
+                    (k) -> new TrackedSequence(UdpSessionManager.this.sequenceNumberTracker.get()));
+            tracked.lastSeen = Instant.now();
+            return tracked.tracker.verify(sequenceNumber);
         }
 
         private final class Resolver implements Session.Resolver {

--- a/src/main/java/org/riptide/flows/parser/sflow/SflowFlowBuilder.java
+++ b/src/main/java/org/riptide/flows/parser/sflow/SflowFlowBuilder.java
@@ -141,7 +141,9 @@ public final class SflowFlowBuilder {
 
             @Override
             public int getEngineId() {
-                return (int) datagram.subAgentId;
+                // sub_agent_id is a full uint32; clamp instead of casting negative —
+                // the persisted engineId column rejects out-of-range values batch-wide
+                return (int) Math.min(datagram.subAgentId, Integer.MAX_VALUE);
             }
 
             @Override

--- a/src/main/java/org/riptide/flows/parser/sflow/SflowUdpParser.java
+++ b/src/main/java/org/riptide/flows/parser/sflow/SflowUdpParser.java
@@ -24,8 +24,9 @@ import java.util.function.BiConsumer;
 
 /**
  * sFlow v5 (sflow.org spec; not RFC 3176 v4). Stateless on the wire — no templates —
- * but the session still tracks datagram sequence numbers per sub-agent via
- * {@link Datagram#getObservationDomainId()}.
+ * but datagram sequence numbers are still tracked, scoped by the full payload identity
+ * ({@code agent_address} + {@code sub_agent_id}) via
+ * {@link org.riptide.flows.parser.session.Session#verifySequenceNumber}.
  */
 public class SflowUdpParser extends UdpParserBase implements DispatchableUdpParser {
 

--- a/src/main/java/org/riptide/flows/parser/sflow/proto/Datagram.java
+++ b/src/main/java/org/riptide/flows/parser/sflow/proto/Datagram.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static org.riptide.flows.utils.BufferUtils.slice;
 import static org.riptide.flows.utils.BufferUtils.uint32;
 
 /**
@@ -53,34 +52,23 @@ public final class Datagram implements FlowPacket {
         if (this.agentAddress == null) {
             throw new InvalidPacketException(buffer, "Invalid agent address");
         }
+        if (buffer.readableBytes() < 16) {
+            throw new InvalidPacketException(buffer, "Truncated datagram header");
+        }
         this.subAgentId = uint32(buffer);
         this.sequence = uint32(buffer);
         this.uptime = uint32(buffer);
 
-        final long count = uint32(buffer);
         final List<FlowSample> samples = new ArrayList<>();
-        for (long i = 0; i < count; i++) {
-            if (buffer.readableBytes() < 8) {
-                throw new InvalidPacketException(buffer, "Truncated sample %d of %d", i + 1, count);
-            }
-            final long sampleType = uint32(buffer);
-            final int length = (int) uint32(buffer);
-            if (length < 0 || length > buffer.readableBytes()) {
-                throw new InvalidPacketException(buffer, "Invalid sample length: %d", length);
-            }
-            final ByteBuf sample = slice(buffer, length);
-
-            if ((sampleType >>> 12) != 0) {
-                continue; // vendor-specific sample: skip by length
-            }
-            switch ((int) (sampleType & 0xFFF)) {
+        Xdr.walk(buffer, uint32(buffer), "sample", (format, sample) -> {
+            switch (format) {
                 case SAMPLE_FLOW -> samples.add(new FlowSample(sample, false));
                 case SAMPLE_FLOW_EXPANDED -> samples.add(new FlowSample(sample, true));
                 default -> {
                     // counter samples and anything else: skip by length
                 }
             }
-        }
+        });
         this.samples = samples;
     }
 
@@ -97,7 +85,8 @@ public final class Datagram implements FlowPacket {
 
     @Override
     public long getObservationDomainId() {
-        // scopes sequence tracking per sub-agent, mirroring observation domains
+        // informational only: sequence tracking is scoped by identity(), which this
+        // class overrides with the full (agent address, sub-agent) payload identity
         return this.subAgentId;
     }
 

--- a/src/main/java/org/riptide/flows/parser/sflow/proto/ExtendedData.java
+++ b/src/main/java/org/riptide/flows/parser/sflow/proto/ExtendedData.java
@@ -8,9 +8,8 @@ package org.riptide.flows.parser.sflow.proto;
 import io.netty.buffer.ByteBuf;
 
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 
-import static org.riptide.flows.utils.BufferUtils.bytes;
+import static org.riptide.flows.utils.BufferUtils.inetAddress;
 import static org.riptide.flows.utils.BufferUtils.uint32;
 
 /**
@@ -83,11 +82,6 @@ public final class ExtendedData {
         if (size < 0 || b.readableBytes() < size) {
             return null;
         }
-        try {
-            return InetAddress.getByAddress(bytes(b, size));
-        } catch (final UnknownHostException e) {
-            // unreachable: length is always 4 or 16
-            throw new IllegalStateException(e);
-        }
+        return inetAddress(b, size);
     }
 }

--- a/src/main/java/org/riptide/flows/parser/sflow/proto/FlowSample.java
+++ b/src/main/java/org/riptide/flows/parser/sflow/proto/FlowSample.java
@@ -9,10 +9,7 @@ import com.google.common.base.MoreObjects;
 import io.netty.buffer.ByteBuf;
 import org.riptide.flows.parser.exceptions.InvalidPacketException;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-
-import static org.riptide.flows.utils.BufferUtils.bytes;
+import static org.riptide.flows.utils.BufferUtils.inetAddress;
 import static org.riptide.flows.utils.BufferUtils.slice;
 import static org.riptide.flows.utils.BufferUtils.uint32;
 
@@ -68,6 +65,9 @@ public final class FlowSample {
     }
 
     public FlowSample(final ByteBuf buffer, final boolean expanded) throws InvalidPacketException {
+        if (buffer.readableBytes() < (expanded ? 44 : 32)) {
+            throw new InvalidPacketException(buffer, "Truncated flow sample header");
+        }
         this.sequence = uint32(buffer);
         if (expanded) {
             uint32(buffer); // source_id type
@@ -86,26 +86,11 @@ public final class FlowSample {
             this.output = InterfaceValue.compact(uint32(buffer));
         }
 
-        final long records = uint32(buffer);
-        for (long i = 0; i < records; i++) {
-            if (buffer.readableBytes() < 8) {
-                throw new InvalidPacketException(buffer, "Truncated flow record %d of %d", i + 1, records);
-            }
-            final long dataFormat = uint32(buffer);
-            final int length = (int) uint32(buffer);
-            if (length < 0 || length > buffer.readableBytes()) {
-                throw new InvalidPacketException(buffer, "Invalid flow record length: %d", length);
-            }
-            this.record(dataFormat, slice(buffer, length));
-        }
+        Xdr.walk(buffer, uint32(buffer), "flow record", this::record);
     }
 
-    private void record(final long dataFormat, final ByteBuf b) {
-        final long enterprise = dataFormat >>> 12;
-        if (enterprise != 0) {
-            return; // vendor-specific record: skip by length
-        }
-        switch ((int) (dataFormat & 0xFFF)) {
+    private void record(final int format, final ByteBuf b) {
+        switch (format) {
             case RECORD_SAMPLED_HEADER -> {
                 if (b.readableBytes() < 16) {
                     return;
@@ -113,9 +98,11 @@ public final class FlowSample {
                 final int headerProtocol = (int) uint32(b);
                 this.frameLength = uint32(b);
                 uint32(b); // stripped octets
-                final int headerLength = (int) uint32(b);
+                // min in long domain: header_length is uint32 and must not go negative
+                // through an int cast (a crafted value would turn slice() into a throw)
+                final long headerLength = uint32(b);
                 this.packet = HeaderDecoder.decode(headerProtocol,
-                        slice(b, Math.min(headerLength, b.readableBytes())));
+                        slice(b, (int) Math.min(headerLength, b.readableBytes())));
             }
             case RECORD_SAMPLED_IPV4 -> this.sampledIp(b, 4);
             case RECORD_SAMPLED_IPV6 -> this.sampledIp(b, 6);
@@ -144,22 +131,13 @@ public final class FlowSample {
         info.ipVersion = version;
         this.frameLength = uint32(b);
         info.protocol = (int) uint32(b);
-        info.srcAddr = rawAddress(b, addressSize);
-        info.dstAddr = rawAddress(b, addressSize);
+        info.srcAddr = inetAddress(b, addressSize);
+        info.dstAddr = inetAddress(b, addressSize);
         info.srcPort = (int) uint32(b);
         info.dstPort = (int) uint32(b);
         info.tcpFlags = (int) uint32(b);
         info.tos = (int) uint32(b); // priority for IPv6 — same slot
         this.packet = info;
-    }
-
-    private static InetAddress rawAddress(final ByteBuf b, final int size) {
-        try {
-            return InetAddress.getByAddress(bytes(b, size));
-        } catch (final UnknownHostException e) {
-            // unreachable: length is always 4 or 16
-            throw new IllegalStateException(e);
-        }
     }
 
     @Override

--- a/src/main/java/org/riptide/flows/parser/sflow/proto/HeaderDecoder.java
+++ b/src/main/java/org/riptide/flows/parser/sflow/proto/HeaderDecoder.java
@@ -7,10 +7,7 @@ package org.riptide.flows.parser.sflow.proto;
 
 import io.netty.buffer.ByteBuf;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-
-import static org.riptide.flows.utils.BufferUtils.bytes;
+import static org.riptide.flows.utils.BufferUtils.inetAddress;
 import static org.riptide.flows.utils.BufferUtils.uint16;
 import static org.riptide.flows.utils.BufferUtils.uint32;
 import static org.riptide.flows.utils.BufferUtils.uint8;
@@ -93,8 +90,8 @@ public final class HeaderDecoder {
         b.skipBytes(1); // ttl
         info.protocol = uint8(b);
         b.skipBytes(2); // checksum
-        info.srcAddr = address(bytes(b, 4));
-        info.dstAddr = address(bytes(b, 4));
+        info.srcAddr = inetAddress(b, 4);
+        info.dstAddr = inetAddress(b, 4);
 
         final int options = headerLength - 20;
         if (options < 0 || b.readableBytes() < options) {
@@ -121,8 +118,8 @@ public final class HeaderDecoder {
         b.skipBytes(2); // payload length
         int next = uint8(b);
         b.skipBytes(1); // hop limit
-        info.srcAddr = address(bytes(b, 16));
-        info.dstAddr = address(bytes(b, 16));
+        info.srcAddr = inetAddress(b, 16);
+        info.dstAddr = inetAddress(b, 16);
 
         for (int i = 0; i < MAX_IPV6_EXTENSIONS; i++) {
             if (next == 0 || next == 43 || next == 60) { // hop-by-hop, routing, dest-opts
@@ -169,12 +166,4 @@ public final class HeaderDecoder {
         }
     }
 
-    private static InetAddress address(final byte[] octets) {
-        try {
-            return InetAddress.getByAddress(octets);
-        } catch (final UnknownHostException e) {
-            // unreachable: length is always 4 or 16
-            throw new IllegalStateException(e);
-        }
-    }
 }

--- a/src/main/java/org/riptide/flows/parser/sflow/proto/Xdr.java
+++ b/src/main/java/org/riptide/flows/parser/sflow/proto/Xdr.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.parser.sflow.proto;
+
+import io.netty.buffer.ByteBuf;
+import org.riptide.flows.parser.exceptions.InvalidPacketException;
+
+import static org.riptide.flows.utils.BufferUtils.slice;
+import static org.riptide.flows.utils.BufferUtils.uint32;
+
+/**
+ * The XDR (type, length, payload) walk shared by sFlow's sample and flow-record lists
+ * (sflow_version_5.txt §5.3): one bounds-checking implementation so a framing fix can
+ * never apply to samples but not records. Vendor-enterprise entries (enterprise bits
+ * nonzero) are skipped by length; the consumer sees only standard-enterprise formats.
+ */
+final class Xdr {
+
+    interface EntryConsumer {
+        void accept(int format, ByteBuf payload) throws InvalidPacketException;
+    }
+
+    private Xdr() {
+    }
+
+    static void walk(final ByteBuf buffer,
+                     final long count,
+                     final String what,
+                     final EntryConsumer consumer) throws InvalidPacketException {
+        for (long i = 0; i < count; i++) {
+            if (buffer.readableBytes() < 8) {
+                throw new InvalidPacketException(buffer, "Truncated %s %d of %d", what, i + 1, count);
+            }
+            final long dataFormat = uint32(buffer);
+            final long length = uint32(buffer);
+            if (length > buffer.readableBytes()) {
+                throw new InvalidPacketException(buffer, "Invalid %s length: %d", what, length);
+            }
+            final ByteBuf payload = slice(buffer, (int) length);
+
+            if ((dataFormat >>> 12) != 0) {
+                continue; // vendor-specific: skip by length
+            }
+            consumer.accept((int) (dataFormat & 0xFFF), payload);
+        }
+    }
+}

--- a/src/main/java/org/riptide/flows/utils/BufferUtils.java
+++ b/src/main/java/org/riptide/flows/utils/BufferUtils.java
@@ -9,6 +9,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.primitives.UnsignedLong;
 import io.netty.buffer.ByteBuf;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.nio.BufferUnderflowException;
 import java.util.function.Function;
 
@@ -116,5 +118,16 @@ public final class BufferUtils {
         final byte[] result = new byte[size];
         buffer.readBytes(result);
         return result;
+    }
+
+    /** Reads {@code octets} bytes (4 or 16) as an address. */
+    public static InetAddress inetAddress(final ByteBuf buffer, final int octets) {
+        Preconditions.checkArgument(octets == 4 || octets == 16);
+        try {
+            return InetAddress.getByAddress(bytes(buffer, octets));
+        } catch (final UnknownHostException e) {
+            // unreachable: getByAddress only rejects lengths other than 4 and 16
+            throw new IllegalStateException(e);
+        }
     }
 }

--- a/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
+++ b/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
@@ -124,7 +124,7 @@ public class ClickhouseRepository implements FlowRepository {
     
             direction Enum8('INGRESS' = 1, 'EGRESS' = 2, 'UNKNOWN' = 3),
     
-            engineId UInt16,
+            engineId UInt32,
             engineType UInt16,
     
             vlan UInt16,
@@ -134,14 +134,14 @@ public class ClickhouseRepository implements FlowRepository {
             tos UInt8,
     
             samplingAlgorithm Enum8(
-                'Unassigned' = 0,
-                'SystematicCountBasedSampling' = 1,
-                'SystematicTimeBasedSampling' = 2,
-                'RandomNOutOfNSampling' = 3,
-                'UniformProbabilisticSampling' = 4,
-                'PropertyMatchFiltering' = 5,
-                'HashBasedFiltering' = 6,
-                'FlowStateDependentIntermediateFlowSelectionProcess' = 7
+                'Unassigned' = 1,
+                'SystematicCountBasedSampling' = 2,
+                'SystematicTimeBasedSampling' = 3,
+                'RandomNOutOfNSampling' = 4,
+                'UniformProbabilisticSampling' = 5,
+                'PropertyMatchFiltering' = 6,
+                'HashBasedFiltering' = 7,
+                'FlowStateDependentIntermediateFlowSelectionProcess' = 8
             ),\s
             samplingInterval Float64,
     

--- a/src/test/java/org/riptide/e2e/Nl6FlowIngestionIT.java
+++ b/src/test/java/org/riptide/e2e/Nl6FlowIngestionIT.java
@@ -136,6 +136,12 @@ public class Nl6FlowIngestionIT {
         reconcile("sflow", "SFLOW", 0.0);
         verifyTimestampsSane("SFLOW");
 
+        final var algorithms = queryClient.queryAll(
+                "SELECT DISTINCT samplingAlgorithm FROM flows WHERE flowProtocol = 'SFLOW'");
+        Assertions.assertThat(algorithms).hasSize(1);
+        Assertions.assertThat(algorithms.getFirst().getString("samplingAlgorithm"))
+                .isEqualTo("RandomNOutOfNSampling");
+
         final var exporters = queryClient.queryAll(
                 "SELECT DISTINCT exporterAddr FROM flows WHERE flowProtocol = 'SFLOW'");
         Assertions.assertThat(exporters).isNotEmpty().allSatisfy(row ->

--- a/src/test/java/org/riptide/flows/parser/session/UdpSessionManagerTest.java
+++ b/src/test/java/org/riptide/flows/parser/session/UdpSessionManagerTest.java
@@ -11,7 +11,9 @@ import org.riptide.flows.parser.ie.Value;
 import org.riptide.flows.parser.ie.values.StringValue;
 import org.riptide.flows.parser.ipfix.IpfixUdpParser;
 import org.riptide.flows.parser.netflow9.Netflow9UdpParser;
+import org.riptide.pipeline.ExporterIdentity;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -194,5 +196,41 @@ public class UdpSessionManagerTest {
         testIpFixSessionKeys(remoteAddress1, localAddress1, remoteAddress3, localAddress2, false);
         testIpFixSessionKeys(remoteAddress1, localAddress1, remoteAddress4, localAddress1, false);
         testIpFixSessionKeys(remoteAddress1, localAddress1, remoteAddress4, localAddress2, false);
+    }
+
+    @Test
+    public void sequenceStreamsAreScopedByExporterIdentity() throws Exception {
+        // two sFlow agents behind ONE UDP source (relay/NAT/shared socket), both
+        // sub_agent_id 0: their independent sequence streams must not interleave in
+        // a single tracker (which flags spurious errors for gaps within patience)
+        final var sessionKey = new Netflow9UdpParser.SessionKey(remoteAddress1.getAddress(), localAddress1);
+        final var manager = new UdpSessionManager(Duration.ofMinutes(30), () -> new SequenceNumberTracker(32));
+        final var session = manager.getSession(sessionKey);
+
+        final var agentA = new ExporterIdentity.Sflow(InetAddress.getByName("10.0.0.1"), 0);
+        final var agentB = new ExporterIdentity.Sflow(InetAddress.getByName("10.0.0.2"), 0);
+
+        assertThat(session.verifySequenceNumber(agentA, 1)).isTrue();
+        assertThat(session.verifySequenceNumber(agentB, 20)).isTrue();
+        assertThat(session.verifySequenceNumber(agentA, 2)).isTrue();
+        assertThat(session.verifySequenceNumber(agentB, 21)).isTrue();
+        assertThat(manager.sequenceTrackerCount()).isEqualTo(2);
+    }
+
+    @Test
+    public void housekeepingAndDropEvictSequenceTrackers() throws Exception {
+        final var sessionKey = new Netflow9UdpParser.SessionKey(remoteAddress1.getAddress(), localAddress1);
+        final var manager = new UdpSessionManager(Duration.ofMinutes(0), () -> new SequenceNumberTracker(32));
+        final var identity = new ExporterIdentity.Sflow(InetAddress.getByName("10.0.0.1"), 0);
+
+        manager.getSession(sessionKey).verifySequenceNumber(identity, 1);
+        assertThat(manager.sequenceTrackerCount()).isEqualTo(1);
+        manager.doHousekeeping();
+        assertThat(manager.sequenceTrackerCount()).isZero();
+
+        manager.getSession(sessionKey).verifySequenceNumber(identity, 2);
+        assertThat(manager.sequenceTrackerCount()).isEqualTo(1);
+        manager.drop(sessionKey);
+        assertThat(manager.sequenceTrackerCount()).isZero();
     }
 }

--- a/src/test/java/org/riptide/flows/parser/sflow/SflowParserTest.java
+++ b/src/test/java/org/riptide/flows/parser/sflow/SflowParserTest.java
@@ -344,4 +344,43 @@ public class SflowParserTest {
         truncated.setInt(24, 1); // num_samples word for an IPv4 agent datagram
         assertThatThrownBy(() -> new Datagram(truncated)).isInstanceOf(InvalidPacketException.class);
     }
+
+    @Test
+    public void hugeHeaderLengthStaysLenient() throws Exception {
+        // header_length 0xFFFFFFFF must not abort the datagram (a negative int cast
+        // used to turn slice() into an unchecked throw); decode what is readable
+        final var frame = ethernetIpv4Tcp();
+        final var record = buf();
+        u32(record, 1, 1500, 4, 0xFFFFFFFFL); // header_protocol, frame_length, stripped, header_length
+        record.writeBytes(frame);
+        final var body = flowSampleBody(2, 1, 1, record(1, record));
+
+        final var flow = flows(datagram("10.1.1.1", 0, sample(1, body))).getFirst();
+
+        assertThat(flow.getSrcAddr()).isEqualTo(InetAddress.getByName("192.0.2.1"));
+        assertThat(flow.getBytes()).isEqualTo(3000);
+    }
+
+    @Test
+    public void undersizedSampleLengthThrowsInvalidPacket() throws Exception {
+        final var stub = buf();
+        u32(stub, 42, 1); // 8 bytes, far below the 32-byte flow_sample fixed header
+        final var d = datagram("10.1.1.1", 0, sample(1, stub));
+
+        assertThatThrownBy(() -> new Datagram(d))
+                .isInstanceOf(InvalidPacketException.class)
+                .hasMessageContaining("Truncated flow sample header");
+    }
+
+    @Test
+    public void engineIdClampsInsteadOfCastingNegative() throws Exception {
+        final var body = flowSampleBody(1, 1, 1);
+        final var d = new Datagram(datagram("10.1.1.1", 0x80000001L, sample(1, body)));
+
+        final var flow = d.buildFlows(NOW).toList().getFirst();
+
+        assertThat(flow.getEngineId()).isEqualTo(Integer.MAX_VALUE); // clamped, not negative
+        assertThat(d.identity(InetAddress.getByName("192.0.2.9")))
+                .isEqualTo(new ExporterIdentity.Sflow(InetAddress.getByName("10.1.1.1"), 0x80000001L)); // identity keeps the real value
+    }
 }


### PR DESCRIPTION
Follow-up applying the verified findings from the structured `/code-review medium` pass over #209–#211 (8 findings: 6 CONFIRMED, 1 PLAUSIBLE, 1 duplication).

## Correctness
- **engineId batch poisoning** — DDL `engineId` UInt16 → UInt32 + clamp of the uint32 `sub_agent_id` (a single agent with sub_agent_id > 65535 failed entire insert batches client-side, taking other exporters' flows with it). Identity keeps the unclamped value.
- **Crafted header_length datagram abort** — `header_length ≥ 2^31` went negative through an int cast and turned `slice()` into an unchecked throw, discarding every valid sample in the datagram; now min-ed in long domain (regression test with `0xFFFFFFFF`).
- **Sequence-tracker collision** — tracking rescoped from `(UDP source, domain)` to the full `ExporterIdentity`; agents behind one socket (the topology sFlow's payload identity exists for) no longer share a tracker (empirically: interleaved streams within tracker patience produced mass spurious sequenceErrors). Warn log names the identity, one `Source` per packet. Partitioning for NetFlow/IPFIX is provably unchanged (identity address is derived from the session key).
- **samplingAlgorithm off-by-one** — DDL enum renumbered 1-based to match the uniform `ordinal()+1` mappers; every sFlow row had persisted `UniformProbabilisticSampling` instead of `RandomNOutOfNSampling` (e2e now asserts the label), and IPFIX selectorAlgorithm 9 no longer maps to an undefined byte.
- **Tracker eviction** (pre-existing, all UDP parsers) — idle sequence trackers are evicted by housekeeping and `drop()`; previously the map only ever grew.

## Robustness & cleanup
- `readableBytes` guards on datagram/sample fixed prefixes → `InvalidPacketException` with hex-dump diagnostics instead of raw netty IOOBE
- XDR TLV walk deduplicated into `Xdr.walk` (one bounds-check implementation for samples and records); `BufferUtils.inetAddress` replaces three identical helpers
- Docs: warning that `observation-domain: 0` pins both NetFlow v5 engine-0/0 exporters and default sFlow sub-agents (pin beats any wildcard) — mitigate by subnet
- Deliberately NOT changed: payload-derived attribution (spec'd), `multi` sflow default (consistent with siblings), sessionCount gauge semantics (pre-existing netflow5 pattern, tracked separately if wanted)

## Review & verification
Structured 2-finder pass ran on THIS branch too; one finding (stale sequence-scoping javadoc) fixed. `make jar` → **597 tests**, all gates green; sFlow e2e re-run locally green in 18s including the new samplingAlgorithm assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)