### PR TITLE
feat: Flow identity columns + location→zone rename (multi-tenant phase 1, #230)

### DIFF
--- a/docs/docs/configuration/clickhouse.md
+++ b/docs/docs/configuration/clickhouse.md
@@ -24,7 +24,35 @@ not survive a Riptide restart in the current design.
 
 :::
 
-Enrichment results are denormalized into the flow row at write time — exporter address
-and location, resolved interface data (`inputSnmpIfName`/`ifAlias`/`ifSpeed` and the
-`output…` counterparts), hostnames, classification, and locality — so queries never need
-join-time lookups.
+Enrichment results are denormalized into the flow row at write time — exporter address,
+resolved interface data (`inputSnmpIfName`/`ifAlias`/`ifSpeed` and the `output…`
+counterparts), hostnames, classification, and locality — so queries never need join-time
+lookups.
+
+## Identity columns
+
+Every persisted flow carries four identity columns stamped by the collecting process:
+`tenant`, `organisation`, `zone` (the isolated network) and `system` (per-instance
+provenance). They default so an out-of-the-box single-tenant deployment works unchanged —
+`tenant`, `organisation` and `zone` default to `default`; `system` defaults to the process
+host name (`riptide.identity.system` → `HOSTNAME` → `InetAddress.getHostName()` →
+`default`). Configure them under `riptide.identity`:
+
+```properties
+riptide.identity.tenant=acme
+riptide.identity.organisation=acme-eu
+riptide.identity.zone=dmz
+riptide.identity.system=collector-01
+```
+
+The flows table sorts by `(tenant, organisation, toStartOfHour(timestamp), <flow tuple>)`;
+`zone` and `system` are filter dimensions and stay out of the sort key. Partitioning stays
+time-only (`toYYYYMMDD(timestamp)`).
+
+:::note
+
+`zone` replaces the former `riptide.location` key. `riptide.location` is deprecated but
+still accepted for one release (mapped to `zone` with a warning); prefer
+`riptide.identity.zone`.
+
+:::

--- a/src/main/java/org/riptide/classification/ClassificationEnricher.java
+++ b/src/main/java/org/riptide/classification/ClassificationEnricher.java
@@ -27,7 +27,7 @@ public class ClassificationEnricher extends Enricher.Single {
     protected CompletableFuture<Void> enrich(Source source, EnrichedFlow flow) {
         final var request = ClassificationRequest.builder()
                 .withExporterAddress(IpAddr.of(source.getExporterAddr()))
-                .withLocation(source.getLocation())
+                .withZone(source.getZone())
                 .withProtocol(Protocols.getProtocol(flow.getProtocol()))
                 .withSrcAddress(IpAddr.of(flow.getSrcAddr()))
                 .withSrcPort(flow.getSrcPort())

--- a/src/main/java/org/riptide/classification/ClassificationRequest.java
+++ b/src/main/java/org/riptide/classification/ClassificationRequest.java
@@ -11,7 +11,7 @@ import lombok.Data;
 @Data
 @Builder(builderClassName = "Builder", setterPrefix = "with")
 public class ClassificationRequest {
-    private final String location;
+    private final String zone;
     private final Protocol protocol;
     private final Integer dstPort;
     private final IpAddr dstAddress;
@@ -24,7 +24,7 @@ public class ClassificationRequest {
                 .withSrcPort(source.srcPort)
                 .withDstPort(source.dstPort)
                 .withProtocol(source.protocol)
-                .withLocation(source.location)
+                .withZone(source.zone)
                 .withDstAddress(source.dstAddress)
                 .withSrcAddress(source.srcAddress)
                 .withExporterAddress(source.exporterAddress);

--- a/src/main/java/org/riptide/config/DaemonConfig.java
+++ b/src/main/java/org/riptide/config/DaemonConfig.java
@@ -9,21 +9,38 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.riptide.pipeline.Identity;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@Slf4j
 @ConfigurationProperties("riptide")
 @NoArgsConstructor
 public final class DaemonConfig {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
+    /**
+     * Deprecated flow-placement key. Superseded by {@code riptide.identity.zone}; still
+     * bound for one release and mapped to {@code zone} with a warning. Left {@code null}
+     * so an explicit {@code riptide.identity.zone} can win over a legacy value.
+     *
+     * @deprecated use {@code riptide.identity.zone}
+     */
+    @Deprecated
     @Getter
     @Setter
-    private String location = "default";
+    private String location;
+
+    @Getter
+    @Setter
+    private IdentityConfig identity = new IdentityConfig();
 
     @Getter
     private Map<String, ReceiverConfig> receivers = new HashMap<>();
@@ -33,5 +50,69 @@ public final class DaemonConfig {
                 e.getKey(),
                 objectMapper.convertValue(e.getValue(), ReceiverConfig.class)
         )).collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    /**
+     * Resolve the effective flow identity once at startup. {@code tenant}, {@code
+     * organisation} and {@code zone} default to {@code "default"}; {@code zone} also
+     * accepts the deprecated {@code riptide.location} (with a warning) when
+     * {@code riptide.identity.zone} is not set. {@code system} resolves from config, then
+     * the host name, then {@code "default"} — never failing startup.
+     */
+    public Identity resolveIdentity() {
+        final String tenant = orDefault(this.identity.getTenant());
+        final String organisation = orDefault(this.identity.getOrganisation());
+        return new Identity(tenant, organisation, resolveZone(), resolveSystem());
+    }
+
+    private String resolveZone() {
+        if (!isBlank(this.identity.getZone())) {
+            return this.identity.getZone();
+        }
+        if (!isBlank(this.location)) {
+            log.warn("Config key 'riptide.location' is deprecated; use 'riptide.identity.zone'. "
+                    + "Mapping the value '{}' to zone.", this.location);
+            return this.location;
+        }
+        return "default";
+    }
+
+    private String resolveSystem() {
+        final String configured = this.identity.getSystem();
+        if (!isBlank(configured)) {
+            return configured;
+        }
+        final String env = System.getenv("HOSTNAME");
+        if (!isBlank(env)) {
+            return env;
+        }
+        try {
+            final String host = InetAddress.getLocalHost().getHostName();
+            if (!isBlank(host)) {
+                return host;
+            }
+        } catch (final UnknownHostException e) {
+            log.debug("Could not resolve local host name for riptide.identity.system", e);
+        }
+        return "default";
+    }
+
+    /** Blank (unset or empty) identity dimensions fall back to their default, uniformly. */
+    private static String orDefault(final String value) {
+        return isBlank(value) ? "default" : value;
+    }
+
+    private static boolean isBlank(final String value) {
+        return value == null || value.isBlank();
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static final class IdentityConfig {
+        private String tenant;
+        private String organisation;
+        private String zone;
+        private String system;
     }
 }

--- a/src/main/java/org/riptide/flows/Daemon.java
+++ b/src/main/java/org/riptide/flows/Daemon.java
@@ -50,7 +50,7 @@ public class Daemon implements ApplicationRunner {
                   @Qualifier("netflow9ValueConversionService") final ValueConversionService netflow9ValueConversionService,
                   final ExporterInterfaceTable exporterInterfaceTable,
                   final DaemonConfig config) {
-        final var location = config.getLocation();
+        final var identity = config.resolveIdentity();
 
         this.pipeline = Objects.requireNonNull(pipeline);
         final BiConsumer<Source, Flow> dispatcher = (source, flow) -> {
@@ -66,7 +66,7 @@ public class Daemon implements ApplicationRunner {
                 .map(e -> e.getValue().accept(new ReceiverConfig.Cases<Listener>() {
                     @Override
                     public Listener match(final ReceiverConfig.Neflow5Config config) {
-                        final var parser = new Netflow5UdpParser(e.getKey(), dispatcher, location, metricRegistry);
+                        final var parser = new Netflow5UdpParser(e.getKey(), dispatcher, identity, metricRegistry);
 
                         return new UdpListener(e.getKey(), parser, metricRegistry)
                                 .withPort(config.getPort())
@@ -75,7 +75,7 @@ public class Daemon implements ApplicationRunner {
 
                     @Override
                     public Listener match(final ReceiverConfig.Neflow9Config config) {
-                        final var parser = new Netflow9UdpParser(e.getKey(), dispatcher, location, metricRegistry, netflow9ValueConversionService)
+                        final var parser = new Netflow9UdpParser(e.getKey(), dispatcher, identity, metricRegistry, netflow9ValueConversionService)
                                 .withFlowActiveTimeoutFallback(config.getFlowActiveTimeoutFallback())
                                 .withFlowInactiveTimeoutFallback(config.getFlowInactiveTimeoutFallback())
                                 .withFlowSamplingIntervalFallback(config.getFlowSamplingIntervalFallback());
@@ -90,7 +90,7 @@ public class Daemon implements ApplicationRunner {
                     public Listener match(final ReceiverConfig.IpfixConfig config) {
                         return switch (config.getTransport()) {
                             case UDP -> {
-                                final var parser = new IpfixUdpParser(e.getKey(), dispatcher, location, metricRegistry, ipfixValueConversionService)
+                                final var parser = new IpfixUdpParser(e.getKey(), dispatcher, identity, metricRegistry, ipfixValueConversionService)
                                         .withFlowActiveTimeoutFallback(config.getFlowActiveTimeoutFallback())
                                         .withFlowInactiveTimeoutFallback(config.getFlowInactiveTimeoutFallback())
                                         .withFlowSamplingIntervalFallback(config.getFlowSamplingIntervalFallback());
@@ -102,7 +102,7 @@ public class Daemon implements ApplicationRunner {
                                         .withHost(config.getHost());
                             }
                             case TCP -> {
-                                final var parser = new IpfixTcpParser(e.getKey(), dispatcher, location, metricRegistry, ipfixValueConversionService)
+                                final var parser = new IpfixTcpParser(e.getKey(), dispatcher, identity, metricRegistry, ipfixValueConversionService)
                                         .withFlowActiveTimeoutFallback(config.getFlowActiveTimeoutFallback())
                                         .withFlowInactiveTimeoutFallback(config.getFlowInactiveTimeoutFallback())
                                         .withFlowSamplingIntervalFallback(config.getFlowSamplingIntervalFallback());
@@ -118,7 +118,7 @@ public class Daemon implements ApplicationRunner {
 
                     @Override
                     public Listener match(final ReceiverConfig.SflowConfig config) {
-                        final var parser = new SflowUdpParser(e.getKey(), dispatcher, location, metricRegistry);
+                        final var parser = new SflowUdpParser(e.getKey(), dispatcher, identity, metricRegistry);
 
                         return new UdpListener(e.getKey(), parser, metricRegistry)
                                 .withPort(config.getPort())
@@ -130,15 +130,15 @@ public class Daemon implements ApplicationRunner {
                         final var parsers = new HashSet<DispatchableUdpParser>();
 
                         if (config.isNetflow5()) {
-                            parsers.add(new Netflow5UdpParser(e.getKey() + ":netflow5", dispatcher, location, metricRegistry));
+                            parsers.add(new Netflow5UdpParser(e.getKey() + ":netflow5", dispatcher, identity, metricRegistry));
                         }
 
                         if (config.isSflow()) {
-                            parsers.add(new SflowUdpParser(e.getKey() + ":sflow", dispatcher, location, metricRegistry));
+                            parsers.add(new SflowUdpParser(e.getKey() + ":sflow", dispatcher, identity, metricRegistry));
                         }
 
                         if (config.isNetflow9()) {
-                            final var netflow9 = new Netflow9UdpParser(e.getKey() + ":netflow9", dispatcher, location, metricRegistry, netflow9ValueConversionService)
+                            final var netflow9 = new Netflow9UdpParser(e.getKey() + ":netflow9", dispatcher, identity, metricRegistry, netflow9ValueConversionService)
                                     .withFlowActiveTimeoutFallback(config.getFlowActiveTimeoutFallback())
                                     .withFlowInactiveTimeoutFallback(config.getFlowInactiveTimeoutFallback())
                                     .withFlowSamplingIntervalFallback(config.getFlowSamplingIntervalFallback());
@@ -147,7 +147,7 @@ public class Daemon implements ApplicationRunner {
                         }
 
                         if (config.isIpfix()) {
-                            final var ipfix = new IpfixUdpParser(e.getKey() + ":ipfix", dispatcher, location, metricRegistry, ipfixValueConversionService)
+                            final var ipfix = new IpfixUdpParser(e.getKey() + ":ipfix", dispatcher, identity, metricRegistry, ipfixValueConversionService)
                                     .withFlowActiveTimeoutFallback(config.getFlowActiveTimeoutFallback())
                                     .withFlowInactiveTimeoutFallback(config.getFlowInactiveTimeoutFallback())
                                     .withFlowSamplingIntervalFallback(config.getFlowSamplingIntervalFallback());

--- a/src/main/java/org/riptide/flows/parser/ParserBase.java
+++ b/src/main/java/org/riptide/flows/parser/ParserBase.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.riptide.flows.parser.data.Flow;
 import org.riptide.flows.parser.session.SequenceNumberTracker;
 import org.riptide.flows.parser.session.Session;
+import org.riptide.pipeline.Identity;
 import org.riptide.pipeline.Source;
 
 import java.time.Instant;
@@ -37,7 +38,7 @@ public abstract class ParserBase implements Parser {
 
     private final BiConsumer<Source, Flow> dispatcher;
 
-    private final String location;
+    private final Identity identity;
 
     private final Meter recordsReceived;
 
@@ -56,12 +57,12 @@ public abstract class ParserBase implements Parser {
     public ParserBase(final Protocol protocol,
                       final String name,
                       final BiConsumer<Source, Flow> dispatcher,
-                      final String location,
+                      final Identity identity,
                       final MetricRegistry metricRegistry) {
         this.protocol = Objects.requireNonNull(protocol);
         this.name = Objects.requireNonNull(name);
         this.dispatcher = Objects.requireNonNull(dispatcher);
-        this.location = Objects.requireNonNull(location);
+        this.identity = Objects.requireNonNull(identity);
 
         this.recordsReceived = metricRegistry.meter(MetricRegistry.name("parsers", name, "recordsReceived"));
         this.recordsDispatched = metricRegistry.meter(MetricRegistry.name("parsers", name, "recordsDispatched"));
@@ -134,7 +135,7 @@ public abstract class ParserBase implements Parser {
                                             final Session session) {
         // one identity per packet: it scopes sequence tracking (below) and every
         // dispatched flow's Source
-        final Source source = new Source(this.location, packet.identity(session.getRemoteAddress()));
+        final Source source = new Source(this.identity, packet.identity(session.getRemoteAddress()));
 
         // Verify that flows sequences are in order
         if (!session.verifySequenceNumber(source.identity(), packet.getSequenceNumber())) {

--- a/src/main/java/org/riptide/flows/parser/UdpParserBase.java
+++ b/src/main/java/org/riptide/flows/parser/UdpParserBase.java
@@ -15,6 +15,7 @@ import org.riptide.flows.parser.data.Flow;
 import org.riptide.flows.parser.session.Session;
 import org.riptide.flows.parser.session.OptionListener;
 import org.riptide.flows.parser.session.UdpSessionManager;
+import org.riptide.pipeline.Identity;
 import org.riptide.pipeline.Source;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,9 +47,9 @@ public abstract class UdpParserBase extends ParserBase implements UdpParser {
     public UdpParserBase(final Protocol protocol,
                          final String name,
                          final BiConsumer<Source, Flow> dispatcher,
-                         final String location,
+                         final Identity identity,
                          final MetricRegistry metricRegistry) {
-        super(protocol, name, dispatcher, location, metricRegistry);
+        super(protocol, name, dispatcher, identity, metricRegistry);
 
         this.packetsReceived = metricRegistry.meter(MetricRegistry.name("parsers",  name, "packetsReceived"));
         this.parserErrors = metricRegistry.counter(MetricRegistry.name("parsers",  name, "parserErrors"));

--- a/src/main/java/org/riptide/flows/parser/ipfix/IpfixTcpParser.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/IpfixTcpParser.java
@@ -19,6 +19,7 @@ import org.riptide.flows.parser.ipfix.proto.Packet;
 import org.riptide.flows.parser.session.OptionListener;
 import org.riptide.flows.parser.session.TcpSession;
 import org.riptide.flows.parser.state.ParserState;
+import org.riptide.pipeline.Identity;
 import org.riptide.pipeline.Source;
 import org.springframework.beans.factory.annotation.Qualifier;
 
@@ -48,10 +49,10 @@ public class IpfixTcpParser extends ParserBase implements TcpParser {
 
     public IpfixTcpParser(final String name,
                           final BiConsumer<Source, Flow> dispatcher,
-                          final String location,
+                          final Identity identity,
                           final MetricRegistry metricRegistry,
                       @Qualifier("ipfixValueConversionService") ValueConversionService conversionService) {
-        super(Protocol.IPFIX, name, dispatcher, location, metricRegistry);
+        super(Protocol.IPFIX, name, dispatcher, identity, metricRegistry);
         this.flowBuilder = new IpFixFlowBuilder(conversionService);
     }
 

--- a/src/main/java/org/riptide/flows/parser/ipfix/IpfixUdpParser.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/IpfixUdpParser.java
@@ -18,6 +18,7 @@ import org.riptide.flows.parser.ipfix.proto.Header;
 import org.riptide.flows.parser.ipfix.proto.Packet;
 import org.riptide.flows.parser.session.Session;
 import org.riptide.flows.parser.session.UdpSessionManager;
+import org.riptide.pipeline.Identity;
 import org.riptide.pipeline.Source;
 import org.springframework.beans.factory.annotation.Qualifier;
 
@@ -38,10 +39,10 @@ public class IpfixUdpParser extends UdpParserBase implements DispatchableUdpPars
 
     public IpfixUdpParser(final String name,
                           final BiConsumer<Source, Flow> dispatcher,
-                          final String location,
+                          final Identity identity,
                           final MetricRegistry metricRegistry,
                           @Qualifier("ipfixValueConversionService") final ValueConversionService conversionService) {
-        super(Protocol.IPFIX, name, dispatcher, location, metricRegistry);
+        super(Protocol.IPFIX, name, dispatcher, identity, metricRegistry);
         this.flowBuilder = new IpFixFlowBuilder(conversionService);
     }
 

--- a/src/main/java/org/riptide/flows/parser/netflow5/Netflow5UdpParser.java
+++ b/src/main/java/org/riptide/flows/parser/netflow5/Netflow5UdpParser.java
@@ -18,6 +18,7 @@ import org.riptide.flows.parser.netflow9.Netflow9UdpParser;
 import org.riptide.flows.parser.session.Session;
 import org.riptide.flows.parser.session.UdpSessionManager;
 import org.riptide.flows.utils.BufferUtils;
+import org.riptide.pipeline.Identity;
 import org.riptide.pipeline.Source;
 
 import java.net.InetSocketAddress;
@@ -29,9 +30,9 @@ public class Netflow5UdpParser extends UdpParserBase implements DispatchableUdpP
 
     public Netflow5UdpParser(final String name,
                              final BiConsumer<Source, Flow> dispatcher,
-                             final String location,
+                             final Identity identity,
                              final MetricRegistry metricRegistry) {
-        super(Protocol.NETFLOW5, name, dispatcher, location, metricRegistry);
+        super(Protocol.NETFLOW5, name, dispatcher, identity, metricRegistry);
     }
 
     @Override

--- a/src/main/java/org/riptide/flows/parser/netflow9/Netflow9UdpParser.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/Netflow9UdpParser.java
@@ -18,6 +18,7 @@ import org.riptide.flows.parser.netflow9.proto.Header;
 import org.riptide.flows.parser.netflow9.proto.Packet;
 import org.riptide.flows.parser.session.Session;
 import org.riptide.flows.parser.session.UdpSessionManager;
+import org.riptide.pipeline.Identity;
 import org.riptide.pipeline.Source;
 
 import java.net.InetAddress;
@@ -37,10 +38,10 @@ public class Netflow9UdpParser extends UdpParserBase implements DispatchableUdpP
 
     public Netflow9UdpParser(final String name,
                              final BiConsumer<Source, Flow> dispatcher,
-                             final String location,
+                             final Identity identity,
                              final MetricRegistry metricRegistry,
                              final ValueConversionService valueConversionService) {
-        super(Protocol.NETFLOW9, name, dispatcher, location, metricRegistry);
+        super(Protocol.NETFLOW9, name, dispatcher, identity, metricRegistry);
         this.flowBuilder = new Netflow9FlowBuilder(valueConversionService);
     }
 

--- a/src/main/java/org/riptide/flows/parser/sflow/SflowUdpParser.java
+++ b/src/main/java/org/riptide/flows/parser/sflow/SflowUdpParser.java
@@ -17,6 +17,7 @@ import org.riptide.flows.parser.session.Session;
 import org.riptide.flows.parser.session.UdpSessionManager;
 import org.riptide.flows.parser.sflow.proto.Datagram;
 import org.riptide.flows.utils.BufferUtils;
+import org.riptide.pipeline.Identity;
 import org.riptide.pipeline.Source;
 
 import java.net.InetSocketAddress;
@@ -32,9 +33,9 @@ public class SflowUdpParser extends UdpParserBase implements DispatchableUdpPars
 
     public SflowUdpParser(final String name,
                           final BiConsumer<Source, Flow> dispatcher,
-                          final String location,
+                          final Identity identity,
                           final MetricRegistry metricRegistry) {
-        super(Protocol.SFLOW, name, dispatcher, location, metricRegistry);
+        super(Protocol.SFLOW, name, dispatcher, identity, metricRegistry);
     }
 
     @Override

--- a/src/main/java/org/riptide/pipeline/EnrichedFlow.java
+++ b/src/main/java/org/riptide/pipeline/EnrichedFlow.java
@@ -63,7 +63,10 @@ public class EnrichedFlow {
 
     private String application;
     private String exporterAddr;
-    private String location;
+    private String tenant;
+    private String organisation;
+    private String zone;
+    private String system;
     private Locality srcLocality;
     private Locality dstLocality;
     private Locality flowLocality;

--- a/src/main/java/org/riptide/pipeline/Identity.java
+++ b/src/main/java/org/riptide/pipeline/Identity.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.pipeline;
+
+import java.util.Objects;
+
+/**
+ * The four identity dimensions stamped onto every persisted flow by the collecting
+ * riptide process: {@code tenant}, {@code organisation}, {@code zone} (the isolated
+ * network) and {@code system} (per-instance provenance). Resolved once at startup from
+ * {@code riptide.identity.*} and carried through {@link Source} to the persisted row.
+ */
+public record Identity(String tenant, String organisation, String zone, String system) {
+    public Identity {
+        Objects.requireNonNull(tenant);
+        Objects.requireNonNull(organisation);
+        Objects.requireNonNull(zone);
+        Objects.requireNonNull(system);
+    }
+}

--- a/src/main/java/org/riptide/pipeline/Pipeline.java
+++ b/src/main/java/org/riptide/pipeline/Pipeline.java
@@ -65,7 +65,7 @@ public class Pipeline {
         // Filter empty logs
         if (flows.isEmpty()) {
             this.emptyFlows.inc();
-            LOG.info("Received empty flows from {} @ {}. Nothing to do.", source.getExporterAddr(), source.getLocation());
+            LOG.info("Received empty flows from {} @ {}. Nothing to do.", source.getExporterAddr(), source.getZone());
             return;
         }
 

--- a/src/main/java/org/riptide/pipeline/Source.java
+++ b/src/main/java/org/riptide/pipeline/Source.java
@@ -9,26 +9,50 @@ import java.net.InetAddress;
 import java.util.Objects;
 
 public class Source {
-    private final String location;
+    private final String zone;
+    private final String tenant;
+    private final String organisation;
+    private final String system;
 
-    private final ExporterIdentity identity;
+    private final ExporterIdentity exporter;
 
-    public Source(final String location, final ExporterIdentity identity) {
-        this.location = Objects.requireNonNull(location);
-        this.identity = Objects.requireNonNull(identity);
+    public Source(final Identity identity, final ExporterIdentity exporter) {
+        Objects.requireNonNull(identity);
+        this.zone = identity.zone();
+        this.tenant = identity.tenant();
+        this.organisation = identity.organisation();
+        this.system = identity.system();
+        this.exporter = Objects.requireNonNull(exporter);
+    }
+
+    /** Convenience for tests without a full identity: the other dimensions default. */
+    public Source(final String zone, final ExporterIdentity exporter) {
+        this(new Identity("default", "default", zone, "default"), exporter);
     }
 
     /** Convenience for protocols (and tests) without an observation-domain concept. */
-    public Source(final String location, final InetAddress exporterAddr) {
-        this(location, new ExporterIdentity.NetflowIpfix(exporterAddr, 0));
+    public Source(final String zone, final InetAddress exporterAddr) {
+        this(zone, new ExporterIdentity.NetflowIpfix(exporterAddr, 0));
     }
 
-    public String getLocation() {
-        return this.location;
+    public String getZone() {
+        return this.zone;
+    }
+
+    public String getTenant() {
+        return this.tenant;
+    }
+
+    public String getOrganisation() {
+        return this.organisation;
+    }
+
+    public String getSystem() {
+        return this.system;
     }
 
     public ExporterIdentity identity() {
-        return this.identity;
+        return this.exporter;
     }
 
     /**
@@ -37,6 +61,6 @@ public class Source {
      * accessor is what populates the persisted {@code exporterAddr} column.
      */
     public InetAddress getExporterAddr() {
-        return this.identity.deviceAddress();
+        return this.exporter.deviceAddress();
     }
 }

--- a/src/main/java/org/riptide/repository/clickhouse/ClickhouseFlow.java
+++ b/src/main/java/org/riptide/repository/clickhouse/ClickhouseFlow.java
@@ -18,7 +18,10 @@ public class ClickhouseFlow {
 
     private byte flowProtocol;
 
-    private String location;
+    private String tenant;
+    private String organisation;
+    private String zone;
+    private String system;
     private String exporterAddr;
 
     private Timestamp receivedAt;

--- a/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
+++ b/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
@@ -83,7 +83,10 @@ public class ClickhouseRepository implements FlowRepository {
                 'SFLOW' = 4
             ),
     
-            location String,
+            tenant String,
+            organisation String,
+            zone String,
+            system String,
             exporterAddr String,
     
             receivedAt DateTime64(9),
@@ -154,10 +157,11 @@ public class ClickhouseRepository implements FlowRepository {
             clockCorrection Nullable(Int64)
         ) ENGINE = MergeTree()
         ORDER BY (
+            tenant, organisation,
+            toStartOfHour(timestamp),
             srcAs, dstAs,
             srcAddr, dstAddr,
-            srcPort, dstPort,
-            toUnixTimestamp(timestamp)
+            srcPort, dstPort
         )
         PARTITION BY toYYYYMMDD(timestamp)
         TTL toDateTime(timestamp) + INTERVAL 30 DAY

--- a/src/test/java/org/riptide/classification/internal/DefaultClassificationEngineTest.java
+++ b/src/test/java/org/riptide/classification/internal/DefaultClassificationEngineTest.java
@@ -68,7 +68,7 @@ public class DefaultClassificationEngineTest {
                 DefaultRule.builder().withName("XXX").withDstAddress("192.168.2.1").build()
         ));
         final var classificationRequest = ClassificationRequest.builder()
-                .withLocation("Default")
+                .withZone("Default")
                 .withSrcPort(0)
                 .withDstAddress("192.168.2.1")
                 .withDstPort(80)
@@ -76,7 +76,7 @@ public class DefaultClassificationEngineTest {
                 .build();
         assertThat(engine.classify(classificationRequest)).isEqualTo("XXX");
         assertThat(engine.classify(ClassificationRequest.builder()
-                .withLocation("Default")
+                .withZone("Default")
                 .withProtocol(ProtocolType.TCP)
                 .withSrcAddress("192.168.2.1").withSrcPort(4789)
                 .withDstAddress("52.31.45.219").withDstPort(80)
@@ -89,7 +89,7 @@ public class DefaultClassificationEngineTest {
         assertThat(IntStream.range(0, 65535))
                 .allSatisfy((i) -> assertThatCode(() -> {
                     final var request = ClassificationRequest.builder()
-                            .withLocation("Default")
+                            .withZone("Default")
                             .withSrcPort(0)
                             .withDstPort(i)
                             .withDstAddress("127.0.0.1")
@@ -109,7 +109,7 @@ public class DefaultClassificationEngineTest {
         }
         final var engine = new DefaultClassificationEngine(() -> rules);
         final var request = ClassificationRequest.builder()
-                .withLocation("localhost")
+                .withZone("localhost")
                 .withSrcPort(1234)
                 .withSrcAddress("127.0.0.1")
                 .withDstPort(80)

--- a/src/test/java/org/riptide/classification/internal/DefaultClassificationExtendedEngineTest.java
+++ b/src/test/java/org/riptide/classification/internal/DefaultClassificationExtendedEngineTest.java
@@ -46,62 +46,62 @@ public class DefaultClassificationExtendedEngineTest {
     Stream<DynamicTest> verifyBasicExtendedRules() throws InterruptedException {
         return Stream.of(
                 Tuple.of("SSH", ClassificationRequest.builder()
-                        .withLocation("Default")
+                        .withZone("Default")
                         .withSrcPort(0)
                         .withDstPort(22)
                         .withDstAddress("127.0.0.1")
                         .withProtocol(ProtocolType.TCP).build()),
                 Tuple.of("HTTP_CUSTOM", ClassificationRequest.builder()
-                        .withLocation("Default")
+                        .withZone("Default")
                         .withSrcPort(0)
                         .withDstPort(80)
                         .withDstAddress("192.168.0.1")
                         .withProtocol(ProtocolType.TCP).build()),
                 Tuple.of("HTTP", ClassificationRequest.builder()
-                        .withLocation("Default")
+                        .withZone("Default")
                         .withSrcPort(0)
                         .withDstPort(80)
                         .withDstAddress("192.168.0.2")
                         .withProtocol(ProtocolType.TCP).build()),
                 Tuple.of(null, ClassificationRequest.builder()
-                        .withLocation("Default")
+                        .withZone("Default")
                         .withSrcPort(0)
                         .withDstPort(5000)
                         .withDstAddress("localhost")
                         .withProtocol(ProtocolType.UDP).build()),
                 Tuple.of(null, ClassificationRequest.builder()
-                        .withLocation("Default")
+                        .withZone("Default")
                         .withSrcPort(0)
                         .withDstPort(5000)
                         .withDstAddress("localhost")
                         .withProtocol(ProtocolType.TCP).build()),
                 Tuple.of("OpenNMS", ClassificationRequest.builder()
-                        .withLocation("Default")
+                        .withZone("Default")
                         .withSrcPort(0)
                         .withDstPort(8980)
                         .withDstAddress("127.0.0.1")
                         .withProtocol(ProtocolType.TCP).build()),
                 Tuple.of("OpenNMS", ClassificationRequest.builder()
-                        .withLocation("Default")
+                        .withZone("Default")
                         .withSrcPort(0)
                         .withDstPort(8980)
                         .withDstAddress("127.0.0.1")
                         .withProtocol(ProtocolType.UDP).build()),
                 Tuple.of("OpenNMS Monitor", ClassificationRequest.builder()
-                        .withLocation("Default")
+                        .withZone("Default")
                         .withSrcAddress("10.0.0.5")
                         .withSrcPort(5347)
                         .withDstPort(1077)
                         .withProtocol(ProtocolType.TCP).build()),
                 Tuple.of("HTTP", ClassificationRequest.builder()
-                        .withLocation("Default")
+                        .withZone("Default")
                         .withSrcAddress(IpAddr.of("10.0.0.5"))
                         .withSrcPort(5347)
                         .withDstPort(80)
                         .withDstAddress("192.168.0.2")
                         .withProtocol(ProtocolType.TCP).build()),
                 Tuple.of("DUMMY", ClassificationRequest.builder()
-                        .withLocation("Default")
+                        .withZone("Default")
                         .withSrcAddress("127.0.0.1")
                         .withDstAddress("10.10.5.3")
                         .withSrcPort(5213)
@@ -123,7 +123,7 @@ public class DefaultClassificationExtendedEngineTest {
         var ipAddresses = IpRange.of("192.168.1.0", "192.168.1.255");
         for (var ipAddress : ipAddresses) {
             final var classificationRequest = ClassificationRequest.builder()
-                    .withLocation("Default")
+                    .withZone("Default")
                     .withSrcPort(0)
                     .withDstPort(8080)
                     .withDstAddress(ipAddress)
@@ -143,7 +143,7 @@ public class DefaultClassificationExtendedEngineTest {
         // Verify CIDR expression
         for (var ipAddress : IpRange.of("192.168.0.0", "192.168.0.255")) {
             final var classificationRequest = ClassificationRequest.builder()
-                    .withLocation("Default")
+                    .withZone("Default")
                     .withSrcPort(0)
                     .withSrcAddress((IpAddr) null)
                     .withDstPort(8080)
@@ -159,7 +159,7 @@ public class DefaultClassificationExtendedEngineTest {
         assertThat(IntStream.range(7000, 8000))
                 .allSatisfy(i -> {
                     final var request = ClassificationRequest.builder()
-                            .withLocation("Default")
+                            .withZone("Default")
                             .withSrcPort(0)
                             .withDstPort(i)
                             .withDstAddress("192.168.0.2")
@@ -175,7 +175,7 @@ public class DefaultClassificationExtendedEngineTest {
         IntStream.range(7000, 8000).forEach(src -> {
             IntStream.range(7000, 8000).forEach(dst -> {
                 final ClassificationRequest classificationRequest = ClassificationRequest.builder()
-                        .withLocation("Default")
+                        .withZone("Default")
                         .withProtocol(ProtocolType.TCP)
                         .withSrcAddress("10.0.0.1").withSrcPort(src)
                         .withDstAddress("192.168.0.2").withDstPort(dst).build();

--- a/src/test/java/org/riptide/config/DaemonConfigTest.java
+++ b/src/test/java/org/riptide/config/DaemonConfigTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.config;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Binds {@code riptide.identity.*} (and the deprecated {@code riptide.location}) via the
+ * Spring {@link Binder} and verifies {@link DaemonConfig#resolveIdentity()}.
+ */
+class DaemonConfigTest {
+
+    private static DaemonConfig bind(final Map<String, Object> props) {
+        final var source = new MapConfigurationPropertySource(props);
+        return new Binder(source).bind("riptide", DaemonConfig.class).orElseGet(DaemonConfig::new);
+    }
+
+    @Test
+    void deprecatedLocationKeyBindsToZoneWithWarning() {
+        final var logger = (Logger) LoggerFactory.getLogger(DaemonConfig.class);
+        final var appender = new ListAppender<ILoggingEvent>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            final var config = bind(Map.of("riptide.location", "legacy-dc"));
+
+            assertThat(config.resolveIdentity().zone()).isEqualTo("legacy-dc");
+            assertThat(appender.list)
+                    .anySatisfy(event -> {
+                        assertThat(event.getLevel()).isEqualTo(Level.WARN);
+                        assertThat(event.getFormattedMessage())
+                                .contains("riptide.location")
+                                .contains("deprecated")
+                                .contains("legacy-dc");
+                    });
+        } finally {
+            logger.detachAppender(appender);
+        }
+    }
+
+    @Test
+    void explicitZoneWinsOverDeprecatedLocation() {
+        final var config = bind(Map.of(
+                "riptide.location", "legacy-dc",
+                "riptide.identity.zone", "dmz"));
+
+        assertThat(config.resolveIdentity().zone()).isEqualTo("dmz");
+    }
+
+    @Test
+    void defaultsWhenUnconfigured() {
+        final var identity = bind(Map.of()).resolveIdentity();
+
+        assertThat(identity.tenant()).isEqualTo("default");
+        assertThat(identity.organisation()).isEqualTo("default");
+        assertThat(identity.zone()).isEqualTo("default");
+        // system is host-derived and never fails startup.
+        assertThat(identity.system()).isNotBlank();
+    }
+
+    @Test
+    void configuredIdentityIsResolved() {
+        final var identity = bind(Map.of(
+                "riptide.identity.tenant", "acme",
+                "riptide.identity.organisation", "acme-eu",
+                "riptide.identity.zone", "dmz",
+                "riptide.identity.system", "collector-01")).resolveIdentity();
+
+        assertThat(identity.tenant()).isEqualTo("acme");
+        assertThat(identity.organisation()).isEqualTo("acme-eu");
+        assertThat(identity.zone()).isEqualTo("dmz");
+        assertThat(identity.system()).isEqualTo("collector-01");
+    }
+
+    @Test
+    void blankIdentityValuesFallBackToDefault() {
+        // an explicitly empty property must not stamp an empty dimension (which would
+        // also lead the ClickHouse sort key with an empty tenant)
+        final var identity = bind(Map.of(
+                "riptide.identity.tenant", "",
+                "riptide.identity.organisation", "",
+                "riptide.identity.zone", "")).resolveIdentity();
+
+        assertThat(identity.tenant()).isEqualTo("default");
+        assertThat(identity.organisation()).isEqualTo("default");
+        assertThat(identity.zone()).isEqualTo("default");
+        assertThat(identity.system()).isNotBlank();
+    }
+}

--- a/src/test/java/org/riptide/flows/parser/sflow/SflowParserTest.java
+++ b/src/test/java/org/riptide/flows/parser/sflow/SflowParserTest.java
@@ -14,6 +14,7 @@ import org.riptide.flows.parser.exceptions.InvalidPacketException;
 import org.riptide.flows.parser.sflow.proto.Datagram;
 import org.riptide.flows.parser.sflow.proto.InterfaceValue;
 import org.riptide.pipeline.ExporterIdentity;
+import org.riptide.pipeline.Identity;
 
 import java.net.InetAddress;
 import java.time.Instant;
@@ -326,7 +327,8 @@ public class SflowParserTest {
 
     @Test
     public void handlesPeeksTheXdrVersionWord() {
-        final var parser = new SflowUdpParser("test", (source, flow) -> { }, "here", new MetricRegistry());
+        final var parser = new SflowUdpParser("test", (source, flow) -> { },
+                new Identity("default", "default", "here", "default"), new MetricRegistry());
 
         assertThat(parser.handles(u32(buf(), 5))).isTrue();
         assertThat(parser.handles(buf().writeShort(0x0005))).isFalse();  // NetFlow v5

--- a/src/test/java/org/riptide/pipeline/FlowMapperTest.java
+++ b/src/test/java/org/riptide/pipeline/FlowMapperTest.java
@@ -16,21 +16,50 @@ import static org.mockito.Mockito.mock;
 
 /**
  * Pins the name-driven MapStruct mapping of {@link Source} properties into
- * {@link EnrichedFlow}: {@code exporterAddr} and {@code location} are populated via
+ * {@link EnrichedFlow}: {@code exporterAddr} and the four identity columns
+ * ({@code tenant}, {@code organisation}, {@code zone}, {@code system}) are populated via
  * property-name matching, so a rename on {@link Source} would otherwise fail silently
- * (NULL exporterAddr in ClickHouse) instead of loudly.
+ * (NULL columns in ClickHouse) instead of loudly.
  */
 public class FlowMapperTest {
 
+    private final EnrichedFlow.FlowMapper mapper = Mappers.getMapper(EnrichedFlow.FlowMapper.class);
+
     @Test
     public void sourcePropertiesMapByName() throws Exception {
-        final var mapper = Mappers.getMapper(EnrichedFlow.FlowMapper.class);
         final var source = new Source("here", InetAddress.getByName("203.0.113.9"));
 
         final var enriched = mapper.enrichedFlow(source, mock(Flow.class));
 
         assertThat(enriched.getExporterAddr()).isEqualTo("203.0.113.9");
-        assertThat(enriched.getLocation()).isEqualTo("here");
+        assertThat(enriched.getZone()).isEqualTo("here");
+    }
+
+    @Test
+    public void identityDefaultsPopulate() throws Exception {
+        // The 2-arg convenience constructor defaults the non-zone identity dimensions.
+        final var source = new Source("default", InetAddress.getByName("203.0.113.9"));
+
+        final var enriched = mapper.enrichedFlow(source, mock(Flow.class));
+
+        assertThat(enriched.getTenant()).isEqualTo("default");
+        assertThat(enriched.getOrganisation()).isEqualTo("default");
+        assertThat(enriched.getZone()).isEqualTo("default");
+        assertThat(enriched.getSystem()).isEqualTo("default");
+    }
+
+    @Test
+    public void configuredIdentityIsStamped() throws Exception {
+        final var identity = new Identity("acme", "acme-eu", "dmz", "collector-01");
+        final var source = new Source(identity, new ExporterIdentity.NetflowIpfix(
+                InetAddress.getByName("203.0.113.9"), 7));
+
+        final var enriched = mapper.enrichedFlow(source, mock(Flow.class));
+
+        assertThat(enriched.getTenant()).isEqualTo("acme");
+        assertThat(enriched.getOrganisation()).isEqualTo("acme-eu");
+        assertThat(enriched.getZone()).isEqualTo("dmz");
+        assertThat(enriched.getSystem()).isEqualTo("collector-01");
     }
 
     @Test

--- a/src/test/java/org/riptide/repository/clickhouse/ClickhouseRepositoryIT.java
+++ b/src/test/java/org/riptide/repository/clickhouse/ClickhouseRepositoryIT.java
@@ -69,13 +69,29 @@ public class ClickhouseRepositoryIT {
         Assertions.assertThat(count).isEqualTo(2);
 
         final var rows = queryClient.queryAll(
-                "SELECT srcPort, dstPort, bytes, flowProtocol, exporterAddr FROM flows ORDER BY srcPort");
+                "SELECT srcPort, dstPort, bytes, flowProtocol, exporterAddr, "
+                        + "tenant, organisation, zone, system FROM flows ORDER BY srcPort");
         Assertions.assertThat(rows).hasSize(2);
         Assertions.assertThat(rows.getFirst().getInteger("srcPort")).isEqualTo(10001);
         Assertions.assertThat(rows.getFirst().getInteger("dstPort")).isEqualTo(443);
         Assertions.assertThat(rows.getFirst().getLong("bytes")).isEqualTo(1234L);
         Assertions.assertThat(rows.getFirst().getString("flowProtocol")).isEqualTo("IPFIX");
         Assertions.assertThat(rows.getFirst().getString("exporterAddr")).isEqualTo("203.0.113.7");
+        Assertions.assertThat(rows.getFirst().getString("tenant")).isEqualTo("default");
+        Assertions.assertThat(rows.getFirst().getString("organisation")).isEqualTo("default");
+        Assertions.assertThat(rows.getFirst().getString("zone")).isEqualTo("default");
+        Assertions.assertThat(rows.getFirst().getString("system")).isEqualTo("default");
+    }
+
+    @Test
+    void sortingKeyLeadsWithTenant() {
+        final var sortingKey = queryClient.queryAll(
+                        "SELECT sorting_key FROM system.tables WHERE name = 'flows'")
+                .getFirst().getString("sorting_key");
+
+        // Tenant-led sort key with a rounded-time term; zone/system stay out of it.
+        Assertions.assertThat(sortingKey).startsWith("tenant, organisation, toStartOfHour(timestamp)");
+        Assertions.assertThat(sortingKey).doesNotContain("zone").doesNotContain("system");
     }
 
     private static EnrichedFlow testFlow(final Instant now, final int srcPort, final int dstPort, final long bytes) throws Exception {
@@ -86,7 +102,10 @@ public class ClickhouseRepositoryIT {
                 .deltaSwitched(now.minusSeconds(10))
                 .lastSwitched(now)
                 .flowProtocol(Flow.FlowProtocol.IPFIX)
-                .location("default")
+                .tenant("default")
+                .organisation("default")
+                .zone("default")
+                .system("default")
                 .exporterAddr("203.0.113.7")
                 .srcAddr(InetAddress.getByName("192.0.2.10"))
                 .srcPort(srcPort)


### PR DESCRIPTION
Phase 1 of the multi-tenant epic (#229) — a **behavioral no-op** that lays the identity vocabulary before any isolation machinery. Closes #230.

## What's here
- **Three identity columns** — `tenant`, `organisation`, `system` as ordinary riptide-populated String columns (uniform with `zone`), threaded via a new `Identity` record: config → `Source` → MapStruct → `EnrichedFlow` → `ClickhouseFlow` → DDL. Default `'default'` (tenant/org), host-derived (`system`: config → `HOSTNAME` → `getHostName()` → `"default"`, never fails startup).
- **`location` → `zone`** ('network zone') across the flow-placement path — the concept is the *isolated network*, not the collector's seat. The unrelated config-file `location` uses (`ConfigFileReloader`, `spring.config.additional-location`) are deliberately untouched. Deprecated `riptide.location` still binds to zone with a warning for one release.
- **Sort key locked** while free (no persistence yet): `ORDER BY (tenant, organisation, toStartOfHour(timestamp), …)` — tenant-led pruning; `zone`/`system` out as filter dimensions. The one irreversible-after-phase-2 decision, made now.

## Not in scope (later phases)
No isolation enforcement — CHECK constraints, per-tenant credentials (phase 3, #232); no DDL-ownership split — riptide keeps `CREATE OR REPLACE` (phase 2, #231).

## Review & verification
Implemented with **Opus 4.8**, structured **Fable 5** review (2 finder angles): one finding — blank identity values (`riptide.identity.tenant=`) stamped `""` instead of `"default"` and would lead the sort key with an empty tenant — **fixed** with uniform `isBlank()` handling + a regression test. `make jar` → **634 tests** + all gates; **nl6 e2e 6/6** and **ClickHouse IT 2/2** green locally (the Source-construction path changed, so both were re-run). The IT pins the new sort key (`sortingKeyLeadsWithTenant`) and the four-column insert.

Refs #229 · Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)