### PR TITLE
feat: SecretRef-backed ClickHouse credentials + tenant write barrier (#232)

### DIFF
--- a/docs/docs/configuration/clickhouse.md
+++ b/docs/docs/configuration/clickhouse.md
@@ -10,9 +10,29 @@ Enriched flows are persisted to ClickHouse:
 ```properties
 riptide.clickhouse.endpoint=http://localhost:8123
 riptide.clickhouse.username=default
-riptide.clickhouse.password=
+#riptide.clickhouse.password=vault://secret/riptide/clickhouse#password
 riptide.clickhouse.database=riptide
 riptide.clickhouse.manage-schema=true
+```
+
+## Credentials
+
+`riptide.clickhouse.username` and `riptide.clickhouse.password` are **secret references**,
+resolved through the same SPI as SNMP credentials:
+
+- a bare literal is used verbatim (plain fallback — existing literal configs keep working);
+- a `scheme://…` reference is resolved from a secret store at startup: `env://VAR`,
+  `file:///path` (optionally `#key` into a properties file), `vault://…`, `sops://…`.
+
+Resolution happens once, when the ClickHouse client is built. An **unresolvable reference fails
+startup** — a database credential that cannot resolve is fatal (unlike an SNMP one, which
+degrades). Leave `password` unset for the default user's empty password; a blank value is not a
+valid reference. Per-tenant writer credentials are sourced this way so no plaintext appears in
+configuration:
+
+```properties
+riptide.clickhouse.username=writer_acme
+riptide.clickhouse.password=vault://secret/riptide/clickhouse/acme#password
 ```
 
 ## Schema ownership
@@ -74,5 +94,86 @@ time-only (`toYYYYMMDD(timestamp)`).
 `zone` replaces the former `riptide.location` key. `riptide.location` is deprecated but
 still accepted for one release (mapped to `zone` with a warning); prefer
 `riptide.identity.zone`.
+
+:::
+
+## Write isolation (multi-tenant)
+
+In provisioned mode (`manage-schema=false`) an admin owns the schema and RBAC, and each riptide
+process connects as a **narrowly-scoped writer** that can only write its own tenant's rows. The
+barrier is enforced entirely by ClickHouse — **riptide never emits a `CHECK` constraint** (that
+would break single-tenant manage mode, which has no `SQL_tenant` setting); it only stamps its
+configured `tenant`/`organisation` (see [Identity columns](#identity-columns)) and inserts.
+
+The mechanism is a per-row `CHECK` constraint that ties each row's `tenant`/`organisation` to a
+`CONST` custom setting pinned on the writer credential. A collector whose config is tampered to
+claim another tenant still carries its own credential, so the server rejects the mismatched row.
+
+### Server requirement
+
+Custom settings with the `SQL_` prefix must be enabled. This is **server config, not an env
+var** — add a `config.d` snippet:
+
+```xml
+<!-- /etc/clickhouse-server/config.d/custom-settings.xml -->
+<clickhouse>
+    <custom_settings_prefixes>SQL_</custom_settings_prefixes>
+</clickhouse>
+```
+
+### Provisioning SQL
+
+Run once per `(tenant, org)` as an admin. The `flows` table is created by a riptide manage-mode
+start (or equivalent DDL); the constraints are then added by `ALTER` (they are only evaluated on
+`INSERT`, so no `SQL_tenant` needs to be defined at DDL time):
+
+```sql
+-- The barrier: each row's tenant/org must equal the writer credential's pinned settings.
+ALTER TABLE riptide.flows
+  ADD CONSTRAINT tenant_pinned CHECK tenant = getSetting('SQL_tenant');
+ALTER TABLE riptide.flows
+  ADD CONSTRAINT org_pinned    CHECK organisation = getSetting('SQL_org');
+
+-- Writer credential for tenant acme / org acme-eu. The SQL_tenant/SQL_org settings are CONST,
+-- so the client cannot override them.
+CREATE USER writer_acme IDENTIFIED WITH sha256_password BY '…'
+  SETTINGS SQL_tenant = 'acme' CONST, SQL_org = 'acme-eu' CONST;
+GRANT INSERT ON riptide.flows TO writer_acme;
+
+-- Optional: bound the writer's ingest rate.
+CREATE QUOTA acme_ingest FOR INTERVAL 1 hour MAX written_rows = 500000000 TO writer_acme;
+
+-- Read isolation: a readonly reader scoped to its own tenant by a row policy.
+CREATE USER reader_acme IDENTIFIED WITH sha256_password BY '…';
+GRANT SELECT ON riptide.flows TO reader_acme;
+CREATE ROW POLICY acme_read ON riptide.flows
+  FOR SELECT USING tenant = 'acme' TO reader_acme;
+```
+
+riptide is then configured with the matching identity and the scoped credential in phase-2
+validate mode:
+
+```properties
+riptide.clickhouse.manage-schema=false
+riptide.clickhouse.username=writer_acme
+riptide.clickhouse.password=vault://secret/riptide/clickhouse/acme#password
+riptide.identity.tenant=acme
+riptide.identity.organisation=acme-eu
+```
+
+### What the barrier guarantees
+
+- **Honest write persists** — riptide's stamped `tenant`/`organisation` match the credential's
+  `CONST` settings, so rows are stored.
+- **Cross-tenant write is rejected** — a tampered config stamping another tenant fails the
+  constraint: `Code: 469 … (VIOLATED_CONSTRAINT)`.
+- **The pin cannot be lifted** — any attempt to override the `CONST` setting (a `SET` or a
+  query-level `SETTINGS SQL_tenant=…`) fails: `Code: 452 … (SETTING_CONSTRAINT_VIOLATION)`.
+- **Reads stay isolated** — the row policy limits each reader to its own tenant's rows.
+
+:::note
+
+This page covers the **write** provisioning only. Query-side users, dashboards, and the full
+operational runbook are a later phase.
 
 :::

--- a/src/main/java/org/riptide/config/ClickhouseConfig.java
+++ b/src/main/java/org/riptide/config/ClickhouseConfig.java
@@ -6,6 +6,7 @@
 package org.riptide.config;
 
 import lombok.Data;
+import org.riptide.secrets.SecretRef;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @Data
@@ -13,8 +14,16 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public final class ClickhouseConfig {
         private String endpoint = "http://localhost:8123";
 
-        private String username;
-        private String password;
+        /**
+         * ClickHouse credentials as {@link SecretRef}s: a bare literal binds through the plain
+         * fallback (existing configs keep working), while a {@code scheme://…} reference is
+         * resolved from a secret store at repository construction. Left unset — or explicitly
+         * blank (e.g. {@code riptide.clickhouse.password=}) — binds null for the default user /
+         * empty password. Per-tenant writer credentials are sourced this way, with no plaintext in
+         * configuration.
+         */
+        private SecretRef username;
+        private SecretRef password;
 
         private String database = "riptide";
 

--- a/src/main/java/org/riptide/configuration/ClickhouseConfiguration.java
+++ b/src/main/java/org/riptide/configuration/ClickhouseConfiguration.java
@@ -7,13 +7,16 @@ package org.riptide.configuration;
 
 import org.riptide.config.ClickhouseConfig;
 import org.riptide.repository.clickhouse.ClickhouseRepository;
+import org.riptide.secrets.SecretResolvers;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class ClickhouseConfiguration {
     @Bean
-    public ClickhouseRepository clickhouseRepository(final ClickhouseRepository.FlowMapper flowMapper, final ClickhouseConfig config) {
-        return new ClickhouseRepository(flowMapper, config);
+    public ClickhouseRepository clickhouseRepository(final ClickhouseRepository.FlowMapper flowMapper,
+                                                     final ClickhouseConfig config,
+                                                     final SecretResolvers secretResolvers) {
+        return new ClickhouseRepository(flowMapper, config, secretResolvers);
     }
 }

--- a/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
+++ b/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
@@ -20,6 +20,7 @@ import org.riptide.pipeline.FlowException;
 import com.clickhouse.client.api.metadata.TableSchema;
 import com.clickhouse.data.ClickHouseColumn;
 import org.riptide.repository.FlowRepository;
+import org.riptide.secrets.SecretResolvers;
 
 import java.io.IOException;
 import java.net.Inet4Address;
@@ -58,14 +59,27 @@ public class ClickhouseRepository implements FlowRepository {
 
     @SneakyThrows
     public ClickhouseRepository(final FlowMapper flowMapper,
-                                final ClickhouseConfig config) {
+                                final ClickhouseConfig config,
+                                final SecretResolvers secretResolvers) {
         this.flowMapper = Objects.requireNonNull(flowMapper);
         this.config = Objects.requireNonNull(config);
+        Objects.requireNonNull(secretResolvers, "secretResolvers");
+
+        // Resolve the credential SecretRefs once, before the client is built. resolve() is
+        // null-safe; an unset ref falls back to the ClickHouse default user / empty password —
+        // preserving the prior behaviour where an absent/blank config bound the default user (the
+        // client distinguishes an empty password from a null one). An unresolvable scheme://
+        // reference throws here and fails startup — a ClickHouse credential that cannot resolve is
+        // fatal.
+        final String resolvedUsername = secretResolvers.resolve(config.getUsername());
+        final String resolvedPassword = secretResolvers.resolve(config.getPassword());
+        final String username = resolvedUsername != null ? resolvedUsername : "default";
+        final String password = resolvedPassword != null ? resolvedPassword : "";
 
         this.client = new Client.Builder()
                 .addEndpoint(config.getEndpoint())
-                .setUsername(config.getUsername())
-                .setPassword(config.getPassword())
+                .setUsername(username)
+                .setPassword(password)
                 .setDefaultDatabase(config.getDatabase())
                 .compressClientRequest(true)
                 .compressServerResponse(true)

--- a/src/main/java/org/riptide/secrets/SecretRefConverter.java
+++ b/src/main/java/org/riptide/secrets/SecretRefConverter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.secrets;
+
+import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+
+/**
+ * Binds configuration Strings to {@link SecretRef}. A blank value maps to {@code null} (an
+ * unset credential) rather than failing — {@link SecretRef}'s constructor rejects blank, but an
+ * explicitly-empty property (e.g. {@code riptide.clickhouse.password=}) must mean "no secret",
+ * the same as leaving it unset. A non-blank value binds through {@link SecretRef}'s parser
+ * (plain literal or {@code scheme://value#key}).
+ */
+@Component
+@ConfigurationPropertiesBinding
+public class SecretRefConverter implements Converter<String, SecretRef> {
+
+    @Override
+    @Nullable
+    public SecretRef convert(final String source) {
+        return source == null || source.isBlank() ? null : new SecretRef(source);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,9 +16,12 @@ spring.config.additional-location=optional:file:/etc/riptide/config.yaml
 #riptide.classification.rules=file:/etc/riptide/classification-rules.csv
 
 # CLICKHOUSE
+# username/password are SecretRefs: a bare literal binds via the plain fallback, a scheme://
+# reference (env://, file://, vault://, sops://) is resolved from a secret store at startup.
+# Leave password unset for the default user's empty password (a blank value is not a valid ref).
 riptide.clickhouse.endpoint=http://localhost:8123
 riptide.clickhouse.username=default
-riptide.clickhouse.password=
+#riptide.clickhouse.password=vault://secret/riptide/clickhouse#password
 riptide.clickhouse.database=riptide
 
 # SNMP CACHE

--- a/src/test/java/org/riptide/repository/clickhouse/ClickhouseCredentialsTest.java
+++ b/src/test/java/org/riptide/repository/clickhouse/ClickhouseCredentialsTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.repository.clickhouse;
+
+import org.junit.jupiter.api.Test;
+import org.riptide.config.ClickhouseConfig;
+import org.riptide.secrets.PlainSecretResolver;
+import org.riptide.secrets.SecretRef;
+import org.riptide.secrets.SecretResolver;
+import org.riptide.secrets.SecretResolvers;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit-level proof that the ClickHouse credential {@link SecretRef}s resolve the way the
+ * repository relies on: a bare literal maps to itself (plain fallback, existing configs keep
+ * working), a {@code scheme://} reference resolves through {@link SecretResolvers}, and an
+ * unresolvable reference fails repository construction (a database credential that cannot resolve
+ * is fatal). Building the client here does not open a connection, so no server is needed.
+ */
+class ClickhouseCredentialsTest {
+
+    @Test
+    void plainLiteralResolvesToItself() {
+        final var config = baseConfig();
+        config.setUsername(SecretRef.of("writer_acme"));
+        config.setPassword(SecretRef.of("s3cr3t"));
+
+        final var resolvers = SecretResolvers.defaults();
+        assertThat(resolvers.resolve(config.getUsername())).isEqualTo("writer_acme");
+        assertThat(resolvers.resolve(config.getPassword())).isEqualTo("s3cr3t");
+
+        assertThatCode(() -> new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), config, resolvers))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void envRefResolvesViaResolvers() {
+        final var config = baseConfig();
+        config.setPassword(SecretRef.of("env://RIPTIDE_CH_PASSWORD"));
+
+        final var resolvers = new SecretResolvers(List.of(
+                new PlainSecretResolver(),
+                new StubEnvResolver(Map.of("RIPTIDE_CH_PASSWORD", "fr0m-env"))));
+
+        assertThat(resolvers.resolve(config.getPassword())).isEqualTo("fr0m-env");
+        assertThatCode(() -> new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), config, resolvers))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void unresolvableRefFailsConstruction() {
+        final var config = baseConfig();
+        config.setPassword(SecretRef.of("env://MISSING_CH_PASSWORD"));
+
+        final var resolvers = new SecretResolvers(List.of(
+                new PlainSecretResolver(),
+                new StubEnvResolver(Map.of())));
+
+        assertThatThrownBy(() -> new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), config, resolvers))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("MISSING_CH_PASSWORD");
+    }
+
+    private static ClickhouseConfig baseConfig() {
+        final var config = new ClickhouseConfig();
+        config.setEndpoint("http://localhost:8123");
+        config.setUsername(SecretRef.of("default"));
+        return config;
+    }
+
+    /** A test-only {@code env://} resolver backed by an in-memory map. */
+    private record StubEnvResolver(Map<String, String> values) implements SecretResolver {
+        @Override
+        public String scheme() {
+            return "env";
+        }
+
+        @Override
+        public String resolve(final SecretRef ref) {
+            final String value = this.values.get(ref.getValue());
+            if (value == null) {
+                throw new IllegalArgumentException("environment variable '" + ref.getValue() + "' is not set");
+            }
+            return value;
+        }
+    }
+}

--- a/src/test/java/org/riptide/repository/clickhouse/ClickhouseRepositoryIT.java
+++ b/src/test/java/org/riptide/repository/clickhouse/ClickhouseRepositoryIT.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 import org.riptide.config.ClickhouseConfig;
 import org.riptide.flows.parser.data.Flow;
 import org.riptide.pipeline.EnrichedFlow;
+import org.riptide.secrets.SecretRef;
+import org.riptide.secrets.SecretResolvers;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
@@ -37,6 +39,8 @@ public class ClickhouseRepositoryIT {
             .withExposedPorts(8123)
             .waitingFor(Wait.forHttp("/ping").forPort(8123).forStatusCode(200));
 
+    private static final SecretResolvers RESOLVERS = SecretResolvers.defaults();
+
     private static ClickhouseRepository repository;
     private static Client queryClient;
 
@@ -44,16 +48,16 @@ public class ClickhouseRepositoryIT {
     static void setUp() {
         final var config = new ClickhouseConfig();
         config.setEndpoint("http://" + CLICKHOUSE.getHost() + ":" + CLICKHOUSE.getMappedPort(8123));
-        config.setUsername("riptide");
-        config.setPassword("riptide");
+        config.setUsername(SecretRef.of("riptide"));
+        config.setPassword(SecretRef.of("riptide"));
 
-        repository = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), config);
+        repository = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), config, RESOLVERS);
         repository.start();
 
         queryClient = new Client.Builder()
                 .addEndpoint(config.getEndpoint())
-                .setUsername(config.getUsername())
-                .setPassword(config.getPassword())
+                .setUsername("riptide")
+                .setPassword("riptide")
                 .setDefaultDatabase(config.getDatabase())
                 .build();
     }
@@ -91,12 +95,12 @@ public class ClickhouseRepositoryIT {
         final var config = configFor(database, true);
 
         // First boot: manage mode creates the flows table and we persist a row.
-        final var first = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), config);
+        final var first = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), config, RESOLVERS);
         first.start();
         first.persist(List.of(testFlow(Instant.now().truncatedTo(ChronoUnit.MILLIS), 30001, 443, 4242L)));
 
         // Simulated restart: a fresh repository runs start() again.
-        final var second = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), config);
+        final var second = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), config, RESOLVERS);
         second.start();
 
         // CREATE TABLE IF NOT EXISTS no-oped, so the previously inserted row survived the restart.
