### PR TITLE
docs: Serve the site under riptide.space/docs/

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,24 @@ jobs:
       - name: Build documentation
         run: |
           make docs
+      # The Docusaurus site lives under /docs (baseUrl must match); the domain root
+      # redirects there until a landing page exists. 404.html must sit at the
+      # artifact root — GitHub Pages only serves it from there — and gets a
+      # redirector so pre-move deep links (riptide.space/X and legacy
+      # riptide-labs.github.io/riptide/X, which GitHub forwards path-preserving)
+      # land on /docs/X instead of a dead end. Real 404s under /docs/ still
+      # render the Docusaurus page.
+      - name: Stage site under /docs with root redirect
+        run: |
+          mkdir -p site/docs
+          cp -R docs/build/. site/docs/
+          REDIRECT='<script>(function(){var p=location.pathname;if(p.indexOf("/docs")!==0){location.replace("/docs"+p+location.search+location.hash)}})()</script>'
+          sed "s|<head>|<head>${REDIRECT}|" docs/build/404.html > site/404.html
+          cat > site/index.html <<'EOF'
+          <!DOCTYPE html>
+          <meta http-equiv="refresh" content="0; url=/docs/">
+          <link rel="canonical" href="https://riptide.space/docs/">
+          EOF
       - name: Configure GitHub Pages
         if: github.event_name != 'pull_request'
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
@@ -36,7 +54,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          path: docs/build
+          path: site
 
   deploy:
     if: github.event_name != 'pull_request'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,14 @@ Thanks for considering a contribution! 🌊
 
 The contributor guide lives in the documentation:
 
-**https://riptide.space/develop/environment**
+**https://riptide.space/docs/develop/environment**
 
 In short:
 
-- [Environment](https://riptide.space/develop/environment) — clone, `make`, IDE setup
-- [Run & debug](https://riptide.space/develop/run-and-debug) — local stack, pcap replay, nl6
-- [Testing](https://riptide.space/develop/testing) — unit / e2e / full-mode tiers
-- [Pull requests](https://riptide.space/develop/pull-requests) — CI quality gates,
+- [Environment](https://riptide.space/docs/develop/environment) — clone, `make`, IDE setup
+- [Run & debug](https://riptide.space/docs/develop/run-and-debug) — local stack, pcap replay, nl6
+- [Testing](https://riptide.space/docs/develop/testing) — unit / e2e / full-mode tiers
+- [Pull requests](https://riptide.space/docs/develop/pull-requests) — CI quality gates,
   **DCO sign-off (`git commit -s`)**, Conventional Commits
 
 Riptide is licensed [GPL-3.0-or-later](LICENSE).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 Give people who love working with networks the tools they deserve to optimize and troubleshoot network traffic.
 
-📖 **Documentation:** https://riptide.space/
+📖 **Documentation:** https://riptide.space/docs/
 
 # 👩‍🏭 Build from source
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -13,7 +13,7 @@ const config: Config = {
   favicon: 'img/favicon.png',
 
   url: 'https://riptide.space',
-  baseUrl: '/',
+  baseUrl: '/docs/',
 
   organizationName: 'Riptide-Labs',
   projectName: 'riptide',


### PR DESCRIPTION
Frees the domain root for a future landing page by moving the docs to **https://riptide.space/docs/** — the intent behind the old staging step, completed properly this time:

- `baseUrl: '/docs/'` + staging step + `upload-pages-artifact` path → `site` (**the missing half before** — the old step staged a tree the upload ignored)
- Root `index.html` → meta-refresh + canonical to `/docs/`
- Artifact-root `404.html` = Docusaurus 404 **plus a redirector**: non-`/docs` paths forward to `/docs<path>` — heals every pre-move deep link *and* all legacy `riptide-labs.github.io/riptide/X` links (GitHub forwards those path-preserving); genuine 404s under `/docs/` still render the Docusaurus page (review finding, fixed in-branch)
- README/CONTRIBUTING links + v0.1.0 release-notes links updated to `/docs/`

**Verified locally:** production build green; staging simulated (`site/404.html`, `site/docs/` with `/docs/`-prefixed assets); the workflow heredoc/sed exercised standalone. Agent review pass: 1 finding (deep-link dead end), fixed as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)