### PR TITLE
refactor: Swap-safe internals for config hot-reload (#163, phase A)

### DIFF
--- a/src/main/java/org/riptide/node/NodeRegistry.java
+++ b/src/main/java/org/riptide/node/NodeRegistry.java
@@ -7,7 +7,6 @@ package org.riptide.node;
 
 import inet.ipaddr.IPAddressString;
 import jakarta.annotation.PostConstruct;
-import lombok.Data;
 import org.riptide.pipeline.ExporterIdentity;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -22,12 +21,26 @@ import java.util.Optional;
  * The node model: matches exporter identities to configured {@link NodeDefinition}s.
  * Nodes are configured as a name-keyed map ({@code riptide.nodes.<name>.…}, same idiom
  * as receivers); the key is the node's identity in logs and error messages.
+ *
+ * <p>Bound state and serving state are separate: Spring binds into {@code nodes} at
+ * boot, lookups read the volatile {@code active} snapshot published by
+ * {@link #validate()} — or by {@link #swap(Map)} on config hot-reload. Lookups are
+ * stateless over one snapshot read, so a swap is the whole concurrency story.</p>
  */
-@Data
 @ConfigurationProperties(prefix = "riptide")
 public class NodeRegistry {
 
     private Map<String, NodeDefinition> nodes = new HashMap<>();
+
+    private volatile Map<String, NodeDefinition> active = Map.of();
+
+    public Map<String, NodeDefinition> getNodes() {
+        return this.nodes;
+    }
+
+    public void setNodes(final Map<String, NodeDefinition> nodes) {
+        this.nodes = nodes;
+    }
 
     /**
      * Matching is order-free: nodes pinned to the flow's observation domain beat
@@ -50,8 +63,9 @@ public class NodeRegistry {
     }
 
     private Optional<Node> lookup(final InetAddress address, final long domain) {
+        final Map<String, NodeDefinition> snapshot = this.active;
         final IPAddressString ipAddressString = new IPAddressString(address.getHostAddress());
-        final List<Map.Entry<String, NodeDefinition>> subnetMatches = this.nodes.entrySet().stream()
+        final List<Map.Entry<String, NodeDefinition>> subnetMatches = snapshot.entrySet().stream()
                 .filter(node -> node.getValue().getSubnetAddress().contains(ipAddressString))
                 .toList();
 
@@ -68,15 +82,31 @@ public class NodeRegistry {
                 .map(node -> new Node(node.getKey(), node.getValue(), ipAddressString));
     }
 
+    /** Validates the boot-time bind and publishes it as the serving snapshot. */
+    @PostConstruct
+    public void validate() {
+        this.active = validated(this.nodes);
+    }
+
+    /** Atomically replaces the serving snapshot with a validated candidate (hot-reload). */
+    public void swap(final Map<String, NodeDefinition> candidate) {
+        this.active = validated(candidate);
+    }
+
     /**
-     * Fails startup on ambiguous configuration. Equal-length CIDR prefixes are either
+     * Fails on ambiguous configuration. Equal-length CIDR prefixes are either
      * identical or disjoint, so a true tie is exactly two nodes with the same subnet and
      * the same pinning state — detection is complete, not heuristic.
+     *
+     * @return an immutable map of the given definitions. The copy is shallow —
+     *         {@link NodeDefinition} is a mutable bean — so isolation of the serving
+     *         snapshot rests on callers passing freshly bound instances and never
+     *         mutating them after publishing (both the boot bind and the hot-reload
+     *         candidate bind create fresh instances)
      */
-    @PostConstruct
-    void validate() {
+    public static Map<String, NodeDefinition> validated(final Map<String, NodeDefinition> nodes) {
         final Map<String, String> seen = new HashMap<>();
-        for (final Map.Entry<String, NodeDefinition> node : this.nodes.entrySet()) {
+        for (final Map.Entry<String, NodeDefinition> node : nodes.entrySet()) {
             if (node.getValue().getSubnetAddress() == null) {
                 throw new IllegalStateException("Node '%s' has no subnet-address — every node needs one to match exporters."
                         .formatted(node.getKey()));
@@ -91,6 +121,7 @@ public class NodeRegistry {
                         .formatted(other, node.getKey()));
             }
         }
+        return Map.copyOf(nodes);
     }
 
     private static int prefixLength(final IPAddressString subnet) {

--- a/src/main/java/org/riptide/node/NodesConfigMigrationCheck.java
+++ b/src/main/java/org/riptide/node/NodesConfigMigrationCheck.java
@@ -9,6 +9,7 @@ import jakarta.annotation.PostConstruct;
 import org.springframework.core.env.AbstractEnvironment;
 import org.springframework.core.env.EnumerablePropertySource;
 import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertySource;
 import org.springframework.stereotype.Component;
 
 import java.util.Objects;
@@ -35,7 +36,12 @@ public class NodesConfigMigrationCheck {
         if (!(this.environment instanceof AbstractEnvironment abstractEnvironment)) {
             return;
         }
-        for (final var source : abstractEnvironment.getPropertySources()) {
+        failOnLegacyIndexedNodes(abstractEnvironment.getPropertySources());
+    }
+
+    /** Reusable against any source stack — config hot-reload runs it on candidates. */
+    public static void failOnLegacyIndexedNodes(final Iterable<PropertySource<?>> sources) {
+        for (final var source : sources) {
             if (source instanceof EnumerablePropertySource<?> enumerable) {
                 for (final String name : enumerable.getPropertyNames()) {
                     if (LEGACY_KEY.matcher(name).find()) {

--- a/src/main/java/org/riptide/routing/RoutingConfig.java
+++ b/src/main/java/org/riptide/routing/RoutingConfig.java
@@ -28,6 +28,11 @@ import java.util.Optional;
  * the same block fail startup. {@code as-names} maps AS numbers to names for exporters
  * that already fill AS fields. The two compose: prefix fill first, then names apply to
  * whatever number the flow ends up with.</p>
+ *
+ * <p>Parsing is parse-then-swap: {@link #parse(Map, Map)} validates a candidate into an
+ * opaque {@link Parsed} snapshot without touching serving state; {@link #parsePrefixes()}
+ * publishes the boot-time bind, {@link #swap(Parsed)} publishes a hot-reload candidate.
+ * Lookups read one volatile snapshot — old or new, never a mix.</p>
  */
 @ConfigurationProperties(prefix = "riptide.routing")
 public class RoutingConfig {
@@ -42,7 +47,7 @@ public class RoutingConfig {
     @Setter
     private Map<Long, String> asNames = new HashMap<>();
 
-    private List<ParsedPrefix> parsed = List.of();
+    private volatile Parsed active = new Parsed(List.of(), Map.of());
 
     public record PrefixInfo(Long asn, String org) {
     }
@@ -50,11 +55,33 @@ public class RoutingConfig {
     private record ParsedPrefix(IPAddressString prefix, int prefixLength, PrefixInfo info) {
     }
 
+    /** Validated, immutable routing state; opaque outside this class. */
+    public static final class Parsed {
+        private final List<ParsedPrefix> prefixes;
+        private final Map<Long, String> asNames;
+
+        private Parsed(final List<ParsedPrefix> prefixes, final Map<Long, String> asNames) {
+            this.prefixes = List.copyOf(prefixes);
+            this.asNames = Map.copyOf(asNames);
+        }
+    }
+
+    /** Validates the boot-time bind and publishes it as the serving snapshot. */
     @PostConstruct
-    void parsePrefixes() {
+    public void parsePrefixes() {
+        this.active = parse(this.prefixes, this.asNames);
+    }
+
+    /** Atomically replaces the serving snapshot with a validated candidate (hot-reload). */
+    public void swap(final Parsed candidate) {
+        this.active = candidate;
+    }
+
+    /** Validates a candidate without touching serving state; throws on bad config. */
+    public static Parsed parse(final Map<String, PrefixInfo> prefixes, final Map<Long, String> asNames) {
         final Map<String, String> seenBlocks = new HashMap<>();
-        final List<ParsedPrefix> result = new ArrayList<>(this.prefixes.size());
-        for (final Map.Entry<String, PrefixInfo> entry : this.prefixes.entrySet()) {
+        final List<ParsedPrefix> result = new ArrayList<>(prefixes.size());
+        for (final Map.Entry<String, PrefixInfo> entry : prefixes.entrySet()) {
             final IPAddressString raw = new IPAddressString(entry.getKey());
             if (raw.getAddress() == null) {
                 throw new IllegalStateException("riptide.routing.prefixes: '%s' is not a valid prefix".formatted(entry.getKey()));
@@ -73,22 +100,23 @@ public class RoutingConfig {
             final Integer length = block.getNetworkPrefixLength();
             result.add(new ParsedPrefix(canonical, length != null ? length : block.getBitCount(), entry.getValue()));
         }
-        this.parsed = List.copyOf(result);
+        return new Parsed(result, asNames);
     }
 
     /** Longest-prefix match, same routing-table semantics as node matching. */
     Optional<PrefixInfo> lookupPrefix(final IPAddressString address) {
-        return this.parsed.stream()
+        return this.active.prefixes.stream()
                 .filter(entry -> entry.prefix().contains(address))
                 .max(Comparator.comparingInt(ParsedPrefix::prefixLength))
                 .map(ParsedPrefix::info);
     }
 
     Optional<String> lookupAsName(final Long asn) {
-        return Optional.ofNullable(asn).map(this.asNames::get);
+        return Optional.ofNullable(asn).map(this.active.asNames::get);
     }
 
     boolean isEmpty() {
-        return this.parsed.isEmpty() && this.asNames.isEmpty();
+        final Parsed snapshot = this.active;
+        return snapshot.prefixes.isEmpty() && snapshot.asNames.isEmpty();
     }
 }


### PR DESCRIPTION
Phase A of the `config-hot-reload` plan — a **behavioral no-op** making the two config beans swap-safe:

- `NodeRegistry`: bound state (Spring binder target) and serving state (volatile immutable snapshot read by `lookup`) are now separate; `validate()` publishes at boot, `swap()` is the hot-reload entry point; validation extracted to a static candidate-callable
- `RoutingConfig`: parse-then-swap — `parse()` validates a candidate into an opaque `Parsed` snapshot without touching serving state; lookups read one volatile snapshot (no torn reads by construction)
- `NodesConfigMigrationCheck`: legacy-key scan reusable against any property-source stack (candidates included)

Review pass (1 finder on a pure refactor): one finding — the "immutable snapshot" javadoc overclaimed (`Map.copyOf` is shallow, `NodeDefinition` is mutable); contract narrowed to the true rule: isolation rests on freshly-bound candidate instances, which phase B's `Bindable.mapOf` binding provides. All existing tests pass **unchanged** (617, all gates).

Refs #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)