@@ -111,9 +115,9 @@ public class ClickhouseRepositoryIT {
         queryClient.execute("CREATE DATABASE IF NOT EXISTS " + database).join();
 
         // Provision the schema via a manage-mode start, then a validate-mode start must succeed.
-        new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), configFor(database, true)).start();
+        new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), configFor(database, true), RESOLVERS).start();
 
-        final var validating = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), configFor(database, false));
+        final var validating = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), configFor(database, false), RESOLVERS);
         Assertions.assertThatCode(validating::start).doesNotThrowAnyException();
     }
 
@@ -122,7 +126,7 @@ public class ClickhouseRepositoryIT {
         final var database = "validate_missing";
         queryClient.execute("CREATE DATABASE IF NOT EXISTS " + database).join();
 
-        final var validating = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), configFor(database, false));
+        final var validating = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), configFor(database, false), RESOLVERS);
         Assertions.assertThatThrownBy(validating::start)
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("flows table not found")
@@ -140,7 +144,7 @@ public class ClickhouseRepositoryIT {
                 + "ENGINE = MergeTree() ORDER BY timestamp").get();
 
         // Manage mode: CREATE TABLE IF NOT EXISTS no-ops over the stale table, then the check trips.
-        final var repository = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), configFor(database, true));
+        final var repository = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), configFor(database, true), RESOLVERS);
         Assertions.assertThatThrownBy(repository::start)
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("tenant");
@@ -149,8 +153,8 @@ public class ClickhouseRepositoryIT {
     private static ClickhouseConfig configFor(final String database, final boolean manageSchema) {
         final var config = new ClickhouseConfig();
         config.setEndpoint("http://" + CLICKHOUSE.getHost() + ":" + CLICKHOUSE.getMappedPort(8123));
-        config.setUsername("riptide");
-        config.setPassword("riptide");
+        config.setUsername(SecretRef.of("riptide"));
+        config.setPassword(SecretRef.of("riptide"));
         config.setDatabase(database);
         config.setManageSchema(manageSchema);
         return config;

--- a/src/test/java/org/riptide/repository/clickhouse/TenantWriteBarrierIT.java
+++ b/src/test/java/org/riptide/repository/clickhouse/TenantWriteBarrierIT.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.repository.clickhouse;
+
+import com.clickhouse.client.api.Client;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.riptide.config.ClickhouseConfig;
+import org.riptide.flows.parser.data.Flow;
+import org.riptide.pipeline.EnrichedFlow;
+import org.riptide.secrets.SecretRef;
+import org.riptide.secrets.SecretResolvers;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.MountableFile;
+
+import java.net.InetAddress;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+/**
+ * The multi-tenant write barrier, proven end to end against a real ClickHouse server.
+ *
+ * <p>An admin provisions the barrier (phase-2 validate mode): a {@code flows} table carrying
+ * {@code CHECK tenant = getSetting('SQL_tenant')} / {@code CHECK organisation = getSetting('SQL_org')},
+ * a per-{@code (tenant, org)} writer whose {@code SQL_tenant}/{@code SQL_org} settings are pinned
+ * {@code CONST}, and a row policy scoping a readonly reader to its own tenant. riptide only stamps
+ * its configured tenant/org and connects as the scoped writer — it never emits a CHECK constraint.
+ *
+ * <p>The attack matrix asserted here:
+ * <ul>
+ *   <li>honest write (riptide identity matches the credential) persists;</li>
+ *   <li>cross-tenant write (a tampered identity) is rejected with error 469 (VIOLATED_CONSTRAINT);</li>
+ *   <li>an attempt to override the pinned CONST setting is rejected with error 452
+ *       (SETTING_CONSTRAINT_VIOLATION);</li>
+ *   <li>a reader sees only its own tenant's rows (row policy).</li>
+ * </ul>
+ *
+ * <p>The server needs {@code custom_settings_prefixes: SQL_}, which is config-only (not an env
+ * var); it is mounted from a {@code config.d} snippet on the classpath.
+ */
+@Testcontainers
+public class TenantWriteBarrierIT {
+
+    private static final String DATABASE = "barrier";
+    private static final SecretResolvers RESOLVERS = SecretResolvers.defaults();
+
+    @Container
+    private static final GenericContainer<?> CLICKHOUSE = new GenericContainer<>("clickhouse/clickhouse-server:25.3")
+            // access management lets the default (admin) user CREATE USER / ROW POLICY.
+            .withEnv("CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT", "1")
+            .withCopyFileToContainer(
+                    MountableFile.forClasspathResource("clickhouse/custom-settings.xml"),
+                    "/etc/clickhouse-server/config.d/custom-settings.xml")
+            .withExposedPorts(8123)
+            .waitingFor(Wait.forHttp("/ping").forPort(8123).forStatusCode(200));
+
+    /** Admin client (default user, access management) for provisioning and query-back. */
+    private static Client admin;
+
+    @BeforeAll
+    static void provision() throws Exception {
+        final String endpoint = "http://" + CLICKHOUSE.getHost() + ":" + CLICKHOUSE.getMappedPort(8123);
+
+        admin = new Client.Builder()
+                .addEndpoint(endpoint)
+                .setUsername("default")
+                .setPassword("")
+                .build();
+
+        admin.execute("CREATE DATABASE IF NOT EXISTS " + DATABASE).get();
+
+        // Create the base flows table with riptide's own manage-mode DDL, as an admin would.
+        new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), adminConfig(true), RESOLVERS).start();
+
+        // The barrier: per-row CHECK constraints tying tenant/org to the writer's CONST settings.
+        // Added by ALTER after creation — the expression is only evaluated on INSERT, so no
+        // SQL_tenant needs to be defined in this admin DDL session.
+        admin.execute("ALTER TABLE " + DATABASE + ".flows "
+                + "ADD CONSTRAINT tenant_pinned CHECK tenant = getSetting('SQL_tenant')").get();
+        admin.execute("ALTER TABLE " + DATABASE + ".flows "
+                + "ADD CONSTRAINT org_pinned CHECK organisation = getSetting('SQL_org')").get();
+
+        // Per-(tenant, org) writers: their SQL_tenant/SQL_org are pinned CONST (unchangeable).
+        admin.execute("CREATE USER writer_acme IDENTIFIED WITH no_password "
+                + "SETTINGS SQL_tenant = 'acme' CONST, SQL_org = 'acme-eu' CONST").get();
+        admin.execute("GRANT INSERT ON " + DATABASE + ".flows TO writer_acme").get();
+
+        admin.execute("CREATE USER writer_other IDENTIFIED WITH no_password "
+                + "SETTINGS SQL_tenant = 'other' CONST, SQL_org = 'other-eu' CONST").get();
+        admin.execute("GRANT INSERT ON " + DATABASE + ".flows TO writer_other").get();
+
+        // Readonly reader for tenant acme, isolated to its own rows by a row policy.
+        admin.execute("CREATE USER reader_acme IDENTIFIED WITH no_password").get();
+        admin.execute("GRANT SELECT ON " + DATABASE + ".flows TO reader_acme").get();
+        admin.execute("CREATE ROW POLICY acme_read ON " + DATABASE + ".flows "
+                + "FOR SELECT USING tenant = 'acme' TO reader_acme").get();
+    }
+
+    @Test
+    void honestWritePersists() throws Exception {
+        final var writer = writerRepository("writer_acme");
+        writer.persist(List.of(
+                flow("acme", "acme-eu", 21001),
+                flow("acme", "acme-eu", 21002)));
+
+        final long count = admin.queryAll(
+                        "SELECT count() AS c FROM " + DATABASE + ".flows WHERE srcPort IN (21001, 21002)")
+                .getFirst().getLong("c");
+        Assertions.assertThat(count).isEqualTo(2);
+    }
+
+    @Test
+    void crossTenantWriteRejectedWith469() {
+        final var writer = writerRepository("writer_acme");
+
+        // The collector's config lies (tenant=evil) but its credential's CONST setting is 'acme':
+        // ClickHouse rejects the row. This is the compromised-collector attack.
+        // Observed: Code: 469. DB::Exception: Constraint `tenant_pinned` for table barrier.flows
+        // is violated at row 1. Expression: (tenant = getSetting('SQL_tenant')). Column values:
+        // tenant = 'evil'. (VIOLATED_CONSTRAINT)
+        Assertions.assertThatThrownBy(() -> writer.persist(List.of(flow("evil", "acme-eu", 21003))))
+                .hasStackTraceContaining("469")
+                .hasStackTraceContaining("VIOLATED_CONSTRAINT");
+
+        final long count = admin.queryAll(
+                        "SELECT count() AS c FROM " + DATABASE + ".flows WHERE tenant = 'evil'")
+                .getFirst().getLong("c");
+        Assertions.assertThat(count).isZero();
+    }
+
+    @Test
+    void constSettingOverrideRejectedWith452() {
+        final var writerClient = new Client.Builder()
+                .addEndpoint("http://" + CLICKHOUSE.getHost() + ":" + CLICKHOUSE.getMappedPort(8123))
+                .setUsername("writer_acme")
+                .setPassword("")
+                .setDefaultDatabase(DATABASE)
+                .build();
+
+        // Attempt to override the pinned CONST setting at query level → SETTING_CONSTRAINT_VIOLATION.
+        // Observed: Code: 452. DB::Exception: Setting SQL_tenant should not be changed.
+        // (SETTING_CONSTRAINT_VIOLATION)
+        Assertions.assertThatThrownBy(
+                        () -> writerClient.queryAll("SELECT getSetting('SQL_tenant') SETTINGS SQL_tenant = 'other'"))
+                .hasStackTraceContaining("452")
+                .hasStackTraceContaining("SETTING_CONSTRAINT_VIOLATION");
+    }
+
+    @Test
+    void readerSeesOnlyItsTenant() throws Exception {
+        // Two pinned writers land one row each; the reader must see only the acme row.
+        writerRepository("writer_acme").persist(List.of(flow("acme", "acme-eu", 26001)));
+        writerRepository("writer_other").persist(List.of(flow("other", "other-eu", 26002)));
+
+        // Admin sees both.
+        final long adminCount = admin.queryAll(
+                        "SELECT count() AS c FROM " + DATABASE + ".flows WHERE srcPort IN (26001, 26002)")
+                .getFirst().getLong("c");
+        Assertions.assertThat(adminCount).isEqualTo(2);
+
+        final var reader = new Client.Builder()
+                .addEndpoint("http://" + CLICKHOUSE.getHost() + ":" + CLICKHOUSE.getMappedPort(8123))
+                .setUsername("reader_acme")
+                .setPassword("")
+                .setDefaultDatabase(DATABASE)
+                .build();
+
+        final var rows = reader.queryAll(
+                "SELECT srcPort, tenant FROM " + DATABASE + ".flows WHERE srcPort IN (26001, 26002)");
+        Assertions.assertThat(rows).hasSize(1);
+        Assertions.assertThat(rows.getFirst().getInteger("srcPort")).isEqualTo(26001);
+        Assertions.assertThat(rows.getFirst().getString("tenant")).isEqualTo("acme");
+    }
+
+    private static ClickhouseRepository writerRepository(final String username) {
+        final var config = new ClickhouseConfig();
+        config.setEndpoint("http://" + CLICKHOUSE.getHost() + ":" + CLICKHOUSE.getMappedPort(8123));
+        config.setUsername(SecretRef.of(username));
+        config.setDatabase(DATABASE);
+        // Provisioned mode: riptide validates the admin-owned schema, never creates it.
+        config.setManageSchema(false);
+        final var repository = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), config, RESOLVERS);
+        // Validate-mode start: describe the provisioned table and register the insert POJO.
+        repository.start();
+        return repository;
+    }
+
+    private static ClickhouseConfig adminConfig(final boolean manageSchema) {
+        final var config = new ClickhouseConfig();
+        config.setEndpoint("http://" + CLICKHOUSE.getHost() + ":" + CLICKHOUSE.getMappedPort(8123));
+        config.setUsername(SecretRef.of("default"));
+        config.setDatabase(DATABASE);
+        config.setManageSchema(manageSchema);
+        return config;
+    }
+
+    private static EnrichedFlow flow(final String tenant, final String organisation, final int srcPort) throws Exception {
+        final var now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+        return EnrichedFlow.builder()
+                .receivedAt(now)
+                .timestamp(now)
+                .firstSwitched(now.minusSeconds(10))
+                .deltaSwitched(now.minusSeconds(10))
+                .lastSwitched(now)
+                .flowProtocol(Flow.FlowProtocol.IPFIX)
+                .tenant(tenant)
+                .organisation(organisation)
+                .zone("default")
+                .system("default")
+                .exporterAddr("203.0.113.7")
+                .srcAddr(InetAddress.getByName("192.0.2.10"))
+                .srcPort(srcPort)
+                .srcAs(64512L)
+                .srcMaskLen(24)
+                .dstAddr(InetAddress.getByName("198.51.100.20"))
+                .dstPort(443)
+                .dstAs(64513L)
+                .dstMaskLen(24)
+                .inputSnmp(1)
+                .outputSnmp(2)
+                .bytes(1234L)
+                .packets(7L)
+                .direction(Flow.Direction.INGRESS)
+                .engineId(0)
+                .engineType(0)
+                .vlan(0)
+                .ipProtocolVersion(4)
+                .protocol(17)
+                .tcpFlags(0)
+                .tos(0)
+                .samplingAlgorithm(Flow.SamplingAlgorithm.Unassigned)
+                .samplingInterval(1.0)
+                .srcLocality(Flow.Locality.PUBLIC)
+                .dstLocality(Flow.Locality.PUBLIC)
+                .flowLocality(Flow.Locality.PUBLIC)
+                .build();
+    }
+}

