### PR TITLE
feat: Interface enrichment from v9/IPFIX option records (#165)

### DIFF
--- a/docs/docs/configuration/nodes-and-snmp.md
+++ b/docs/docs/configuration/nodes-and-snmp.md
@@ -44,7 +44,11 @@ distinguish the nodes by subnet instead.
 :::
 
 A node without an `snmp` block matches flows but is not polled — it can still enrich
-interfaces statically via the `interfaces` map (see below).
+interfaces statically via the `interfaces` map (see below), and from **exporter-pushed
+option records** (e.g. Cisco `option interface-table`) with zero configuration. SNMP
+stays worth configuring even then: option records carry names/descriptions but never
+ifAlias or ifHighSpeed, and a real SNMP ifAlias outranks an option-record description
+(see [Enrichment](../enrichment.md)).
 
 ## Static interface mapping
 

--- a/docs/docs/enrichment.md
+++ b/docs/docs/enrichment.md
@@ -17,6 +17,7 @@ gracefully** — in the worst case a flow carries exactly what the packets said:
 | Layer | Source | Needs |
 |---|---|---|
 | 2 — live | SNMP IF-MIB, reverse DNS | reachable agents/resolvers |
+| 1.5 — exporter-pushed | v9/IPFIX interface option records (`option interface-table`) | the exporter sending them — nothing on riptide's side |
 | 1 — static | operator mapping files (node `interfaces`, routing mapping) | a config file |
 | 0 — packet | ifIndex numbers, exporter-sent AS numbers, addresses, next hop | nothing — always available |
 
@@ -24,6 +25,15 @@ gracefully** — in the worst case a flow carries exactly what the packets said:
 value; live sources fill the fields the file doesn't set; packet data is the floor.
 For AS numbers, a **nonzero exporter-provided value always wins** — the routing mapping
 only fills zeros.
+
+For interface fields, exporter-pushed option data and live SNMP share the work with
+**per-field authority** (after any static pin): the interface **name** prefers the
+option record (IE 82 is exactly ifName, and pushed data is fresher than a poll); the
+**alias** prefers SNMP ifAlias — IE 83 (`interfaceDescription`) may carry ifDescr- or
+ifAlias-style content depending on the vendor, so it only fills the alias when SNMP
+can't; the **speed** exists only in SNMP. Cisco IOS-XR exporters send their interface
+table with descriptions only (no IE 82) — those flows get aliases without any SNMP
+configuration.
 
 The floor extends into parsing: an sFlow sample whose raw packet header cannot be
 decoded (truncated by the sampler, non-IP payload) still becomes a flow carrying the

--- a/src/main/java/org/riptide/flows/Daemon.java
+++ b/src/main/java/org/riptide/flows/Daemon.java
@@ -24,6 +24,7 @@ import org.riptide.flows.parser.sflow.SflowUdpParser;
 import org.riptide.flows.parser.netflow9.Netflow9UdpParser;
 import org.riptide.pipeline.FlowException;
 import org.riptide.pipeline.Pipeline;
+import org.riptide.snmp.ExporterInterfaceTable;
 import org.riptide.pipeline.Source;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.ApplicationArguments;
@@ -47,6 +48,7 @@ public class Daemon implements ApplicationRunner {
                   final MetricRegistry metricRegistry,
                   @Qualifier("ipfixValueConversionService") final ValueConversionService ipfixValueConversionService,
                   @Qualifier("netflow9ValueConversionService") final ValueConversionService netflow9ValueConversionService,
+                  final ExporterInterfaceTable exporterInterfaceTable,
                   final DaemonConfig config) {
         final var location = config.getLocation();
 
@@ -77,6 +79,7 @@ public class Daemon implements ApplicationRunner {
                                 .withFlowActiveTimeoutFallback(config.getFlowActiveTimeoutFallback())
                                 .withFlowInactiveTimeoutFallback(config.getFlowInactiveTimeoutFallback())
                                 .withFlowSamplingIntervalFallback(config.getFlowSamplingIntervalFallback());
+                        parser.setOptionListener(exporterInterfaceTable);
 
                         return new UdpListener(e.getKey(), parser, metricRegistry)
                                 .withPort(config.getPort())
@@ -92,6 +95,8 @@ public class Daemon implements ApplicationRunner {
                                         .withFlowInactiveTimeoutFallback(config.getFlowInactiveTimeoutFallback())
                                         .withFlowSamplingIntervalFallback(config.getFlowSamplingIntervalFallback());
 
+                                parser.setOptionListener(exporterInterfaceTable);
+
                                 yield new UdpListener(e.getKey(), parser, metricRegistry)
                                         .withPort(config.getPort())
                                         .withHost(config.getHost());
@@ -101,6 +106,8 @@ public class Daemon implements ApplicationRunner {
                                         .withFlowActiveTimeoutFallback(config.getFlowActiveTimeoutFallback())
                                         .withFlowInactiveTimeoutFallback(config.getFlowInactiveTimeoutFallback())
                                         .withFlowSamplingIntervalFallback(config.getFlowSamplingIntervalFallback());
+
+                                parser.setOptionListener(exporterInterfaceTable);
 
                                 yield new TcpListener(e.getKey(), parser, metricRegistry)
                                         .withPort(config.getPort())
@@ -131,17 +138,21 @@ public class Daemon implements ApplicationRunner {
                         }
 
                         if (config.isNetflow9()) {
-                            parsers.add(new Netflow9UdpParser(e.getKey() + ":netflow9", dispatcher, location, metricRegistry, netflow9ValueConversionService)
+                            final var netflow9 = new Netflow9UdpParser(e.getKey() + ":netflow9", dispatcher, location, metricRegistry, netflow9ValueConversionService)
                                     .withFlowActiveTimeoutFallback(config.getFlowActiveTimeoutFallback())
                                     .withFlowInactiveTimeoutFallback(config.getFlowInactiveTimeoutFallback())
-                                    .withFlowSamplingIntervalFallback(config.getFlowSamplingIntervalFallback()));
+                                    .withFlowSamplingIntervalFallback(config.getFlowSamplingIntervalFallback());
+                            netflow9.setOptionListener(exporterInterfaceTable);
+                            parsers.add(netflow9);
                         }
 
                         if (config.isIpfix()) {
-                            parsers.add(new IpfixUdpParser(e.getKey() + ":ipfix", dispatcher, location, metricRegistry, ipfixValueConversionService)
+                            final var ipfix = new IpfixUdpParser(e.getKey() + ":ipfix", dispatcher, location, metricRegistry, ipfixValueConversionService)
                                     .withFlowActiveTimeoutFallback(config.getFlowActiveTimeoutFallback())
                                     .withFlowInactiveTimeoutFallback(config.getFlowInactiveTimeoutFallback())
-                                    .withFlowSamplingIntervalFallback(config.getFlowSamplingIntervalFallback()));
+                                    .withFlowSamplingIntervalFallback(config.getFlowSamplingIntervalFallback());
+                            ipfix.setOptionListener(exporterInterfaceTable);
+                            parsers.add(ipfix);
                         }
 
                         final var parser = new DispatchingUdpParser(e.getKey(), parsers);

--- a/src/main/java/org/riptide/flows/parser/UdpParserBase.java
+++ b/src/main/java/org/riptide/flows/parser/UdpParserBase.java
@@ -13,6 +13,7 @@ import io.netty.buffer.ByteBuf;
 import org.riptide.flows.listeners.UdpParser;
 import org.riptide.flows.parser.data.Flow;
 import org.riptide.flows.parser.session.Session;
+import org.riptide.flows.parser.session.OptionListener;
 import org.riptide.flows.parser.session.UdpSessionManager;
 import org.riptide.pipeline.Source;
 import org.slf4j.Logger;
@@ -21,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -39,6 +41,7 @@ public abstract class UdpParserBase extends ParserBase implements UdpParser {
 
     private ScheduledFuture<?> housekeepingFuture;
     private Duration templateTimeout = Duration.ofMinutes(30);
+    private OptionListener optionListener = OptionListener.NONE;
 
     public UdpParserBase(final Protocol protocol,
                          final String name,
@@ -82,10 +85,15 @@ public abstract class UdpParserBase extends ParserBase implements UdpParser {
         }
     }
 
+    /** Must be set before {@link #start}; the session manager is built there. */
+    public void setOptionListener(final OptionListener optionListener) {
+        this.optionListener = Objects.requireNonNull(optionListener);
+    }
+
     @Override
     public void start(final ScheduledExecutorService executorService) {
         super.start(executorService);
-        this.sessionManager = new UdpSessionManager(this.templateTimeout, this::sequenceNumberTracker);
+        this.sessionManager = new UdpSessionManager(this.templateTimeout, this::sequenceNumberTracker, this.optionListener);
         this.housekeepingFuture = executorService.scheduleAtFixedRate(this.sessionManager::doHousekeeping,
                 HOUSEKEEPING_INTERVAL,
                 HOUSEKEEPING_INTERVAL,

--- a/src/main/java/org/riptide/flows/parser/ipfix/IpfixTcpParser.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/IpfixTcpParser.java
@@ -16,6 +16,7 @@ import org.riptide.flows.parser.data.Flow;
 import org.riptide.flows.parser.FlowPacket;
 import org.riptide.flows.parser.ipfix.proto.Header;
 import org.riptide.flows.parser.ipfix.proto.Packet;
+import org.riptide.flows.parser.session.OptionListener;
 import org.riptide.flows.parser.session.TcpSession;
 import org.riptide.flows.parser.state.ParserState;
 import org.riptide.pipeline.Source;
@@ -24,6 +25,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -38,6 +40,12 @@ public class IpfixTcpParser extends ParserBase implements TcpParser {
 
     private final Set<TcpSession> sessions = Sets.newConcurrentHashSet();
 
+    private OptionListener optionListener = OptionListener.NONE;
+
+    public void setOptionListener(final OptionListener optionListener) {
+        this.optionListener = Objects.requireNonNull(optionListener);
+    }
+
     public IpfixTcpParser(final String name,
                           final BiConsumer<Source, Flow> dispatcher,
                           final String location,
@@ -50,7 +58,7 @@ public class IpfixTcpParser extends ParserBase implements TcpParser {
     @Override
     public Handler accept(final InetSocketAddress remoteAddress,
                           final InetSocketAddress localAddress) {
-        final TcpSession session = new TcpSession(remoteAddress.getAddress(), this::sequenceNumberTracker);
+        final TcpSession session = new TcpSession(remoteAddress.getAddress(), this::sequenceNumberTracker, this.optionListener);
 
         return new Handler() {
             @Override

--- a/src/main/java/org/riptide/flows/parser/session/OptionListener.java
+++ b/src/main/java/org/riptide/flows/parser/session/OptionListener.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.parser.session;
+
+import org.riptide.flows.parser.ie.Value;
+import org.riptide.pipeline.ExporterIdentity;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Observes option data records at arrival, with raw scopes and fields intact. This is
+ * the only place `(exporter identity, ifIndex → interface name)` mappings exist in a
+ * consumable shape: the per-record option merge can never carry interface options
+ * (v9 scope names don't appear as data-record fields by construction; IPFIX matches
+ * the ingress side at most), so consumers tap here instead.
+ */
+public interface OptionListener {
+
+    OptionListener NONE = (identity, scopes, values) -> {
+    };
+
+    void accept(ExporterIdentity identity, Collection<Value<?>> scopes, List<Value<?>> values);
+}

--- a/src/main/java/org/riptide/flows/parser/session/TcpSession.java
+++ b/src/main/java/org/riptide/flows/parser/session/TcpSession.java
@@ -110,9 +110,18 @@ public class TcpSession implements Session {
 
     private final Supplier<SequenceNumberTracker> sequenceNumberTracker;
 
+    private final OptionListener optionListener;
+
     public TcpSession(final InetAddress remoteAddress, final Supplier<SequenceNumberTracker> sequenceNumberTracker) {
+        this(remoteAddress, sequenceNumberTracker, OptionListener.NONE);
+    }
+
+    public TcpSession(final InetAddress remoteAddress,
+                      final Supplier<SequenceNumberTracker> sequenceNumberTracker,
+                      final OptionListener optionListener) {
         this.remoteAddress = Objects.requireNonNull(remoteAddress);
         this.sequenceNumberTracker = Objects.requireNonNull(sequenceNumberTracker);
+        this.optionListener = Objects.requireNonNull(optionListener);
     }
 
     @Override
@@ -137,6 +146,10 @@ public class TcpSession implements Session {
                            final List<Value<?>> values) {
         final TemplateKey key = new TemplateKey(observationDomainId, templateId);
         this.options.computeIfAbsent(key, (k) -> new HashMap<>()).put(new HashSet<>(scopes), values);
+
+        this.optionListener.accept(
+                new ExporterIdentity.NetflowIpfix(this.remoteAddress, observationDomainId),
+                scopes, values);
     }
 
     @Override

--- a/src/main/java/org/riptide/flows/parser/session/UdpSessionManager.java
+++ b/src/main/java/org/riptide/flows/parser/session/UdpSessionManager.java
@@ -41,9 +41,18 @@ public class UdpSessionManager {
 
     private final Supplier<SequenceNumberTracker> sequenceNumberTracker;
 
+    private final OptionListener optionListener;
+
     public UdpSessionManager(final Duration timeout, final Supplier<SequenceNumberTracker> sequenceNumberTracker) {
+        this(timeout, sequenceNumberTracker, OptionListener.NONE);
+    }
+
+    public UdpSessionManager(final Duration timeout,
+                             final Supplier<SequenceNumberTracker> sequenceNumberTracker,
+                             final OptionListener optionListener) {
         this.timeout = timeout;
         this.sequenceNumberTracker = Objects.requireNonNull(sequenceNumberTracker);
+        this.optionListener = Objects.requireNonNull(optionListener);
     }
 
     public void doHousekeeping() {
@@ -250,6 +259,10 @@ public class UdpSessionManager {
                                final List<Value<?>> values) {
             final TemplateKey key = new TemplateKey(this.sessionKey, observationDomainId, templateId);
             UdpSessionManager.this.templates.get(key).wrapped.options.put(new HashSet<>(scopes), new TimeWrapper<>(values));
+
+            UdpSessionManager.this.optionListener.accept(
+                    new ExporterIdentity.NetflowIpfix(this.sessionKey.getRemoteAddress(), observationDomainId),
+                    scopes, values);
         }
 
         @Override

--- a/src/main/java/org/riptide/snmp/CachingSnmpService.java
+++ b/src/main/java/org/riptide/snmp/CachingSnmpService.java
@@ -36,7 +36,7 @@ public class CachingSnmpService implements SnmpService {
         this.delegate = Objects.requireNonNull(delegate);
         this.cacheConfig = Objects.requireNonNull(cacheConfig);
         ifIndexCache = CacheBuilder.newBuilder()
-                .expireAfterWrite(cacheConfig.retentionMs, TimeUnit.MILLISECONDS)
+                .expireAfterWrite(cacheConfig.getRetentionMs(), TimeUnit.MILLISECONDS)
                 .build();
     }
 

--- a/src/main/java/org/riptide/snmp/ExporterInterfaceTable.java
+++ b/src/main/java/org/riptide/snmp/ExporterInterfaceTable.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.snmp;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.primitives.UnsignedLong;
+import org.riptide.flows.parser.ie.Value;
+import org.riptide.flows.parser.session.OptionListener;
+import org.riptide.pipeline.ExporterIdentity;
+import org.riptide.utils.Tuple;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Interface names pushed by exporters as v9/IPFIX option records — the enrichment
+ * ladder's zero-config rung between static mappings and live SNMP. Fed by the option
+ * tap ({@link OptionListener}); entries expire on the same retention as the SNMP
+ * cache (exporters re-send option tables periodically; Cisco defaults to 600 s).
+ *
+ * <p>Recognized shapes (see change design, verified against captured fixtures):
+ * ifIndex in the scope (v9 {@code SCOPE:INTERFACE}, IPFIX {@code ingressInterface})
+ * or — the shape real Cisco IOS-XR exporters use — a system scope with the ifIndex as
+ * an option <em>field</em>. The trigger is IE 82/83 present in the fields: the ASR9k
+ * interface table carries only {@code IF_DESC}(83), never IE 82.</p>
+ *
+ * <p>Description (83) lands in the {@code alias} slot: IANA anchors it to ifDescr but
+ * its own examples include ifAlias-style content; per-field authority in
+ * {@link IfInfo#optionsThenSnmp} lets a real SNMP ifAlias win over it.</p>
+ */
+@Component
+public class ExporterInterfaceTable implements OptionListener {
+
+    private static final List<String> NAME_FIELDS = List.of("IF_NAME", "interfaceName");
+    private static final List<String> DESCRIPTION_FIELDS = List.of("IF_DESC", "interfaceDescription");
+    private static final List<String> IFINDEX_SCOPES = List.of("SCOPE:INTERFACE", "ingressInterface");
+    private static final List<String> IFINDEX_FIELDS = List.of("INPUT_SNMP", "ingressInterface");
+
+    private final Cache<Tuple<ExporterIdentity, Integer>, IfInfo> table;
+
+    private final Meter recordsConsumed;
+    private final Meter recordsSkipped;
+
+    public ExporterInterfaceTable(final SnmpCacheConfig cacheConfig, final MetricRegistry metrics) {
+        this.table = CacheBuilder.newBuilder()
+                .expireAfterWrite(cacheConfig.getRetentionMs(), TimeUnit.MILLISECONDS)
+                .build();
+        this.recordsConsumed = metrics.meter(MetricRegistry.name("enrichment", "optionInterfaces", "consumed"));
+        this.recordsSkipped = metrics.meter(MetricRegistry.name("enrichment", "optionInterfaces", "skipped"));
+    }
+
+    @Override
+    public void accept(final ExporterIdentity identity, final Collection<Value<?>> scopes, final List<Value<?>> values) {
+        final String name = string(values, NAME_FIELDS);
+        final String description = string(values, DESCRIPTION_FIELDS);
+        if (name == null && description == null) {
+            return; // not an interface option record (sampler/VRF/app tables, …)
+        }
+
+        Integer ifIndex = unsigned(scopes, IFINDEX_SCOPES);
+        if (ifIndex == null) {
+            ifIndex = unsigned(values, IFINDEX_FIELDS);
+        }
+        if (ifIndex == null || ifIndex == 0) {
+            this.recordsSkipped.mark();
+            return;
+        }
+
+        this.table.put(Tuple.of(identity, ifIndex), new IfInfo(name, description, null));
+        this.recordsConsumed.mark();
+    }
+
+    public Optional<IfInfo> lookup(final ExporterIdentity identity, final int ifIndex) {
+        return Optional.ofNullable(this.table.getIfPresent(Tuple.of(identity, ifIndex)));
+    }
+
+    private static String string(final Collection<Value<?>> values, final List<String> names) {
+        for (final Value<?> value : values) {
+            // v9 strings are fixed-width and NUL-padded on the wire
+            if (names.contains(value.getName()) && value.getValue() instanceof String s) {
+                final String trimmed = s.replace("\0", "").trim();
+                return trimmed.isEmpty() ? null : trimmed;
+            }
+        }
+        return null;
+    }
+
+    private static Integer unsigned(final Collection<Value<?>> values, final List<String> names) {
+        for (final Value<?> value : values) {
+            if (names.contains(value.getName()) && value.getValue() instanceof UnsignedLong u) {
+                return u.intValue();
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/riptide/snmp/IfInfo.java
+++ b/src/main/java/org/riptide/snmp/IfInfo.java
@@ -30,4 +30,24 @@ public record IfInfo(String name, String alias, Long highSpeed) {
                 pinned.alias != null ? pinned.alias : fallback.alias,
                 pinned.highSpeed != null ? pinned.highSpeed : fallback.highSpeed);
     }
+
+    /**
+     * Per-field authority between exporter-pushed option data and live SNMP:
+     * {@code name} prefers options (IE 82 is exactly ifName, and pushed data is
+     * fresher than a poll); {@code alias} prefers SNMP (ifAlias is definitionally the
+     * operator alias, while IE 83 is maybe-ifDescr and only fills when SNMP can't);
+     * {@code highSpeed} exists only in SNMP. Either side may be {@code null}.
+     */
+    public static IfInfo optionsThenSnmp(final IfInfo options, final IfInfo snmp) {
+        if (options == null) {
+            return snmp;
+        }
+        if (snmp == null) {
+            return options;
+        }
+        return new IfInfo(
+                options.name != null ? options.name : snmp.name,
+                snmp.alias != null ? snmp.alias : options.alias,
+                snmp.highSpeed);
+    }
 }

--- a/src/main/java/org/riptide/snmp/SnmpCacheConfig.java
+++ b/src/main/java/org/riptide/snmp/SnmpCacheConfig.java
@@ -5,10 +5,20 @@
 
 package org.riptide.snmp;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-
+/**
+ * Retention for interface information: the SNMP poll cache and the exporter option
+ * table. A JavaBean property (not a bare public field) on purpose — Spring's binder
+ * silently skips fields without accessors, which would leave the caches at a 0 ms
+ * TTL regardless of configuration.
+ */
+@Getter
+@Setter
 @ConfigurationProperties(prefix = "riptide.snmp.cache")
 public class SnmpCacheConfig {
-    public long retentionMs;
+
+    private long retentionMs = 600_000;
 }

--- a/src/main/java/org/riptide/snmp/SnmpEnricher.java
+++ b/src/main/java/org/riptide/snmp/SnmpEnricher.java
@@ -21,8 +21,9 @@ import java.util.function.Consumer;
 
 /**
  * Resolves flow interface indexes against the matched node: the static interface
- * mapping pins per field, live SNMP fills the rest (enrichment-ladder semantics).
- * A node without an SNMP block enriches purely statically.
+ * mapping pins per field, exporter-pushed option data and live SNMP fill the rest
+ * with per-field authority (enrichment-ladder semantics). A node without an SNMP
+ * block still enriches from statics and option data.
  */
 @Component
 @RequiredArgsConstructor
@@ -34,36 +35,43 @@ public class SnmpEnricher implements Enricher {
     @NonNull
     private final NodeRegistry nodeRegistry;
 
+    @NonNull
+    private final ExporterInterfaceTable exporterInterfaceTable;
+
     @Override
     public CompletableFuture<Void> enrich(final Source source, final List<EnrichedFlow> flows) {
         return CompletableFuture.supplyAsync(() -> {
-            this.nodeRegistry.lookup(source.identity()).ifPresent(node -> {
-                final Optional<SnmpEndpoint> snmpEndpoint = node.snmpEndpoint();
-                for (final EnrichedFlow flow : flows) {
-                    apply(node, snmpEndpoint, flow.getInputSnmp(), ifInfo -> {
-                        flow.setInputSnmpIfName(ifInfo.name());
-                        flow.setInputSnmpIfAlias(ifInfo.alias());
-                        flow.setInputSnmpIfSpeed(ifInfo.highSpeed());
-                    });
-                    apply(node, snmpEndpoint, flow.getOutputSnmp(), ifInfo -> {
-                        flow.setOutputSnmpIfName(ifInfo.name());
-                        flow.setOutputSnmpIfAlias(ifInfo.alias());
-                        flow.setOutputSnmpIfSpeed(ifInfo.highSpeed());
-                    });
-                }
-            });
+            // exporter-pushed option data enriches even without a configured node —
+            // it is keyed by exporter identity, not by node
+            final Optional<Node> node = this.nodeRegistry.lookup(source.identity());
+            final Optional<SnmpEndpoint> snmpEndpoint = node.flatMap(Node::snmpEndpoint);
+            for (final EnrichedFlow flow : flows) {
+                apply(node, snmpEndpoint, source, flow.getInputSnmp(), ifInfo -> {
+                    flow.setInputSnmpIfName(ifInfo.name());
+                    flow.setInputSnmpIfAlias(ifInfo.alias());
+                    flow.setInputSnmpIfSpeed(ifInfo.highSpeed());
+                });
+                apply(node, snmpEndpoint, source, flow.getOutputSnmp(), ifInfo -> {
+                    flow.setOutputSnmpIfName(ifInfo.name());
+                    flow.setOutputSnmpIfAlias(ifInfo.alias());
+                    flow.setOutputSnmpIfSpeed(ifInfo.highSpeed());
+                });
+            }
 
             return null;
         });
     }
 
-    private void apply(final Node node, final Optional<SnmpEndpoint> snmpEndpoint, final int ifIndex,
-                       final Consumer<IfInfo> setter) {
-        final IfInfo pinned = node.definition().getInterfaces().get(ifIndex);
+    private void apply(final Optional<Node> node, final Optional<SnmpEndpoint> snmpEndpoint, final Source source,
+                       final int ifIndex, final Consumer<IfInfo> setter) {
+        final IfInfo pinned = node
+                .map(n -> n.definition().getInterfaces().get(ifIndex))
+                .orElse(null);
+        final IfInfo options = this.exporterInterfaceTable.lookup(source.identity(), ifIndex).orElse(null);
         final IfInfo live = snmpEndpoint
                 .flatMap(endpoint -> this.snmpService.getIfInfo(endpoint, ifIndex))
                 .orElse(null);
-        final IfInfo merged = IfInfo.merge(pinned, live);
+        final IfInfo merged = IfInfo.merge(pinned, IfInfo.optionsThenSnmp(options, live));
         if (merged != null) {
             setter.accept(merged);
         }

--- a/src/test/java/org/riptide/flows/netflow9/InterfaceOptionsBlackboxTest.java
+++ b/src/test/java/org/riptide/flows/netflow9/InterfaceOptionsBlackboxTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.netflow9;
+
+import com.codahale.metrics.MetricRegistry;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.Test;
+import org.riptide.flows.parser.netflow9.proto.Header;
+import org.riptide.flows.parser.netflow9.proto.Packet;
+import org.riptide.flows.parser.session.SequenceNumberTracker;
+import org.riptide.flows.parser.session.Session;
+import org.riptide.flows.parser.session.TcpSession;
+import org.riptide.pipeline.ExporterIdentity;
+import org.riptide.snmp.ExporterInterfaceTable;
+import org.riptide.snmp.IfInfo;
+import org.riptide.snmp.SnmpCacheConfig;
+
+import java.net.InetAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.riptide.flows.utils.BufferUtils.slice;
+
+/**
+ * Drives interface option records through the real v9/IPFIX parse path (Packet →
+ * session.addOptions → option tap) into the exporter interface table. The Cisco
+ * ASR9k case uses genuine captured packets — the fixture that confirmed the
+ * system-scoped, ifIndex-as-field, description-only shape.
+ */
+public class InterfaceOptionsBlackboxTest {
+
+    private static final Path FOLDER = Paths.get("src/test/resources/flows");
+
+    private final ExporterInterfaceTable table = new ExporterInterfaceTable(config(), new MetricRegistry());
+
+    private static SnmpCacheConfig config() {
+        final SnmpCacheConfig config = new SnmpCacheConfig();
+        config.setRetentionMs(60_000);
+        return config;
+    }
+
+    private final Session session =
+            new TcpSession(InetAddress.getLoopbackAddress(), () -> new SequenceNumberTracker(32), this.table);
+
+    private void parseV9(final ByteBuf buf) throws Exception {
+        do {
+            new Packet(this.session, new Header(slice(buf, Header.SIZE)), buf);
+        } while (buf.isReadable());
+    }
+
+    @Test
+    public void asr9kInterfaceTableReachesTheExporterTable() throws Exception {
+        // real ASR9k capture: opt template 256 = system scope + INPUT_SNMP + IF_DESC(64)
+        parseV9(Unpooled.wrappedBuffer(Files.readAllBytes(FOLDER.resolve("netflow9_test_cisco_asr9k_opttpl256.dat"))));
+        parseV9(Unpooled.wrappedBuffer(Files.readAllBytes(FOLDER.resolve("netflow9_test_cisco_asr9k_data256.dat"))));
+
+        final var identity = new ExporterIdentity.NetflowIpfix(InetAddress.getLoopbackAddress(), 2177);
+        assertThat(this.table.lookup(identity, 74)).contains(new IfInfo(null, "TenGigE0_0_1_0", null));
+        assertThat(this.table.lookup(identity, 162)).contains(new IfInfo(null, "Bundle-Ether2", null));
+        assertThat(this.table.lookup(identity, 999)).isEmpty();
+    }
+
+    @Test
+    public void craftedV9InterfaceScopedOptionsReachTheTable() throws Exception {
+        // shape A: v9 options template scoped by SCOPE:INTERFACE with IF_NAME + IF_DESC
+        final ByteBuf b = Unpooled.buffer();
+        b.writeShort(9).writeShort(2).writeInt(1000).writeInt(1_700_000_000).writeInt(1).writeInt(42);
+        // options template set: id=1, length incl. 4-byte set header
+        b.writeShort(1).writeShort(22);
+        b.writeShort(300).writeShort(4).writeShort(8); // templateId, scopeLen(1 spec), optionLen(2 specs)
+        b.writeShort(2).writeShort(4);   // scope: Interface, 4 bytes
+        b.writeShort(82).writeShort(8);  // IF_NAME, 8 bytes
+        b.writeShort(83).writeShort(8);  // IF_DESC, 8 bytes
+        // option data set: template 300, one record: ifIndex 7, "Eth1/0", "uplink"
+        b.writeShort(300).writeShort(24);
+        b.writeInt(7);
+        b.writeBytes("Eth1/0\0\0".getBytes());
+        b.writeBytes("uplink\0\0".getBytes());
+
+        parseV9(b);
+
+        final var identity = new ExporterIdentity.NetflowIpfix(InetAddress.getLoopbackAddress(), 42);
+        assertThat(this.table.lookup(identity, 7)).contains(new IfInfo("Eth1/0", "uplink", null));
+    }
+}

--- a/src/test/java/org/riptide/snmp/ExporterInterfaceTableTest.java
+++ b/src/test/java/org/riptide/snmp/ExporterInterfaceTableTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.snmp;
+
+import com.codahale.metrics.MetricRegistry;
+import org.junit.jupiter.api.Test;
+import org.riptide.flows.parser.ie.values.StringValue;
+import org.riptide.flows.parser.ie.values.UnsignedValue;
+import org.riptide.pipeline.ExporterIdentity;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExporterInterfaceTableTest {
+
+    private final MetricRegistry metrics = new MetricRegistry();
+    private final ExporterInterfaceTable table = new ExporterInterfaceTable(config(), metrics);
+
+    private static SnmpCacheConfig config() {
+        final SnmpCacheConfig config = new SnmpCacheConfig();
+        config.setRetentionMs(60_000);
+        return config;
+    }
+
+    private static ExporterIdentity identity(final String host, final long domain) throws UnknownHostException {
+        return new ExporterIdentity.NetflowIpfix(InetAddress.getByName(host), domain);
+    }
+
+    @Test
+    public void shapeA_v9InterfaceScope() throws Exception {
+        final var identity = identity("10.0.0.1", 1);
+        this.table.accept(identity,
+                List.of(new UnsignedValue("SCOPE:INTERFACE", 7)),
+                List.of(new StringValue("IF_NAME", "Eth1/0"), new StringValue("IF_DESC", "uplink")));
+
+        assertThat(this.table.lookup(identity, 7)).contains(new IfInfo("Eth1/0", "uplink", null));
+    }
+
+    @Test
+    public void shapeB_systemScopeWithIfIndexField_descriptionOnly() throws Exception {
+        // the real Cisco ASR9k shape: system scope, INPUT_SNMP as field, IF_DESC only
+        final var identity = identity("10.0.0.1", 2177);
+        this.table.accept(identity,
+                List.of(new UnsignedValue("SCOPE:SYSTEM", 0xC1C2C3C4L)),
+                List.of(new UnsignedValue("INPUT_SNMP", 74), new StringValue("IF_DESC", "TenGigE0_0_1_0")));
+
+        assertThat(this.table.lookup(identity, 74)).contains(new IfInfo(null, "TenGigE0_0_1_0", null));
+    }
+
+    @Test
+    public void shapeC_ipfixIngressInterfaceScope() throws Exception {
+        final var identity = identity("10.0.0.2", 0);
+        this.table.accept(identity,
+                List.of(new UnsignedValue("ingressInterface", 5)),
+                List.of(new StringValue("interfaceName", "ge-0/0/0"), new StringValue("interfaceDescription", "core")));
+
+        assertThat(this.table.lookup(identity, 5)).contains(new IfInfo("ge-0/0/0", "core", null));
+    }
+
+    @Test
+    public void mappingsAreScopedPerExporterIdentity() throws Exception {
+        final var a = identity("10.0.0.1", 1);
+        final var b = identity("10.0.0.1", 2); // same address, different domain
+        this.table.accept(a, List.of(new UnsignedValue("SCOPE:INTERFACE", 5)),
+                List.of(new StringValue("IF_NAME", "a-if5")));
+        this.table.accept(b, List.of(new UnsignedValue("SCOPE:INTERFACE", 5)),
+                List.of(new StringValue("IF_NAME", "b-if5")));
+
+        assertThat(this.table.lookup(a, 5)).map(IfInfo::name).contains("a-if5");
+        assertThat(this.table.lookup(b, 5)).map(IfInfo::name).contains("b-if5");
+    }
+
+    @Test
+    public void nonInterfaceOptionsAreIgnoredWithoutMetrics() throws Exception {
+        // sampler table (opttpl257 shape): no IE 82/83 → not even counted as skipped
+        this.table.accept(identity("10.0.0.1", 1),
+                List.of(new UnsignedValue("SCOPE:SYSTEM", 1)),
+                List.of(new UnsignedValue("SAMPLER_ID", 1), new StringValue("SAMPLER_NAME", "s1")));
+
+        assertThat(this.metrics.meter("enrichment.optionInterfaces.consumed").getCount()).isZero();
+        assertThat(this.metrics.meter("enrichment.optionInterfaces.skipped").getCount()).isZero();
+    }
+
+    @Test
+    public void interfaceRecordWithoutResolvableIfIndexIsCountedSkipped() throws Exception {
+        this.table.accept(identity("10.0.0.1", 1),
+                List.of(new UnsignedValue("SCOPE:SYSTEM", 1)),
+                List.of(new StringValue("IF_NAME", "orphan")));
+
+        assertThat(this.metrics.meter("enrichment.optionInterfaces.skipped").getCount()).isEqualTo(1);
+        assertThat(this.metrics.meter("enrichment.optionInterfaces.consumed").getCount()).isZero();
+    }
+
+    @Test
+    public void wireStringsAreNulTrimmed() throws Exception {
+        final var identity = identity("10.0.0.1", 1);
+        this.table.accept(identity,
+                List.of(new UnsignedValue("SCOPE:INTERFACE", 9)),
+                List.of(new StringValue("IF_NAME", "Eth9\0\0\0\0"), new StringValue("IF_DESC", "\0\0\0")));
+
+        assertThat(this.table.lookup(identity, 9)).contains(new IfInfo("Eth9", null, null));
+    }
+
+    @Test
+    public void entriesExpireOnRetention() throws Exception {
+        final SnmpCacheConfig expiring = new SnmpCacheConfig();
+        expiring.setRetentionMs(0); // immediate expiry
+        final ExporterInterfaceTable shortLived = new ExporterInterfaceTable(expiring, new MetricRegistry());
+        final var identity = identity("10.0.0.1", 1);
+
+        shortLived.accept(identity, List.of(new UnsignedValue("SCOPE:INTERFACE", 3)),
+                List.of(new StringValue("IF_NAME", "gone")));
+
+        assertThat(shortLived.lookup(identity, 3)).isEmpty();
+    }
+}

--- a/src/test/java/org/riptide/snmp/IfInfoTest.java
+++ b/src/test/java/org/riptide/snmp/IfInfoTest.java
@@ -43,4 +43,22 @@ public class IfInfoTest {
 
         assertThat(IfInfo.merge(pinned, live)).isEqualTo(pinned);
     }
+
+    @Test
+    public void optionsThenSnmpAppliesPerFieldAuthority() {
+        final IfInfo options = new IfInfo("opt-name", "opt-desc", null);
+        final IfInfo snmp = new IfInfo("snmp-name", "snmp-alias", 100L);
+
+        assertThat(IfInfo.optionsThenSnmp(options, snmp))
+                .isEqualTo(new IfInfo("opt-name", "snmp-alias", 100L));
+    }
+
+    @Test
+    public void optionsDescriptionFillsAliasOnlyWithoutSnmp() {
+        final IfInfo options = new IfInfo(null, "opt-desc", null);
+
+        assertThat(IfInfo.optionsThenSnmp(options, null)).isEqualTo(new IfInfo(null, "opt-desc", null));
+        assertThat(IfInfo.optionsThenSnmp(null, null)).isNull();
+        assertThat(IfInfo.optionsThenSnmp(null, new IfInfo("s", "a", 1L))).isEqualTo(new IfInfo("s", "a", 1L));
+    }
 }

--- a/src/test/java/org/riptide/snmp/SnmpEnricherTest.java
+++ b/src/test/java/org/riptide/snmp/SnmpEnricherTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mapstruct.factory.Mappers;
 import org.mockito.Mockito;
 import org.riptide.flows.parser.data.Flow;
+import org.riptide.flows.parser.ie.values.StringValue;
+import org.riptide.flows.parser.ie.values.UnsignedValue;
 import org.riptide.node.NodeRegistry;
 import org.riptide.pipeline.EnrichedFlow;
 import org.riptide.pipeline.Enricher;
@@ -34,7 +36,8 @@ import static org.mockito.Mockito.when;
         "riptide.nodes.test-agent.snmp.snmp-version=v2c",
         "riptide.nodes.test-agent.snmp.community=" + TestSnmpAgent.COMMUNITY,
         // enrichment-ladder per-field pin: static alias overrides SNMP, rest is live
-        "riptide.nodes.test-agent.interfaces.1.alias=Uplink pinned by file"
+        "riptide.nodes.test-agent.interfaces.1.alias=Uplink pinned by file",
+        "riptide.snmp.cache.retentionMs=4242"
 })
 public class SnmpEnricherTest {
 
@@ -55,7 +58,7 @@ public class SnmpEnricherTest {
         snmpAgent.registerIfTable();
         snmpAgent.registerIfXTable();
 
-        final var enrichers = List.<Enricher>of(new SnmpEnricher(this.snmpService, this.nodeRegistry));
+        final var enrichers = List.<Enricher>of(new SnmpEnricher(this.snmpService, this.nodeRegistry, emptyInterfaceTable()));
         final var repository = new TestRepository(metricRegistry);
         final var pipeline = new Pipeline(enrichers, repository.asPersister(), this.metricRegistry, this.flowMapper);
 
@@ -83,5 +86,93 @@ public class SnmpEnricherTest {
             assertThat(enrichedFlow.getOutputSnmpIfSpeed()).isEqualTo(34L);
         });
     }
-}
 
+
+    @Test
+    public void optionDataJoinsTheLadderWithPerFieldAuthority(@TempDir Path temporaryFolder) throws Exception {
+        final TestSnmpAgent snmpAgent = new TestSnmpAgent("127.0.0.1/12345", temporaryFolder);
+        snmpAgent.start();
+        snmpAgent.registerIfTable();
+        snmpAgent.registerIfXTable();
+
+        final var source = new Source("here", InetAddress.getByName("127.0.0.1"));
+
+        // exporter pushed option records for both interfaces (name + description)
+        final ExporterInterfaceTable interfaceTable = emptyInterfaceTable();
+        interfaceTable.accept(source.identity(),
+                List.of(new UnsignedValue("SCOPE:INTERFACE", 1)),
+                List.of(new StringValue("IF_NAME", "opt-if1"),
+                        new StringValue("IF_DESC", "opt-desc1")));
+        interfaceTable.accept(source.identity(),
+                List.of(new UnsignedValue("SCOPE:INTERFACE", 2)),
+                List.of(new StringValue("IF_NAME", "opt-if2"),
+                        new StringValue("IF_DESC", "opt-desc2")));
+
+        final var enrichers = List.<Enricher>of(new SnmpEnricher(this.snmpService, this.nodeRegistry, interfaceTable));
+        final var repository = new TestRepository(metricRegistry);
+        final var pipeline = new Pipeline(enrichers, repository.asPersister(), this.metricRegistry, this.flowMapper);
+
+        final Flow flow = Mockito.mock(Flow.class);
+        when(flow.getSrcAddr()).thenReturn(InetAddress.getByName("10.10.10.10"));
+        when(flow.getDstAddr()).thenReturn(InetAddress.getByName("10.20.20.10"));
+        when(flow.getInputSnmp()).thenReturn(1);
+        when(flow.getOutputSnmp()).thenReturn(2);
+
+        pipeline.process(source, List.of(flow));
+
+        snmpAgent.stop();
+
+        assertThat(repository.flows()).allSatisfy(enrichedFlow -> {
+            // name: options beat live SNMP (eth0-x / lo0-x)
+            assertThat(enrichedFlow.getInputSnmpIfName()).isEqualTo("opt-if1");
+            assertThat(enrichedFlow.getOutputSnmpIfName()).isEqualTo("opt-if2");
+            // alias: static pin first, then SNMP ifAlias beats the option description
+            assertThat(enrichedFlow.getInputSnmpIfAlias()).isEqualTo("Uplink pinned by file");
+            assertThat(enrichedFlow.getOutputSnmpIfAlias()).isEqualTo("My loopback interface");
+            // speed: SNMP only
+            assertThat(enrichedFlow.getInputSnmpIfSpeed()).isEqualTo(14L);
+            assertThat(enrichedFlow.getOutputSnmpIfSpeed()).isEqualTo(34L);
+        });
+    }
+
+
+    @Test
+    public void optionDataEnrichesWithoutAnyConfiguredNode() throws Exception {
+        // 10.99.0.1 matches no riptide.nodes entry — the zero-config rung
+        final var source = new Source("here", InetAddress.getByName("10.99.0.1"));
+
+        final ExporterInterfaceTable interfaceTable = emptyInterfaceTable();
+        interfaceTable.accept(source.identity(),
+                List.of(new UnsignedValue("SCOPE:INTERFACE", 1)),
+                List.of(new StringValue("IF_NAME", "no-node-if1"), new StringValue("IF_DESC", "pushed")));
+
+        final var enrichers = List.<Enricher>of(new SnmpEnricher(this.snmpService, this.nodeRegistry, interfaceTable));
+        final var repository = new TestRepository(metricRegistry);
+        final var pipeline = new Pipeline(enrichers, repository.asPersister(), this.metricRegistry, this.flowMapper);
+
+        final Flow flow = Mockito.mock(Flow.class);
+        when(flow.getSrcAddr()).thenReturn(InetAddress.getByName("10.10.10.10"));
+        when(flow.getDstAddr()).thenReturn(InetAddress.getByName("10.20.20.10"));
+        when(flow.getInputSnmp()).thenReturn(1);
+
+        pipeline.process(source, List.of(flow));
+
+        assertThat(repository.flows()).allSatisfy(enrichedFlow -> {
+            assertThat(enrichedFlow.getInputSnmpIfName()).isEqualTo("no-node-if1");
+            assertThat(enrichedFlow.getInputSnmpIfAlias()).isEqualTo("pushed");
+            assertThat(enrichedFlow.getInputSnmpIfSpeed()).isNull();
+        });
+    }
+
+    @Test
+    public void cacheRetentionBindsFromProperties(@Autowired final SnmpCacheConfig cacheConfig) {
+        // regression: a bare public field never binds — both caches then run at 0 ms TTL
+        assertThat(cacheConfig.getRetentionMs()).isEqualTo(4242);
+    }
+
+    private static ExporterInterfaceTable emptyInterfaceTable() {
+        final SnmpCacheConfig cacheConfig = new SnmpCacheConfig();
+        cacheConfig.setRetentionMs(60_000);
+        return new ExporterInterfaceTable(cacheConfig, new MetricRegistry());
+    }
+}

--- a/src/test/java/org/riptide/snmp/SnmpTest.java
+++ b/src/test/java/org/riptide/snmp/SnmpTest.java
@@ -211,7 +211,7 @@ public class SnmpTest {
     public void testSnmpCache(@TempDir Path temporaryFolder) throws IOException, ExecutionException {
         final int port = getNextPort();
         final SnmpCacheConfig snmpCacheConfig = new SnmpCacheConfig();
-        snmpCacheConfig.retentionMs = 600000;
+        snmpCacheConfig.setRetentionMs(600000);
 
         final SnmpService snmpCache = new CachingSnmpService(new DefaultSnmpService(SECRET_RESOLVERS), snmpCacheConfig);
         final SnmpEndpoint snmpEndpoint = communityV2c(new IPAddressString("127.0.0.1"), port, TestSnmpAgent.COMMUNITY);

--- a/src/test/java/org/riptide/snmp/StaticInterfaceEnricherTest.java
+++ b/src/test/java/org/riptide/snmp/StaticInterfaceEnricherTest.java
@@ -50,7 +50,7 @@ public class StaticInterfaceEnricherTest {
 
     @Test
     public void staticMappingEnrichesWithoutSnmp() throws Exception {
-        final var enrichers = List.<Enricher>of(new SnmpEnricher(this.snmpService, this.nodeRegistry));
+        final var enrichers = List.<Enricher>of(new SnmpEnricher(this.snmpService, this.nodeRegistry, emptyInterfaceTable()));
         final var repository = new TestRepository(metricRegistry);
         final var pipeline = new Pipeline(enrichers, repository.asPersister(), this.metricRegistry, this.flowMapper);
 
@@ -70,5 +70,11 @@ public class StaticInterfaceEnricherTest {
             assertThat(enrichedFlow.getOutputSnmpIfName()).isEqualTo("lo0");
             assertThat(enrichedFlow.getOutputSnmpIfAlias()).isNull();
         });
+    }
+
+    private static ExporterInterfaceTable emptyInterfaceTable() {
+        final SnmpCacheConfig cacheConfig = new SnmpCacheConfig();
+        cacheConfig.setRetentionMs(60_000);
+        return new ExporterInterfaceTable(cacheConfig, new MetricRegistry());
     }
 }


### PR DESCRIPTION
Implements the `option-interface-enrichment` change — the enrichment ladder's zero-config rung between static mappings and live SNMP.

## Why the per-record merge couldn't do this (verified)
v9 interface scopes surface as `SCOPE:INTERFACE`, which never appears among data-record field names, so `lookupOptions` can never match them; IPFIX merges at most the ingress half and nothing consumed it anyway. So option data is tapped **at arrival** instead.

## What's here
- **Option tap** — inside `UdpSession`/`TcpSession.addOptions` (one hook per session flavor; TCP IPFIX for free), plumbed via `setOptionListener` from `Daemon` into all five v9/IPFIX receiver arms
- **`ExporterInterfaceTable`** — TTL cache keyed by `(ExporterIdentity, ifIndex)`; consumed/skipped meters
- **Shape recognizer** — trigger on IE 82 **or** 83 (the OR is load-bearing, see below); ifIndex from scope (`SCOPE:INTERFACE` / `ingressInterface`) with field fallback (`INPUT_SNMP`/`ingressInterface`)
- **Per-field authority** (`IfInfo.optionsThenSnmp`): name → options beat SNMP; alias → SNMP ifAlias beats IE 83; speed → SNMP only; static pins first. Applies **even without a configured node** — option data is identity-keyed, not node-keyed
- **Docs**: ladder gains layer 1.5 with the authority table; nodes-and-snmp explains why SNMP stays worth configuring

## The empirical win
The design's one unverified cell (v9 'shape B': system scope, ifIndex as option *field*) was **confirmed from the repo's own captured fixture** `netflow9_test_cisco_asr9k_opttpl256.dat` — real ASR9k exports exactly that, and with `IF_DESC`(83) only, no IE 82 at all. The blackbox test drives the genuine capture through the real parse path and asserts `ifIndex 74 → TenGigE0_0_1_0`.

## Review pass (structured, 2 finders) — and what it caught
- **`SnmpCacheConfig.retentionMs` never binds** (bare public field): `riptide.snmp.cache.retentionMs=600000` was silently ignored, running the SNMP poll cache — and this table — at 0 ms TTL. Pre-existing for the poll cache (cost: extra polls); fatal for this feature. Fixed with accessors + 600 s default + a Spring binding regression test
- **Node-gated enrichment contradicted the zero-config docs** — fixed: enricher falls back to option data when no node matches (test included)
- Accepted-by-design: `setOptionListener` as a plain setter rather than a fluent `with*` (explicit wiring; a chain method wouldn't prevent a forgotten call either)
- Design doc updated to record the tap-location refinement (Session impls, not Packet call sites)

## Verification
`make jar` → **612 tests**, all gates green. e2e `Nl6FlowIngestionIT` re-run locally green (Daemon wiring changed). Docs production build green.

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)