### PR TITLE
test: e2e coverage for sFlow sub-agent pinning + option-record enrichment (nl6 v0.16.0)

### DIFF
--- a/src/test/java/org/riptide/e2e/Nl6Container.java
+++ b/src/test/java/org/riptide/e2e/Nl6Container.java
@@ -15,6 +15,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -32,7 +33,7 @@ import java.util.Map;
  */
 public final class Nl6Container extends GenericContainer<Nl6Container> {
 
-    private static final String IMAGE = "ghcr.io/labmonkeys-space/nl6:v0.15.1";
+    private static final String IMAGE = "ghcr.io/labmonkeys-space/nl6:v0.16.0";
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final HttpClient httpClient = HttpClient.newHttpClient();
@@ -93,15 +94,27 @@ public final class Nl6Container extends GenericContainer<Nl6Container> {
 
     /** Creates a batch of devices exporting flows to the given host port on the Docker host. */
     public void createDevices(final String startIp, final int count, final String protocol, final int collectorHostPort) throws Exception {
+        createDevices(startIp, count, protocol, collectorHostPort, Map.of());
+    }
+
+    /**
+     * As above, with extra keys merged into the {@code flow} block — e.g.
+     * {@code sub_agent_id} (sFlow, nl6 ≥ v0.16.0) or {@code options_interface_table}
+     * ({@code "if-scoped"}/{@code "system-scoped"}, NetFlow v9 / IPFIX).
+     */
+    public void createDevices(final String startIp, final int count, final String protocol,
+                              final int collectorHostPort, final Map<String, Object> flowExtras) throws Exception {
+        final var flow = new HashMap<String, Object>(Map.of(
+                "collector", "host.docker.internal:" + collectorHostPort,
+                "protocol", protocol,
+                "tick_interval", "2s",
+                "active_timeout", "5s",
+                "inactive_timeout", "5s"));
+        flow.putAll(flowExtras);
         final var body = objectMapper.writeValueAsString(Map.of(
                 "start_ip", startIp,
                 "device_count", count,
-                "flow", Map.of(
-                        "collector", "host.docker.internal:" + collectorHostPort,
-                        "protocol", protocol,
-                        "tick_interval", "2s",
-                        "active_timeout", "5s",
-                        "inactive_timeout", "5s")));
+                "flow", flow));
 
         final var request = HttpRequest.newBuilder(URI.create(apiBase() + "/devices"))
                 .header("Content-Type", "application/json")

--- a/src/test/java/org/riptide/e2e/Nl6FlowIngestionIT.java
+++ b/src/test/java/org/riptide/e2e/Nl6FlowIngestionIT.java
@@ -18,6 +18,7 @@ import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Map;
 
 import static org.riptide.e2e.E2eTestSupport.await;
 import static org.riptide.e2e.E2eTestSupport.freeUdpPort;
@@ -90,6 +91,15 @@ public class Nl6FlowIngestionIT {
         registry.add("riptide.nodes.sflow-agents.subnet-address", () -> "10.42.3.0/24");
         registry.add("riptide.nodes.sflow-agents.interfaces.1.name", () -> "sfl-in");
         registry.add("riptide.nodes.sflow-agents.interfaces.2.name", () -> "sfl-out");
+
+        // Two nodes on one subnet to prove sFlow sub-agent pinning: the pinned node
+        // (observation-domain = the sub_agent_id) beats the wildcard. Distinct static
+        // interface names let the query tell which node matched.
+        registry.add("riptide.nodes.sflow-pinned.subnet-address", () -> "10.42.6.0/24");
+        registry.add("riptide.nodes.sflow-pinned.observation-domain", () -> "7");
+        registry.add("riptide.nodes.sflow-pinned.interfaces.1.name", () -> "pinned-in");
+        registry.add("riptide.nodes.sflow-wild.subnet-address", () -> "10.42.6.0/24");
+        registry.add("riptide.nodes.sflow-wild.interfaces.1.name", () -> "wild-in");
     }
 
     @BeforeAll
@@ -105,6 +115,18 @@ public class Nl6FlowIngestionIT {
         NL6.createDevices("10.42.1.1", 3, "netflow9", NETFLOW9_PORT);
         NL6.createDevices("10.42.2.1", 3, "ipfix", IPFIX_PORT);
         NL6.createDevices("10.42.3.1", 3, "sflow", SFLOW_PORT);
+
+        // Interface option records (nl6 v0.16.0) — SNMP-less enrichment, both wire shapes:
+        // if-scoped emits IE 82+83 (name via scope), system-scoped emits IE 83 only
+        // (description via the INPUT_SNMP field fallback — the real IOS-XR shape).
+        // These add flow data to the v9/ipfix reconcile counts (fine — both sides grow);
+        // nl6 excludes option records from sent_records, so the ledger stays clean.
+        NL6.createDevices("10.42.4.1", 2, "netflow9", NETFLOW9_PORT, Map.of("options_interface_table", "if-scoped"));
+        NL6.createDevices("10.42.5.1", 2, "ipfix", IPFIX_PORT, Map.of("options_interface_table", "system-scoped"));
+
+        // sFlow sub-agent pinning — a device group per sub_agent_id on one subnet.
+        NL6.createDevices("10.42.6.1", 2, "sflow", SFLOW_PORT, Map.of("sub_agent_id", 7));    // → sflow-pinned
+        NL6.createDevices("10.42.6.21", 2, "sflow", SFLOW_PORT, Map.of("sub_agent_id", 3));   // → sflow-wild
     }
 
     @Test
@@ -142,14 +164,62 @@ public class Nl6FlowIngestionIT {
         Assertions.assertThat(algorithms.getFirst().getString("samplingAlgorithm"))
                 .isEqualTo("RandomNOutOfNSampling");
 
+        // every sFlow exporter is a device address (10.42.x), never the shared-socket
+        // container IP — the payload-derived-attribution proof
         final var exporters = queryClient.queryAll(
                 "SELECT DISTINCT exporterAddr FROM flows WHERE flowProtocol = 'SFLOW'");
         Assertions.assertThat(exporters).isNotEmpty().allSatisfy(row ->
+                Assertions.assertThat(row.getString("exporterAddr")).startsWith("10.42."));
+        Assertions.assertThat(exporters).anySatisfy(row ->
                 Assertions.assertThat(row.getString("exporterAddr")).startsWith("10.42.3."));
 
         await(Duration.ofMinutes(1), "sFlow rows enriched via the agent-address-matched node",
                 () -> queryClient.queryAll(
                         "SELECT count() AS c FROM flows WHERE flowProtocol = 'SFLOW' AND inputSnmpIfName = 'sfl-in'")
+                        .getFirst().getLong("c") > 0);
+    }
+
+    /**
+     * sFlow sub-agent pinning (nl6 v0.16.0 configurable {@code sub_agent_id}): two nodes
+     * share subnet 10.42.6.0/24, one pinned to observation-domain 7. Devices sending
+     * {@code sub_agent_id} 7 must attribute to the pinned node, others to the wildcard —
+     * proving {@code NodeRegistry} keys sFlow by {@code (agent_address, sub_agent_id)}.
+     */
+    @Test
+    void verifySflowSubAgentPinning() throws Exception {
+        await(Duration.ofMinutes(2), "sub_agent_id 7 devices attribute to the pinned node",
+                () -> queryClient.queryAll(
+                        "SELECT count() AS c FROM flows WHERE flowProtocol = 'SFLOW' "
+                        + "AND exporterAddr IN ('10.42.6.1','10.42.6.2') AND inputSnmpIfName = 'pinned-in'")
+                        .getFirst().getLong("c") > 0);
+
+        await(Duration.ofMinutes(2), "other sub_agent_id devices attribute to the wildcard node",
+                () -> queryClient.queryAll(
+                        "SELECT count() AS c FROM flows WHERE flowProtocol = 'SFLOW' "
+                        + "AND exporterAddr IN ('10.42.6.21','10.42.6.22') AND inputSnmpIfName = 'wild-in'")
+                        .getFirst().getLong("c") > 0);
+    }
+
+    /**
+     * Interface enrichment from v9/IPFIX option records (nl6 v0.16.0), with no SNMP and
+     * no node configured — pure option-table enrichment. The if-scoped shape carries
+     * IE 82 (name); the system-scoped shape carries IE 83 only (description → alias),
+     * exercising riptide's scope-resolution and field-fallback paths respectively.
+     */
+    @Test
+    void verifyOptionRecordEnrichmentWithoutSnmp() throws Exception {
+        // if-scoped (NetFlow v9): IE 82 present → interface NAME enriched
+        await(Duration.ofMinutes(2), "netflow9 flows enriched with an interface name from option records",
+                () -> queryClient.queryAll(
+                        "SELECT count() AS c FROM flows WHERE flowProtocol = 'NetflowV9' "
+                        + "AND inputSnmpIfName IS NOT NULL AND inputSnmpIfName != ''")
+                        .getFirst().getLong("c") > 0);
+
+        // system-scoped (IPFIX): IE 83 only → interface ALIAS enriched, name absent
+        await(Duration.ofMinutes(2), "ipfix flows enriched with an interface alias (description-only) from option records",
+                () -> queryClient.queryAll(
+                        "SELECT count() AS c FROM flows WHERE flowProtocol = 'IPFIX' "
+                        + "AND inputSnmpIfAlias IS NOT NULL AND inputSnmpIfAlias != ''")
                         .getFirst().getLong("c") > 0);
     }
 


### PR DESCRIPTION
Closes the two **deferred e2e gaps** from features shipped this cycle — now testable against real traffic because nl6 v0.16.0 implements the two upstream issues this project filed:

- **nl6#232** (configurable `sub_agent_id`) → the sFlow sub-agent pinning path in `sflow-support` was unit-test-only (nl6 hardcoded `0`)
- **nl6#233** (v9/IPFIX interface option records) → `option-interface-enrichment`'s enrichment was fixture-only (nl6 emitted no option tables)

## What's here
- **`verifySflowSubAgentPinning`** — two nodes share subnet 10.42.6.0/24, one pinned to `observation-domain 7`; a device group with `sub_agent_id 7` attributes to the pinned node (`pinned-in`), a group with `sub_agent_id 3` to the wildcard (`wild-in`). The two awaits mutually guard: test 1 fails if pinning breaks, test 2 fails if the pinned node greedily wins the whole subnet — together they prove sub-agent discrimination end to end.
- **`verifyOptionRecordEnrichmentWithoutSnmp`** — v9 `if-scoped` devices (IE 82+83) enrich `inputSnmpIfName`; ipfix `system-scoped` devices (IE 83 only — the real IOS-XR shape) enrich `inputSnmpIfAlias` with no name. No SNMP, no node — pure option-table enrichment, exercising both the scope and field-fallback resolution paths. Sound because nothing else can populate those columns for these devices (verified against `SnmpEnricher`).
- **`Nl6Container`** pin v0.15.1 → v0.16.0; `createDevices` overload merges extras (`sub_agent_id`, `options_interface_table`) into the REST flow block.

## Review & verification
Structured review pass: 2 findings — a fully-qualified `HashMap` (fixed) and a query about option records inflating the reconcile ledger (**refuted by nl6 docs**: option records count toward `sent_packets`/`sent_bytes` but **not** `sent_records`, which `reconcile()` keys on). `make jar` → 627 unit tests + all gates green; **6/6 e2e green in 25s** against real nl6 v0.16.0 (was 4/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)