--- a/src/test/java/org/riptide/secrets/SecretRefConverterTest.java
+++ b/src/test/java/org/riptide/secrets/SecretRefConverterTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.secrets;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The converter binds configuration Strings to {@link SecretRef}. The load-bearing case is that a
+ * blank value maps to {@code null} rather than throwing: an explicitly-empty property such as
+ * {@code riptide.clickhouse.password=} must mean "no secret" (default user / empty password), the
+ * same as leaving it unset — {@link SecretRef}'s constructor rejects blank, so without this
+ * converter that property would fail startup.
+ */
+class SecretRefConverterTest {
+
+    private final SecretRefConverter converter = new SecretRefConverter();
+
+    @Test
+    void blankMapsToNull() {
+        assertThat(this.converter.convert("")).isNull();
+        assertThat(this.converter.convert("   ")).isNull();
+    }
+
+    @Test
+    void plainLiteralBindsThroughSecretRef() {
+        assertThat(this.converter.convert("s3cr3t")).isEqualTo(SecretRef.of("s3cr3t"));
+    }
+
+    @Test
+    void schemeReferenceBindsThroughSecretRef() {
+        final SecretRef ref = this.converter.convert("env://RIPTIDE_CH_PASSWORD");
+        assertThat(ref.getScheme()).isEqualTo("env");
+        assertThat(ref.getValue()).isEqualTo("RIPTIDE_CH_PASSWORD");
+    }
+}

