### PR TITLE
docs: Serve the site at the riptide.space root

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,15 +29,6 @@ jobs:
       - name: Build documentation
         run: |
           make docs
-      - name: Stage site under /docs with root redirect
-        run: |
-          mkdir -p site/docs
-          cp -R docs/build/. site/docs/
-          cat > site/index.html <<'EOF'
-          <!DOCTYPE html>
-          <meta http-equiv="refresh" content="0; url=/docs/">
-          <link rel="canonical" href="https://riptide.space/docs/">
-          EOF
       - name: Configure GitHub Pages
         if: github.event_name != 'pull_request'
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,14 @@ Thanks for considering a contribution! 🌊
 
 The contributor guide lives in the documentation:
 
-**https://riptide-labs.github.io/riptide/develop/environment**
+**https://riptide.space/develop/environment**
 
 In short:
 
-- [Environment](https://riptide-labs.github.io/riptide/develop/environment) — clone, `make`, IDE setup
-- [Run & debug](https://riptide-labs.github.io/riptide/develop/run-and-debug) — local stack, pcap replay, nl6
-- [Testing](https://riptide-labs.github.io/riptide/develop/testing) — unit / e2e / full-mode tiers
-- [Pull requests](https://riptide-labs.github.io/riptide/develop/pull-requests) — CI quality gates,
+- [Environment](https://riptide.space/develop/environment) — clone, `make`, IDE setup
+- [Run & debug](https://riptide.space/develop/run-and-debug) — local stack, pcap replay, nl6
+- [Testing](https://riptide.space/develop/testing) — unit / e2e / full-mode tiers
+- [Pull requests](https://riptide.space/develop/pull-requests) — CI quality gates,
   **DCO sign-off (`git commit -s`)**, Conventional Commits
 
 Riptide is licensed [GPL-3.0-or-later](LICENSE).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 Give people who love working with networks the tools they deserve to optimize and troubleshoot network traffic.
 
-📖 **Documentation:** https://riptide-labs.github.io/riptide/
+📖 **Documentation:** https://riptide.space/
 
 # 👩‍🏭 Build from source
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -13,7 +13,7 @@ const config: Config = {
   favicon: 'img/favicon.png',
 
   url: 'https://riptide.space',
-  baseUrl: '/docs/',
+  baseUrl: '/',
 
   organizationName: 'Riptide-Labs',
   projectName: 'riptide',


### PR DESCRIPTION
Fixes https://riptide.space/ — DNS (Pages A/AAAA + www CNAME), the Pages `cname`, and HTTPS enforcement were all already correct; the break was `baseUrl: '/docs/'` against an artifact deployed at the domain root: the root page returned HTML whose every asset/link pointed at `/docs/…` (404), with Docusaurus's red wrong-baseUrl banner injected.

- `baseUrl` → `'/'` (matches the deployed artifact layout; `url` stays `https://riptide.space`)
- Removed the dead **Stage site under /docs** workflow step — it staged a `site/` tree the upload step never referenced (`path: docs/build`), and it's the trap that would break the site again if someone "fixed" the upload path to match it (review finding)
- README + CONTRIBUTING: 6 links moved from `riptide-labs.github.io/riptide` → `riptide.space`

Reviewed (agent finder pass): 1 finding (the dead staging step), fixed here; all rewritten links verified to resolve under the new baseUrl. `npm run build` green (`onBrokenLinks: throw`).

If a separate landing page at the root is ever wanted (docs under `/docs/`), that's a deliberate artifact-restructure + baseUrl change together — noted here so the intent behind the old step isn't lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)