### PR TITLE
fix: Harden the exporter option table (post-merge review findings)

### DIFF
--- a/src/main/java/org/riptide/snmp/ExporterInterfaceTable.java
+++ b/src/main/java/org/riptide/snmp/ExporterInterfaceTable.java
@@ -11,6 +11,8 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.primitives.UnsignedLong;
 import org.riptide.flows.parser.ie.Value;
+import org.riptide.flows.parser.ie.values.visitor.StringVisitor;
+import org.riptide.flows.parser.ie.values.visitor.UnsignedLongVisitor;
 import org.riptide.flows.parser.session.OptionListener;
 import org.riptide.pipeline.ExporterIdentity;
 import org.riptide.utils.Tuple;
@@ -42,8 +44,9 @@ public class ExporterInterfaceTable implements OptionListener {
 
     private static final List<String> NAME_FIELDS = List.of("IF_NAME", "interfaceName");
     private static final List<String> DESCRIPTION_FIELDS = List.of("IF_DESC", "interfaceDescription");
-    private static final List<String> IFINDEX_SCOPES = List.of("SCOPE:INTERFACE", "ingressInterface");
-    private static final List<String> IFINDEX_FIELDS = List.of("INPUT_SNMP", "ingressInterface");
+    // the table is direction-neutral, so egress-keyed variants are accepted too
+    private static final List<String> IFINDEX_SCOPES = List.of("SCOPE:INTERFACE", "ingressInterface", "egressInterface");
+    private static final List<String> IFINDEX_FIELDS = List.of("INPUT_SNMP", "ingressInterface", "OUTPUT_SNMP", "egressInterface");
 
     private final Cache<Tuple<ExporterIdentity, Integer>, IfInfo> table;
 
@@ -52,7 +55,11 @@ public class ExporterInterfaceTable implements OptionListener {
 
     public ExporterInterfaceTable(final SnmpCacheConfig cacheConfig, final MetricRegistry metrics) {
         this.table = CacheBuilder.newBuilder()
-                .expireAfterWrite(cacheConfig.getRetentionMs(), TimeUnit.MILLISECONDS)
+                // 2x the poll-cache retention: exporters re-send option tables at
+                // roughly the same cadence (Cisco default 600 s == our default
+                // retention), so a 1x TTL would race every refresh and one lost
+                // option packet would unenrich flows for a full cycle
+                .expireAfterWrite(2 * cacheConfig.getRetentionMs(), TimeUnit.MILLISECONDS)
                 .build();
         this.recordsConsumed = metrics.meter(MetricRegistry.name("enrichment", "optionInterfaces", "consumed"));
         this.recordsSkipped = metrics.meter(MetricRegistry.name("enrichment", "optionInterfaces", "skipped"));
@@ -67,7 +74,8 @@ public class ExporterInterfaceTable implements OptionListener {
         }
 
         Integer ifIndex = unsigned(scopes, IFINDEX_SCOPES);
-        if (ifIndex == null) {
+        if (ifIndex == null || ifIndex == 0) {
+            // a zero scope value is as good as none: fall through to the fields
             ifIndex = unsigned(values, IFINDEX_FIELDS);
         }
         if (ifIndex == null || ifIndex == 0) {
@@ -75,8 +83,17 @@ public class ExporterInterfaceTable implements OptionListener {
             return;
         }
 
-        this.table.put(Tuple.of(identity, ifIndex), new IfInfo(name, description, null));
+        // per-field merge: exporters may split name and description over separate
+        // option tables (e.g. an interface-scoped table plus the IOS-XR style one);
+        // the fresh record pins its fields, the existing entry fills the rest
+        final Tuple<ExporterIdentity, Integer> key = Tuple.of(identity, ifIndex);
+        this.table.put(key, IfInfo.merge(new IfInfo(name, description, null), this.table.getIfPresent(key)));
         this.recordsConsumed.mark();
+    }
+
+    /** Approximate and cheap; exactly {@code true} when nothing was ever inserted. */
+    public boolean isEmpty() {
+        return this.table.size() == 0;
     }
 
     public Optional<IfInfo> lookup(final ExporterIdentity identity, final int ifIndex) {
@@ -85,10 +102,13 @@ public class ExporterInterfaceTable implements OptionListener {
 
     private static String string(final Collection<Value<?>> values, final List<String> names) {
         for (final Value<?> value : values) {
-            // v9 strings are fixed-width and NUL-padded on the wire
-            if (names.contains(value.getName()) && value.getValue() instanceof String s) {
-                final String trimmed = s.replace("\0", "").trim();
-                return trimmed.isEmpty() ? null : trimmed;
+            if (names.contains(value.getName())) {
+                final String s = value.accept(new StringVisitor());
+                if (s != null) {
+                    // v9 strings are fixed-width and NUL-padded on the wire
+                    final String trimmed = s.replace("\0", "").trim();
+                    return trimmed.isEmpty() ? null : trimmed;
+                }
             }
         }
         return null;
@@ -96,8 +116,11 @@ public class ExporterInterfaceTable implements OptionListener {
 
     private static Integer unsigned(final Collection<Value<?>> values, final List<String> names) {
         for (final Value<?> value : values) {
-            if (names.contains(value.getName()) && value.getValue() instanceof UnsignedLong u) {
-                return u.intValue();
+            if (names.contains(value.getName())) {
+                final UnsignedLong u = value.accept(new UnsignedLongVisitor());
+                if (u != null) {
+                    return u.intValue();
+                }
             }
         }
         return null;

--- a/src/main/java/org/riptide/snmp/SnmpEnricher.java
+++ b/src/main/java/org/riptide/snmp/SnmpEnricher.java
@@ -44,6 +44,9 @@ public class SnmpEnricher implements Enricher {
             // exporter-pushed option data enriches even without a configured node —
             // it is keyed by exporter identity, not by node
             final Optional<Node> node = this.nodeRegistry.lookup(source.identity());
+            if (node.isEmpty() && this.exporterInterfaceTable.isEmpty()) {
+                return null; // nothing could contribute — keep the hot path free
+            }
             final Optional<SnmpEndpoint> snmpEndpoint = node.flatMap(Node::snmpEndpoint);
             for (final EnrichedFlow flow : flows) {
                 apply(node, snmpEndpoint, source, flow.getInputSnmp(), ifInfo -> {

--- a/src/test/java/org/riptide/flows/ipfix/IpfixInterfaceOptionsTest.java
+++ b/src/test/java/org/riptide/flows/ipfix/IpfixInterfaceOptionsTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.ipfix;
+
+import com.codahale.metrics.MetricRegistry;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.Test;
+import org.riptide.flows.parser.ipfix.proto.Header;
+import org.riptide.flows.parser.ipfix.proto.Packet;
+import org.riptide.flows.parser.session.SequenceNumberTracker;
+import org.riptide.flows.parser.session.Session;
+import org.riptide.flows.parser.session.TcpSession;
+import org.riptide.pipeline.ExporterIdentity;
+import org.riptide.snmp.ExporterInterfaceTable;
+import org.riptide.snmp.IfInfo;
+import org.riptide.snmp.SnmpCacheConfig;
+
+import java.net.InetAddress;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.riptide.flows.utils.BufferUtils.slice;
+
+/**
+ * Drives an ingressInterface-scoped IPFIX option record through the real parse path
+ * into the exporter interface table. This pins the IANA registry names
+ * ({@code interfaceName}/{@code interfaceDescription}/{@code ingressInterface}) end to
+ * end — a registry-XML drift breaks this test instead of production only.
+ */
+public class IpfixInterfaceOptionsTest {
+
+    @Test
+    public void ipfixIngressScopedOptionsReachTheTable() throws Exception {
+        final SnmpCacheConfig cacheConfig = new SnmpCacheConfig();
+        final ExporterInterfaceTable table = new ExporterInterfaceTable(cacheConfig, new MetricRegistry());
+        final Session session = new TcpSession(InetAddress.getLoopbackAddress(), () -> new SequenceNumberTracker(32), table);
+
+        final ByteBuf b = Unpooled.buffer();
+        // message header: version, length (patched below), export time, sequence, domain
+        b.writeShort(0x000A).writeShort(0).writeInt(1_700_000_000).writeInt(1).writeInt(7);
+        // options template set (id 3): template 400, fieldCount 3, scopeFieldCount 1
+        b.writeShort(3).writeShort(4 + 6 + 3 * 4);
+        b.writeShort(400).writeShort(3).writeShort(1);
+        b.writeShort(10).writeShort(4);  // scope: ingressInterface
+        b.writeShort(82).writeShort(8);  // interfaceName
+        b.writeShort(83).writeShort(8);  // interfaceDescription
+        // data set for template 400: ifIndex 5, "ge-0/0/0", "core-up"
+        b.writeShort(400).writeShort(4 + 20);
+        b.writeInt(5);
+        b.writeBytes("ge-0/0/0".getBytes());
+        b.writeBytes("core-up\0".getBytes());
+        b.setShort(2, b.readableBytes()); // patch message length
+
+        final Header header = new Header(slice(b, Header.SIZE));
+        new Packet(session, header, slice(b, header.payloadLength()));
+
+        final var identity = new ExporterIdentity.NetflowIpfix(InetAddress.getLoopbackAddress(), 7);
+        assertThat(table.lookup(identity, 5)).contains(new IfInfo("ge-0/0/0", "core-up", null));
+    }
+}

--- a/src/test/java/org/riptide/flows/parser/session/UdpSessionManagerTest.java
+++ b/src/test/java/org/riptide/flows/parser/session/UdpSessionManagerTest.java
@@ -233,4 +233,21 @@ public class UdpSessionManagerTest {
         manager.drop(sessionKey);
         assertThat(manager.sequenceTrackerCount()).isZero();
     }
+
+    @Test
+    public void addOptionsNotifiesTheOptionListener() throws Exception {
+        final var sessionKey = new Netflow9UdpParser.SessionKey(remoteAddress1.getAddress(), localAddress1);
+        final var seen = new ArrayList<ExporterIdentity>();
+        final var manager = new UdpSessionManager(Duration.ofMinutes(30), () -> new SequenceNumberTracker(32),
+                (identity, scopes, values) -> seen.add(identity));
+        final var session = manager.getSession(sessionKey);
+
+        final var template = Template.builder(templateId1, Template.Type.OPTIONS_TEMPLATE)
+                .withFields(List.of(field("f"))).withScopes(List.of(scope("s"))).build();
+        session.addTemplate(observationId1, template);
+        session.addOptions(observationId1, templateId1, List.of(value("s", "sv")), List.of(value("f", "fv")));
+
+        assertThat(seen).containsExactly(
+                new ExporterIdentity.NetflowIpfix(remoteAddress1.getAddress(), observationId1));
+    }
 }

--- a/src/test/java/org/riptide/snmp/ExporterInterfaceTableTest.java
+++ b/src/test/java/org/riptide/snmp/ExporterInterfaceTableTest.java
@@ -119,4 +119,46 @@ public class ExporterInterfaceTableTest {
 
         assertThat(shortLived.lookup(identity, 3)).isEmpty();
     }
+
+    @Test
+    public void splitTablesMergePerField() throws Exception {
+        // exporter sends name and description in separate option tables — arrival
+        // order must not clobber the other field
+        final var identity = identity("10.0.0.1", 1);
+        this.table.accept(identity, List.of(new UnsignedValue("SCOPE:INTERFACE", 4)),
+                List.of(new StringValue("IF_NAME", "Eth4")));
+        this.table.accept(identity, List.of(new UnsignedValue("SCOPE:SYSTEM", 1)),
+                List.of(new UnsignedValue("INPUT_SNMP", 4), new StringValue("IF_DESC", "backbone")));
+
+        assertThat(this.table.lookup(identity, 4)).contains(new IfInfo("Eth4", "backbone", null));
+
+        // and the fresher record wins per field
+        this.table.accept(identity, List.of(new UnsignedValue("SCOPE:INTERFACE", 4)),
+                List.of(new StringValue("IF_NAME", "Eth4-renamed")));
+        assertThat(this.table.lookup(identity, 4)).contains(new IfInfo("Eth4-renamed", "backbone", null));
+    }
+
+    @Test
+    public void zeroScopeValueFallsThroughToTheFieldIfIndex() throws Exception {
+        final var identity = identity("10.0.0.1", 1);
+        this.table.accept(identity,
+                List.of(new UnsignedValue("SCOPE:INTERFACE", 0)),
+                List.of(new UnsignedValue("INPUT_SNMP", 11), new StringValue("IF_NAME", "via-field")));
+
+        assertThat(this.table.lookup(identity, 11)).map(IfInfo::name).contains("via-field");
+    }
+
+    @Test
+    public void egressKeyedRecordsAreAccepted() throws Exception {
+        final var identity = identity("10.0.0.1", 1);
+        this.table.accept(identity,
+                List.of(new UnsignedValue("egressInterface", 12)),
+                List.of(new StringValue("interfaceName", "egress-if")));
+        this.table.accept(identity,
+                List.of(new UnsignedValue("SCOPE:SYSTEM", 1)),
+                List.of(new UnsignedValue("OUTPUT_SNMP", 13), new StringValue("IF_DESC", "out-desc")));
+
+        assertThat(this.table.lookup(identity, 12)).map(IfInfo::name).contains("egress-if");
+        assertThat(this.table.lookup(identity, 13)).map(IfInfo::alias).contains("out-desc");
+    }
 }


### PR DESCRIPTION
Applies the verified findings from the full `/code-review medium` pass over #216 (8 findings: 4 CONFIRMED, 4 PLAUSIBLE).

## Correctness
- **Split-table clobbering** (CONFIRMED) — exporters may send name and description in separate option tables (interface-scoped + the IOS-XR style); `accept()` now merges per field via `IfInfo.merge` instead of blind `put`
- **Zero scope blocked the field fallback** — `SCOPE:INTERFACE=0` now falls through to `INPUT_SNMP`/`ingressInterface` fields
- **Egress-keyed tables accepted** — the table is direction-neutral; `egressInterface`/`OUTPUT_SNMP` join the recognizer
- **TTL race** — table TTL is now 2× the poll-cache retention (default 600 s equals Cisco's option resend cadence exactly — zero slack meant every refresh raced expiry)

## Robustness & coverage
- Value extraction via the canonical `StringVisitor`/`UnsignedLongVisitor` (behavior-equivalent, verified across all 13 Value subclasses) instead of parallel `instanceof` dispatch
- Enricher fast path restored: early return when no node matches and the table is empty (the node-less fallback had made the loop unconditional for everyone)
- **New tests**: crafted IPFIX option packet through the real parse path — pins the IANA XML names that were previously only tautologically tested — plus the UDP-side tap (previously untested), split-table merge, zero-scope fallback, egress keys

Accepted-by-design from the review: uint32→int ifIndex truncation (symmetric with the flow side, keys always match); `SCOPE:INTERFACE` stays a literal (the constant would add a snmp→netflow9-proto edge for 1 of 6 names); `SnmpEnricher`→`InterfaceEnricher` rename deferred. The trailer-format finding is fixed in this commit itself (contiguous block, verified with `git interpret-trailers`).

**Verification:** `make jar` → **617 tests**, all gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)