--- a/src/test/resources/clickhouse/custom-settings.xml
+++ b/src/test/resources/clickhouse/custom-settings.xml
@@ -1,0 +1,11 @@
+<!--
+  Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+  SPDX-License-Identifier: GPL-3.0-or-later
+-->
+<clickhouse>
+    <!--
+      Allow custom user settings with the SQL_ prefix so a writer credential can pin its tenant/org
+      as CONST settings and the flows CHECK constraints can read them via getSetting('SQL_tenant').
+    -->
+    <custom_settings_prefixes>SQL_</custom_settings_prefixes>
+</clickhouse>


### PR DESCRIPTION
## Phase 3 of the multi-tenant epic (#229)

Makes the **hard write barrier** real: a riptide process for `(tenant, org)` is *unable* to write another tenant's data, even with a tampered config. The mechanism was empirically verified in the research (ClickHouse `CHECK` constraint tied to the CH user's `CONST` setting rejects a mismatched row with error 469).

The barrier lives in ClickHouse (admin-provisioned, phase-2 validate mode) — riptide's code footprint is small: resolve per-tenant CH credentials from a secret store, and prove the barrier end to end in the test tier.

## What changes

- **SecretRef-backed ClickHouse credentials** — `riptide.clickhouse.username`/`password` become `SecretRef`s, resolved through the existing SPI (`env://`, `file://`, `vault://`, `sops://`, plain fallback). Per-tenant CH writer credentials come from one secure store; no plaintext in config. An unresolvable reference fails startup.
- **`SecretRefConverter`** — binds config Strings to `SecretRef`, mapping **blank → null** so an explicitly-empty `riptide.clickhouse.password=` still means the default user's empty password (as before) rather than failing at bind time. Found by the pre-PR structured review.
- **`TenantWriteBarrierIT`** — the substantive deliverable. A ClickHouse Testcontainer with `custom_settings_prefixes: SQL_`; an admin provisions a per-`(tenant, org)` writer user (`SETTINGS SQL_tenant/SQL_org CONST`), the `flows` table with `CHECK tenant = getSetting('SQL_tenant')` (+ org), a readonly user, and a row policy. Asserts the attack matrix:
  - honest write (right tenant/org for the credential) → rows persist;
  - cross-tenant write (config lies about tenant) → **469** (`VIOLATED_CONSTRAINT`);
  - `CONST` setting override attempt → **452** (`SETTING_CONSTRAINT_VIOLATION`);
  - the readonly user sees only its own tenant's rows (row policy).
- **Docs** — "Write isolation (multi-tenant)" provisioning recipe on the ClickHouse config page.

## Non-goals

riptide does **not** add CHECK constraints to its manage-mode DDL — in single-tenant manage mode there is no `SQL_tenant` setting, so a `getSetting`-based CHECK would break inserts. The barrier is a provisioned-mode (admin-owned) concern. Query-side users, Grafana topology, and the full runbook are phase 4 (#233).

## Verification

- `make jar` → 640 tests, all gates green (checkstyle, Error Prone, SpotBugs, JaCoCo floor).
- `mvn verify -Pe2e` → TenantWriteBarrierIT 4/4, ClickhouseRepositoryIT 6/6, Nl6FlowIngestionIT 6/6, VaultSecretResolverIT 3/3.

Implemented with Opus 4.8, reviewed with `/code-review medium` (Fable 5) — the one surviving finding (empty-password bind regression) is fixed by `SecretRefConverter`.

Closes #232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)