### PR TITLE
docs: Default the color theme to the system preference

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -53,6 +53,11 @@ const config: Config = {
   ],
 
   themeConfig: {
+    // follow the OS dark/light preference by default; the navbar toggle still
+    // lets visitors override it (persisted in localStorage)
+    colorMode: {
+      respectPrefersColorScheme: true,
+    },
     // og:image / social card for links shared to Slack, Mastodon, …
     image: 'img/favicon.png',
     navbar: {


### PR DESCRIPTION
Adds `colorMode.respectPrefersColorScheme: true` — the site now follows the visitor's OS dark/light preference by default instead of forcing light. The navbar toggle still overrides (persisted in localStorage; system-driven changes deliberately are not persisted). `defaultMode` stays unset on purpose: it is only consulted when `respectPrefersColorScheme` is off.

Verified: production build green; built HTML boots via `matchMedia('(prefers-color-scheme: dark)')` in the blocking inline script (no wrong-theme flash). Agent review pass: no findings — dark-mode CSS variants and prism darkTheme already present, logo legible on the dark navbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)