### PR TITLE
feat: ClickHouse schema-ownership toggle (multi-tenant phase 2, #231)

### DIFF
--- a/docs/docs/configuration/clickhouse.md
+++ b/docs/docs/configuration/clickhouse.md
@@ -12,15 +12,35 @@ riptide.clickhouse.endpoint=http://localhost:8123
 riptide.clickhouse.username=default
 riptide.clickhouse.password=
 riptide.clickhouse.database=riptide
+riptide.clickhouse.manage-schema=true
 ```
 
-Riptide owns its schema: at startup it issues `CREATE OR REPLACE TABLE` for the `flows`
-table.
+## Schema ownership
+
+`riptide.clickhouse.manage-schema` (boolean, default `true`) selects who owns the schema:
+
+- **`true` (default, single-tenant)** — riptide ensures the schema idempotently at startup:
+  the `flows` table with `CREATE TABLE IF NOT EXISTS` (an existing table is not replaced, so
+  its data survives), and the `samples` view with `CREATE OR REPLACE VIEW` (a view holds no
+  data, so it is always refreshed and can never go stale). A fresh install is created; a
+  restart keeps the data — so **flow data now survives a Riptide restart**.
+- **`false` (provisioned / multi-tenant)** — riptide creates nothing. It validates that the
+  `flows` table exists and carries every column it inserts and **fails startup with a clear,
+  provisioning-pointing error** if it does not. Use this when an admin owns the schema and
+  RBAC and each riptide process is a narrowly-scoped writer that only uses the table.
+
+In both modes, startup verifies the `flows` table is present and carries every column riptide
+inserts (including the `tenant`/`organisation`/`zone`/`system` identity columns) by reading the
+table's own schema — so the check works even for a narrowly-granted writer without server-catalog
+access, and a stale or mis-provisioned schema fails fast rather than surfacing later as an opaque
+insert error.
 
 :::warning
 
-`CREATE OR REPLACE TABLE` **recreates the flows table on every start** — flow data does
-not survive a Riptide restart in the current design.
+Schema evolution is not migrated automatically. Because manage mode uses
+`CREATE TABLE IF NOT EXISTS`, a schema change between Riptide versions is **not** applied to
+an existing table — the startup column check fails fast and the operator must drop and let
+Riptide recreate the table (or re-provision it) until schema migrations land.
 
 :::
 

--- a/docs/docs/deploy/operations.md
+++ b/docs/docs/deploy/operations.md
@@ -15,11 +15,19 @@ title: Operations
 
 ## Restarts and data
 
+In manage mode (`riptide.clickhouse.manage-schema=true`, the default), Riptide ensures its
+`flows` table with `CREATE TABLE IF NOT EXISTS` at startup — an existing table is not
+replaced, so **flow data now survives a Riptide restart**. (This fixes the earlier
+`CREATE OR REPLACE` behavior, which recreated the table on every boot and lost all data.)
+
 :::warning
 
-Riptide issues `CREATE OR REPLACE TABLE` for its `flows` table at startup — **flow data
-does not survive a Riptide restart** in the current design. Plan retention accordingly
-(e.g. export/aggregate downstream) until schema migration lands.
+Schema evolution is still not migrated automatically. `CREATE TABLE IF NOT EXISTS` no-ops on
+an existing table, so a schema change between Riptide versions is **not** applied — the
+startup column check fails fast if the on-disk schema is stale, and the operator must **drop
+the `flows` table** (Riptide recreates it in manage mode) or re-provision it in
+`manage-schema=false` mode. This is a deliberate fail-fast until schema migrations land; plan
+retention accordingly if a version upgrade requires dropping the table.
 
 :::
 

--- a/src/main/java/org/riptide/config/ClickhouseConfig.java
+++ b/src/main/java/org/riptide/config/ClickhouseConfig.java
@@ -17,4 +17,12 @@ public final class ClickhouseConfig {
         private String password;
 
         private String database = "riptide";
+
+        /**
+         * When {@code true} (default), riptide ensures the ClickHouse schema idempotently at
+         * startup. When {@code false}, riptide creates nothing and instead validates that an
+         * admin-provisioned {@code flows} table is present, failing fast if it is not — the
+         * multi-tenant / provisioned mode.
+         */
+        private boolean manageSchema = true;
 }

--- a/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
+++ b/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
@@ -17,22 +17,42 @@ import org.riptide.config.ClickhouseConfig;
 import org.riptide.flows.parser.data.Flow;
 import org.riptide.pipeline.EnrichedFlow;
 import org.riptide.pipeline.FlowException;
+import com.clickhouse.client.api.metadata.TableSchema;
+import com.clickhouse.data.ClickHouseColumn;
 import org.riptide.repository.FlowRepository;
 
 import java.io.IOException;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.net.InetAddress;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 
 @Slf4j
 public class ClickhouseRepository implements FlowRepository {
 
+    /**
+     * The columns riptide inserts, derived from the persisted-flow POJO whose field names match
+     * the ClickHouse column names 1:1. The startup schema check requires all of these to be
+     * present; a table missing any is stale or mis-provisioned and fails fast (before the first
+     * insert would fail opaquely).
+     */
+    private static final Set<String> REQUIRED_COLUMNS = Arrays.stream(ClickhouseFlow.class.getDeclaredFields())
+            .filter(field -> !Modifier.isStatic(field.getModifiers()) && !field.isSynthetic())
+            .map(Field::getName)
+            .collect(Collectors.toUnmodifiableSet());
+
     private final FlowMapper flowMapper;
+
+    private final ClickhouseConfig config;
 
     private final Client client;
 
@@ -40,6 +60,7 @@ public class ClickhouseRepository implements FlowRepository {
     public ClickhouseRepository(final FlowMapper flowMapper,
                                 final ClickhouseConfig config) {
         this.flowMapper = Objects.requireNonNull(flowMapper);
+        this.config = Objects.requireNonNull(config);
 
         this.client = new Client.Builder()
                 .addEndpoint(config.getEndpoint())
@@ -65,15 +86,70 @@ public class ClickhouseRepository implements FlowRepository {
     @Override
     @SneakyThrows
     public void start() {
-        this.client.execute(DDL_FLOWS).get();
-        this.client.execute(DDL_SAMPLES).get();
+        if (this.config.isManageSchema()) {
+            // Manage mode: ensure the schema idempotently. IF NOT EXISTS means an existing flows
+            // table is not replaced, so previously persisted data survives a restart; the samples
+            // VIEW holds no data and is always refreshed (OR REPLACE) so it never goes stale.
+            this.client.execute(DDL_FLOWS).get();
+            this.client.execute(DDL_SAMPLES).get();
+        }
 
-        this.client.register(ClickhouseFlow.class, this.client.getTableSchema("flows"));
+        // Both modes: the flows table must exist and carry every column riptide inserts. Fail-fast
+        // guard (no ALTER, no migration): in manage mode it catches a stale table that IF NOT
+        // EXISTS no-oped over; in validate mode it catches an absent or mis-provisioned schema —
+        // before the first insert would fail with an opaque error. Reuses the schema for register.
+        final TableSchema schema = checkSchema();
+
+        this.client.register(ClickhouseFlow.class, schema);
+    }
+
+    /**
+     * Verify the {@code flows} table is present and carries every column riptide inserts, throwing
+     * an actionable {@link IllegalStateException} otherwise. Reads the table's own schema (not the
+     * {@code system} database), so it works for a narrowly-granted writer that can describe its
+     * table but not the server catalog.
+     *
+     * @return the table schema, reused for POJO registration
+     */
+    private TableSchema checkSchema() {
+        final TableSchema schema;
+        try {
+            schema = this.client.getTableSchema("flows");
+        } catch (final RuntimeException e) {
+            throw new IllegalStateException(
+                    "flows table not found in database '" + this.config.getDatabase()
+                            + "' — provision the schema (see the ClickHouse deployment docs) or set "
+                            + "riptide.clickhouse.manage-schema=true to let riptide create it.", e);
+        }
+
+        final Set<String> present = schema.getColumns().stream()
+                .map(ClickHouseColumn::getColumnName)
+                .collect(Collectors.toSet());
+        if (present.isEmpty()) {
+            throw new IllegalStateException(
+                    "flows table not found in database '" + this.config.getDatabase()
+                            + "' — provision the schema (see the ClickHouse deployment docs) or set "
+                            + "riptide.clickhouse.manage-schema=true to let riptide create it.");
+        }
+
+        final var missing = REQUIRED_COLUMNS.stream()
+                .filter(column -> !present.contains(column))
+                .sorted()
+                .toList();
+        if (!missing.isEmpty()) {
+            throw new IllegalStateException(
+                    "flows table in database '" + this.config.getDatabase()
+                            + "' is missing expected column(s) " + missing
+                            + " — the schema is stale or mis-provisioned. Riptide performs no automatic "
+                            + "migration: drop and re-provision the flows table (see the ClickHouse "
+                            + "deployment docs).");
+        }
+        return schema;
     }
 
     @Language("ClickHouse")
     private static final String DDL_FLOWS = """
-        CREATE OR REPLACE TABLE flows (
+        CREATE TABLE IF NOT EXISTS flows (
             timestamp DateTime64(3),
     
             flowProtocol Enum8(
@@ -170,7 +246,7 @@ public class ClickhouseRepository implements FlowRepository {
 
     @Language("ClickHouse")
     private static final String DDL_SAMPLES = """
-        CREATE or REPLACE VIEW samples AS
+        CREATE OR REPLACE VIEW samples AS
         WITH
             toInt64({ival:Int64} * 1e9) AS interval_ns,
     

--- a/src/test/java/org/riptide/repository/clickhouse/ClickhouseRepositoryIT.java
+++ b/src/test/java/org/riptide/repository/clickhouse/ClickhouseRepositoryIT.java
@@ -84,6 +84,79 @@ public class ClickhouseRepositoryIT {
     }
 
     @Test
+    void manageModeCreatesAndPreservesDataAcrossRestart() throws Exception {
+        final var database = "manage_restart";
+        queryClient.execute("CREATE DATABASE IF NOT EXISTS " + database).get();
+
+        final var config = configFor(database, true);
+
+        // First boot: manage mode creates the flows table and we persist a row.
+        final var first = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), config);
+        first.start();
+        first.persist(List.of(testFlow(Instant.now().truncatedTo(ChronoUnit.MILLIS), 30001, 443, 4242L)));
+
+        // Simulated restart: a fresh repository runs start() again.
+        final var second = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), config);
+        second.start();
+
+        // CREATE TABLE IF NOT EXISTS no-oped, so the previously inserted row survived the restart.
+        final var count = queryClient.queryAll("SELECT count() AS c FROM " + database + ".flows")
+                .getFirst().getLong("c");
+        Assertions.assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void validateModeSucceedsWithProvisionedTable() {
+        final var database = "validate_ok";
+        queryClient.execute("CREATE DATABASE IF NOT EXISTS " + database).join();
+
+        // Provision the schema via a manage-mode start, then a validate-mode start must succeed.
+        new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), configFor(database, true)).start();
+
+        final var validating = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), configFor(database, false));
+        Assertions.assertThatCode(validating::start).doesNotThrowAnyException();
+    }
+
+    @Test
+    void validateModeFailsFastWhenTableAbsent() {
+        final var database = "validate_missing";
+        queryClient.execute("CREATE DATABASE IF NOT EXISTS " + database).join();
+
+        final var validating = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), configFor(database, false));
+        Assertions.assertThatThrownBy(validating::start)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("flows table not found")
+                .hasMessageContaining("provision");
+    }
+
+    @Test
+    void columnCheckFailsFastWhenIdentityColumnMissing() throws Exception {
+        final var database = "stale_schema";
+        queryClient.execute("CREATE DATABASE IF NOT EXISTS " + database).get();
+
+        // A pre-existing flows table missing the tenant identity column (stale-upgrade case).
+        queryClient.execute("CREATE TABLE " + database + ".flows ("
+                + "timestamp DateTime64(3), organisation String, zone String, system String) "
+                + "ENGINE = MergeTree() ORDER BY timestamp").get();
+
+        // Manage mode: CREATE TABLE IF NOT EXISTS no-ops over the stale table, then the check trips.
+        final var repository = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), configFor(database, true));
+        Assertions.assertThatThrownBy(repository::start)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("tenant");
+    }
+
+    private static ClickhouseConfig configFor(final String database, final boolean manageSchema) {
+        final var config = new ClickhouseConfig();
+        config.setEndpoint("http://" + CLICKHOUSE.getHost() + ":" + CLICKHOUSE.getMappedPort(8123));
+        config.setUsername("riptide");
+        config.setPassword("riptide");
+        config.setDatabase(database);
+        config.setManageSchema(manageSchema);
+        return config;
+    }
+
+    @Test
     void sortingKeyLeadsWithTenant() {
         final var sortingKey = queryClient.queryAll(
                         "SELECT sorting_key FROM system.tables WHERE name = 'flows'")


### PR DESCRIPTION
Phase 2 of the multi-tenant epic (#229) — riptide stops unconditionally owning its ClickHouse table so provisioned deployments can have an admin own the schema + RBAC, while single-tenant keeps working out of the box. Closes #231.

## `riptide.clickhouse.manage-schema` (default `true`)
- **`true`** (single-tenant) — ensures the schema idempotently: `flows` via `CREATE TABLE IF NOT EXISTS` (existing table not replaced, so **flow data now survives a restart** — fixes the `CREATE OR REPLACE` data-loss caveat), `samples` view via `CREATE OR REPLACE` (no data → always refreshed, never stale).
- **`false`** (provisioned / multi-tenant) — creates nothing; validates the `flows` table exists with every column riptide inserts and **fails startup with a clear, provisioning-pointing error** otherwise. The mode phase-3 per-tenant INSERT-only writers run in.

The startup check reads the table's **own** schema (`getTableSchema`, not the `system` database — so a narrowly-granted writer without server-catalog access still passes) and checks the **full** inserted-column set (reflected from `ClickhouseFlow`), so a mis-provisioned/stale schema fails fast instead of dying opaquely at first insert.

## Not in scope (later phases)
Per-tenant credentials + CHECK barrier (phase 3, #232); row policies, query-side, provisioning runbook (phase 4, #233); replicated access storage (server-config/docs, not riptide code).

## Review & verification
Implemented with **Opus 4.8**, structured **Fable 5** review (3 findings, all fixed): (1) samples view was `IF NOT EXISTS` → could silently serve a stale view after an upgrade; now `OR REPLACE`. (2) schema check used `system.columns` → a locked-down validate-mode writer may lack access; now reads the table's own schema. (3) check covered only the 4 identity columns → a table missing another column would still die at insert; now checks the full set. `make jar` → **634 tests** + all gates; **ClickHouse IT 6/6** (manage-restart-survives-data, validate-ok, validate-missing-fails, stale-column-fails) and **nl6 e2e 6/6** green; docs build green.

Refs #229 · Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)