### PR TITLE
feat: query-side tenant isolation + multi-tenancy runbook (#233)

### DIFF
--- a/docs/docs/configuration/clickhouse.md
+++ b/docs/docs/configuration/clickhouse.md
@@ -87,7 +87,8 @@ riptide.identity.system=collector-01
 
 The flows table sorts by `(tenant, organisation, toStartOfHour(timestamp), <flow tuple>)`;
 `zone` and `system` are filter dimensions and stay out of the sort key. Partitioning stays
-time-only (`toYYYYMMDD(timestamp)`).
+time-only (`toYYYYMMDD(timestamp)`). For the full identity model and how `tenant`/`organisation`
+anchor hard isolation, see the [Multi-tenancy runbook](../deploy/multi-tenancy.md#the-identity-model).
 
 :::note
 
@@ -140,8 +141,8 @@ CREATE USER writer_acme IDENTIFIED WITH sha256_password BY '…'
   SETTINGS SQL_tenant = 'acme' CONST, SQL_org = 'acme-eu' CONST;
 GRANT INSERT ON riptide.flows TO writer_acme;
 
--- Optional: bound the writer's ingest rate.
-CREATE QUOTA acme_ingest FOR INTERVAL 1 hour MAX written_rows = 500000000 TO writer_acme;
+-- Optional: bound the writer's ingest volume (written_bytes — written_rows is not a quota metric).
+CREATE QUOTA acme_ingest FOR INTERVAL 1 hour MAX written_bytes = 50000000000 TO writer_acme;
 
 -- Read isolation: a readonly reader scoped to its own tenant by a row policy.
 CREATE USER reader_acme IDENTIFIED WITH sha256_password BY '…';
@@ -173,7 +174,8 @@ riptide.identity.organisation=acme-eu
 
 :::note
 
-This page covers the **write** provisioning only. Query-side users, dashboards, and the full
-operational runbook are a later phase.
+This section covers the **write** provisioning. For the read-side hardening (per-tenant BI
+users + row policies), Grafana topology, the end-to-end onboarding recipe, and the scaling
+ceiling, see the [Multi-tenancy runbook](../deploy/multi-tenancy.md).
 
 :::

--- a/docs/docs/deploy/multi-tenancy.md
+++ b/docs/docs/deploy/multi-tenancy.md
@@ -1,0 +1,150 @@
+---
+sidebar_position: 4
+title: Multi-tenancy
+---
+
+# Multi-tenant provisioning
+
+Run many riptide processes — one per isolated network, several per network — writing into **one
+ClickHouse cluster**, with **hard isolation** between tenants and organisations and **soft
+filtering** by zone and system. A monitoring provider can collect NetFlow/IPFIX/sFlow from many
+customers' isolated networks (overlapping RFC 1918 space included) and keep each customer's data
+provably separate, on both the write and the read side.
+
+This page is the operator runbook. The write barrier's mechanism is explained on the
+[ClickHouse](../configuration/clickhouse.md#write-isolation-multi-tenant) page; here we give the
+end-to-end onboarding recipe, the read-side hardening, topology guidance, and the scaling ceiling.
+
+## The identity model
+
+Every persisted flow carries four identity columns (see
+[Identity columns](../configuration/clickhouse.md#identity-columns)):
+
+| ID | Nature | Isolation | Enforced by |
+|---|---|---|---|
+| `tenant` | ownership | **hard** (read + write) | server-validated: `CHECK tenant = getSetting('SQL_tenant')` vs the CH user's `CONST` setting |
+| `organisation` | ownership subdivision | **hard** | second `CHECK` column — the isolation unit is `(tenant, organisation)`, so credentials are per-`(tenant, org)` |
+| `zone` | network placement | soft (filter) | payload column, unvalidated (the isolated network / "network zone") |
+| `system` | collector provenance | soft (filter) | payload column, unvalidated (per-instance identity) |
+
+The **hard/soft split is a placement decision**: hard IDs are anchored to the authenticated
+ClickHouse credential — identity comes from *authentication, never from a client claim* — so a
+tampered collector config cannot cross-write. Soft IDs are ordinary unvalidated payload used only
+for filtering. All four are riptide-populated columns.
+
+## Prerequisites
+
+- ClickHouse with **replicated access storage** so users, roles, and row policies exist on every
+  node — otherwise a credential provisioned on one node is unknown on another. The default config
+  stores SQL-created users in a node-local `local_directory`, so the snippet must **replace** the
+  whole `user_directories` block (not merge into it) — keep `users_xml` for the bootstrap admin,
+  drop `local_directory`, and add `replicated` so new users land in Keeper:
+
+  ```xml
+  <!-- /etc/clickhouse-server/config.d/access-storage.xml -->
+  <clickhouse>
+      <user_directories replace="replace">
+          <users_xml>
+              <path>users.xml</path>
+          </users_xml>
+          <replicated>
+              <zookeeper_path>/clickhouse/access/</zookeeper_path>
+          </replicated>
+      </user_directories>
+  </clickhouse>
+  ```
+
+  Without `replace="replace"` the snippet appends to the default block, `local_directory` stays,
+  and SQL-created users are written there — node-local, exactly the failure this prevents.
+
+- The `SQL_` custom-settings prefix enabled (write-barrier requirement) — see the
+  [server requirement](../configuration/clickhouse.md#server-requirement).
+- The `flows` table provisioned by an admin, with riptide running in
+  [validate mode](../configuration/clickhouse.md#schema-ownership) (`manage-schema=false`).
+
+## Onboard a tenant
+
+Run once per `(tenant, organisation)` as an admin. This is the whole boundary — writer, read-side,
+and quota — in one block. It reuses the write barrier from the
+[ClickHouse page](../configuration/clickhouse.md#write-isolation-multi-tenant); the new part here is
+the **hardened BI reader**.
+
+```sql
+-- 1. The write barrier (once per table): each row's tenant/org must equal the
+--    writer credential's pinned CONST settings.
+ALTER TABLE riptide.flows ADD CONSTRAINT tenant_pinned CHECK tenant = getSetting('SQL_tenant');
+ALTER TABLE riptide.flows ADD CONSTRAINT org_pinned    CHECK organisation = getSetting('SQL_org');
+
+-- 2. Per-(tenant, org) writer. SQL_tenant/SQL_org are CONST — the client cannot override them.
+CREATE USER writer_acme IDENTIFIED WITH sha256_password BY '…'
+  SETTINGS SQL_tenant = 'acme' CONST, SQL_org = 'acme-eu' CONST;
+GRANT INSERT ON riptide.flows TO writer_acme;
+-- Bound ingest volume (written_bytes, not written_rows — the latter is not a quota metric).
+CREATE QUOTA acme_ingest FOR INTERVAL 1 hour MAX written_bytes = 50000000000 TO writer_acme;
+
+-- 3. Hardened BI reader: read-only, no DDL, scoped to its own tenant by a row policy, with the
+--    catalog access a query builder (Grafana) needs. readonly = 2 blocks writes and DDL while
+--    still tolerating the read-only settings an HTTP client sends per query; readonly = 1 would
+--    reject those and break the connection.
+CREATE USER bi_acme IDENTIFIED WITH sha256_password BY '…'
+  SETTINGS readonly = 2, allow_ddl = 0;
+GRANT SELECT ON riptide.flows      TO bi_acme;
+GRANT SELECT ON system.databases   TO bi_acme;
+GRANT SELECT ON system.tables      TO bi_acme;
+GRANT SELECT ON system.columns     TO bi_acme;
+CREATE ROW POLICY acme_bi ON riptide.flows FOR SELECT USING tenant = 'acme' TO bi_acme;
+CREATE QUOTA acme_read FOR INTERVAL 1 hour MAX execution_time = 3600 TO bi_acme;
+```
+
+Then configure the riptide process for this tenant with the scoped writer credential and matching
+identity (validate mode):
+
+```properties
+riptide.clickhouse.manage-schema=false
+riptide.clickhouse.username=writer_acme
+riptide.clickhouse.password=vault://secret/riptide/clickhouse/acme#password
+riptide.identity.tenant=acme
+riptide.identity.organisation=acme-eu
+riptide.identity.zone=dmz
+```
+
+### What the reader guarantees
+
+The hardened BI credential is a real boundary, not just a filter (proven by
+`TenantQueryIsolationIT`):
+
+- **Reads stay in-tenant** — the row policy limits `bi_acme` to `tenant = 'acme'` rows, even
+  against a shared table holding every tenant.
+- **Cannot write** — no `INSERT` grant and `readonly` mean a write is rejected (`ACCESS_DENIED`).
+- **Cannot change schema** — `allow_ddl = 0` rejects any DDL, so a compromised dashboard credential
+  cannot alter or drop the table.
+- **Query builder still works** — the `system.databases/tables/columns` grants let Grafana's query
+  builder introspect the schema.
+
+## Grafana topology
+
+The isolation boundary in Grafana **OSS** is **one Grafana org (or one Grafana instance) per
+tenant**, each with a datasource that authenticates as that tenant's `bi_*` user. The ClickHouse
+row policy does the enforcing; Grafana just holds the right credential.
+
+What is **not** a boundary on OSS:
+
+- **Per-tenant datasources inside one shared org** — any user in that org can query any datasource,
+  so this leaks across tenants. Datasource-level permissions are a Grafana **Enterprise** feature.
+- **Dashboard-variable tenant filtering** (a `$tenant` template variable) — never a boundary at
+  all: a viewer can edit the variable to any value. Use it for UX within a tenant, never for
+  isolation.
+
+The guarantee comes from the ClickHouse credential + row policy, so it holds regardless of what a
+dashboard sends.
+
+## Scaling ceiling
+
+Per-tenant ClickHouse users and row policies work comfortably into the **low hundreds of tenants**.
+Beyond that, the per-user access objects become the bottleneck and the model pivots to a **shared
+BI user keyed by `quota_key`** with tenant scoping applied at the application/query layer rather
+than one CH user per tenant.
+
+This is a known future migration, **out of scope** for the current release — documented here so it
+is a planned step, not a surprise. Nothing in the per-tenant model above blocks it: the identity
+columns and row-policy predicates carry over unchanged.

--- a/src/test/java/org/riptide/repository/clickhouse/ClickhouseItFlows.java
+++ b/src/test/java/org/riptide/repository/clickhouse/ClickhouseItFlows.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.repository.clickhouse;
+
+import org.riptide.flows.parser.data.Flow;
+import org.riptide.pipeline.EnrichedFlow;
+
+import java.net.InetAddress;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * Shared flow builder for the multi-tenant ClickHouse ITs ({@link TenantWriteBarrierIT},
+ * {@link TenantQueryIsolationIT}). A single fixture so the {@link EnrichedFlow} shape lives in one
+ * place — when a required column is added, both ITs pick it up from here rather than drifting.
+ */
+final class ClickhouseItFlows {
+
+    private ClickhouseItFlows() {
+    }
+
+    /** A fully-populated enriched flow stamped with the given identity and source port. */
+    static EnrichedFlow flow(final String tenant, final String organisation, final int srcPort) throws Exception {
+        final var now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+        return EnrichedFlow.builder()
+                .receivedAt(now)
+                .timestamp(now)
+                .firstSwitched(now.minusSeconds(10))
+                .deltaSwitched(now.minusSeconds(10))
+                .lastSwitched(now)
+                .flowProtocol(Flow.FlowProtocol.IPFIX)
+                .tenant(tenant)
+                .organisation(organisation)
+                .zone("default")
+                .system("default")
+                .exporterAddr("203.0.113.7")
+                .srcAddr(InetAddress.getByName("192.0.2.10"))
+                .srcPort(srcPort)
+                .srcAs(64512L)
+                .srcMaskLen(24)
+                .dstAddr(InetAddress.getByName("198.51.100.20"))
+                .dstPort(443)
+                .dstAs(64513L)
+                .dstMaskLen(24)
+                .inputSnmp(1)
+                .outputSnmp(2)
+                .bytes(1234L)
+                .packets(7L)
+                .direction(Flow.Direction.INGRESS)
+                .engineId(0)
+                .engineType(0)
+                .vlan(0)
+                .ipProtocolVersion(4)
+                .protocol(17)
+                .tcpFlags(0)
+                .tos(0)
+                .samplingAlgorithm(Flow.SamplingAlgorithm.Unassigned)
+                .samplingInterval(1.0)
+                .srcLocality(Flow.Locality.PUBLIC)
+                .dstLocality(Flow.Locality.PUBLIC)
+                .flowLocality(Flow.Locality.PUBLIC)
+                .build();
+    }
+}

--- a/src/test/java/org/riptide/repository/clickhouse/TenantQueryIsolationIT.java
+++ b/src/test/java/org/riptide/repository/clickhouse/TenantQueryIsolationIT.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.repository.clickhouse;
+
+import com.clickhouse.client.api.Client;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.riptide.config.ClickhouseConfig;
+import org.riptide.secrets.SecretRef;
+import org.riptide.secrets.SecretResolvers;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+
+import static org.riptide.repository.clickhouse.ClickhouseItFlows.flow;
+
+/**
+ * The read side of multi-tenant isolation: a per-tenant BI/query credential is a real boundary,
+ * not just a filter. This proves the {@code onboard_tenant} runbook's reader recipe against a real
+ * ClickHouse server, the read-side counterpart to {@link TenantWriteBarrierIT}.
+ *
+ * <p>An admin provisions a {@code bi_acme} user with {@code readonly = 2}, {@code allow_ddl = 0}, a
+ * {@code SELECT} grant on the flows table plus the catalog tables a query builder needs, and a row
+ * policy scoping it to {@code tenant = 'acme'}. The assertions:
+ * <ul>
+ *   <li>it reads only its own tenant's rows (row policy);</li>
+ *   <li>as provisioned (no write grant) it cannot {@code INSERT} — rejected with ACCESS_DENIED,
+ *       no row lands;</li>
+ *   <li>as provisioned (no ALTER grant) it cannot DDL ({@code ALTER … ADD COLUMN}) — rejected with
+ *       ACCESS_DENIED, the schema is unchanged;</li>
+ *   <li>it can read {@code system.columns} for {@code flows} (the Grafana query builder works).</li>
+ * </ul>
+ *
+ * <p>The recipe hardens the reader in two independent layers — the missing write grants AND
+ * {@code readonly}/{@code allow_ddl} — so a stray future grant does not silently open the boundary.
+ * The first three assertions above exercise the grant layer (it fires first). A separate probe
+ * ({@link #readonlyBlocksAGrantedWrite()}) proves {@code readonly} itself blocks a write even when
+ * the grant is present, so both layers are covered.
+ *
+ * <p>The read side needs no custom settings, so — unlike the write-barrier IT — no {@code SQL_}
+ * config is mounted.
+ */
+@Testcontainers
+public class TenantQueryIsolationIT {
+
+    private static final String DATABASE = "queryiso";
+    private static final SecretResolvers RESOLVERS = SecretResolvers.defaults();
+
+    @Container
+    private static final GenericContainer<?> CLICKHOUSE = new GenericContainer<>("clickhouse/clickhouse-server:25.3")
+            // access management lets the default (admin) user CREATE USER / ROW POLICY.
+            .withEnv("CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT", "1")
+            .withExposedPorts(8123)
+            .waitingFor(Wait.forHttp("/ping").forPort(8123).forStatusCode(200));
+
+    /** Admin client (default user, access management) for provisioning and query-back. */
+    private static Client admin;
+
+    @BeforeAll
+    static void provision() throws Exception {
+        admin = new Client.Builder()
+                .addEndpoint(endpoint())
+                .setUsername("default")
+                .setPassword("")
+                .build();
+
+        admin.execute("CREATE DATABASE IF NOT EXISTS " + DATABASE).get();
+
+        // Create the flows table with riptide's own manage-mode DDL, as an admin would, then seed
+        // two tenants' rows. The admin writer has no CONST pinning, so it can land any tenant.
+        final var seeder = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), adminConfig(), RESOLVERS);
+        seeder.start();
+        seeder.persist(List.of(
+                flow("acme", "acme-eu", 27001),
+                flow("other", "other-eu", 27002)));
+
+        // The hardened BI credential: read-only, no DDL, scoped to its own tenant by a row policy,
+        // with catalog access so a query builder (Grafana) can inspect the schema. readonly=2
+        // blocks writes and DDL while still tolerating the read-only settings the HTTP client sends
+        // per query (readonly=1 would reject those and break the connection).
+        admin.execute("CREATE USER bi_acme IDENTIFIED WITH no_password "
+                + "SETTINGS readonly = 2, allow_ddl = 0").get();
+        admin.execute("GRANT SELECT ON " + DATABASE + ".flows TO bi_acme").get();
+        admin.execute("GRANT SELECT ON system.databases TO bi_acme").get();
+        admin.execute("GRANT SELECT ON system.tables TO bi_acme").get();
+        admin.execute("GRANT SELECT ON system.columns TO bi_acme").get();
+        admin.execute("CREATE ROW POLICY acme_bi ON " + DATABASE + ".flows "
+                + "FOR SELECT USING tenant = 'acme' TO bi_acme").get();
+
+        // A probe with an INSERT grant but readonly = 2: proves the readonly layer blocks writes
+        // independently of the grant layer, so it is genuinely load-bearing (a stray future write
+        // grant would not silently open the boundary).
+        admin.execute("CREATE USER probe_readonly IDENTIFIED WITH no_password SETTINGS readonly = 2").get();
+        admin.execute("GRANT INSERT ON " + DATABASE + ".flows TO probe_readonly").get();
+    }
+
+    @Test
+    void biUserReadsOnlyItsTenant() throws Exception {
+        // Admin sees both seeded rows.
+        Assertions.assertThat(count(admin, "SELECT count() AS c FROM " + DATABASE + ".flows "
+                + "WHERE srcPort IN (27001, 27002)")).isEqualTo(2);
+
+        try (var bi = biClient()) {
+            final var rows = bi.queryAll(
+                    "SELECT srcPort, tenant FROM " + DATABASE + ".flows WHERE srcPort IN (27001, 27002)");
+            Assertions.assertThat(rows).hasSize(1);
+            Assertions.assertThat(rows.getFirst().getInteger("srcPort")).isEqualTo(27001);
+            Assertions.assertThat(rows.getFirst().getString("tenant")).isEqualTo("acme");
+        }
+    }
+
+    @Test
+    void biUserCannotWrite() throws Exception {
+        try (var bi = biClient()) {
+            // The BI user has no INSERT grant, so the write is rejected with ACCESS_DENIED (the
+            // grant check fires before readonly). Behavioural backstop: no row lands.
+            Assertions.assertThatThrownBy(
+                            () -> bi.execute("INSERT INTO " + DATABASE + ".flows (tenant) VALUES ('acme')").get())
+                    .hasStackTraceContaining("ACCESS_DENIED");
+        }
+        Assertions.assertThat(count(admin, "SELECT count() AS c FROM " + DATABASE + ".flows WHERE srcPort = 0"))
+                .isZero();
+    }
+
+    @Test
+    void biUserCannotChangeSchema() throws Exception {
+        try (var bi = biClient()) {
+            // No ALTER grant → ACCESS_DENIED (allow_ddl=0 is a second layer). Assert the specific
+            // rejection, not just any exception, so a malformed statement can't pass vacuously.
+            Assertions.assertThatThrownBy(
+                            () -> bi.execute("ALTER TABLE " + DATABASE + ".flows ADD COLUMN hacked String").get())
+                    .hasStackTraceContaining("ACCESS_DENIED");
+        }
+        // The schema is unchanged — the injected column never appeared.
+        Assertions.assertThat(count(admin, "SELECT count() AS c FROM system.columns "
+                + "WHERE database = '" + DATABASE + "' AND table = 'flows' AND name = 'hacked'")).isZero();
+    }
+
+    @Test
+    void readonlyBlocksAGrantedWrite() throws Exception {
+        // probe_readonly *has* the INSERT grant, so only readonly = 2 can stop it: proves the
+        // readonly layer is load-bearing, not redundant with the missing grant.
+        final var probe = new Client.Builder()
+                .addEndpoint(endpoint())
+                .setUsername("probe_readonly")
+                .setPassword("")
+                .setDefaultDatabase(DATABASE)
+                .build();
+        try (probe) {
+            Assertions.assertThatThrownBy(
+                            () -> probe.execute("INSERT INTO " + DATABASE + ".flows (tenant) VALUES ('acme')").get())
+                    .hasStackTraceContaining("READONLY");
+        }
+    }
+
+    @Test
+    void biUserCanReadCatalog() throws Exception {
+        try (var bi = biClient()) {
+            // The Grafana query builder inspects columns via system.columns.
+            final var columns = bi.queryAll("SELECT name FROM system.columns "
+                    + "WHERE database = '" + DATABASE + "' AND table = 'flows'");
+            Assertions.assertThat(columns).isNotEmpty();
+        }
+    }
+
+    private static long count(final Client client, final String sql) throws Exception {
+        return client.queryAll(sql).getFirst().getLong("c");
+    }
+
+    private static Client biClient() {
+        return new Client.Builder()
+                .addEndpoint(endpoint())
+                .setUsername("bi_acme")
+                .setPassword("")
+                .setDefaultDatabase(DATABASE)
+                .build();
+    }
+
+    private static ClickhouseConfig adminConfig() {
+        final var config = new ClickhouseConfig();
+        config.setEndpoint(endpoint());
+        config.setUsername(SecretRef.of("default"));
+        config.setDatabase(DATABASE);
+        config.setManageSchema(true);
+        return config;
+    }
+
+    private static String endpoint() {
+        return "http://" + CLICKHOUSE.getHost() + ":" + CLICKHOUSE.getMappedPort(8123);
+    }
+}

--- a/src/test/java/org/riptide/repository/clickhouse/TenantWriteBarrierIT.java
+++ b/src/test/java/org/riptide/repository/clickhouse/TenantWriteBarrierIT.java
@@ -10,8 +10,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.riptide.config.ClickhouseConfig;
-import org.riptide.flows.parser.data.Flow;
-import org.riptide.pipeline.EnrichedFlow;
 import org.riptide.secrets.SecretRef;
 import org.riptide.secrets.SecretResolvers;
 import org.testcontainers.containers.GenericContainer;
@@ -20,10 +18,9 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.MountableFile;
 
-import java.net.InetAddress;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
+
+import static org.riptide.repository.clickhouse.ClickhouseItFlows.flow;
 
 /**
  * The multi-tenant write barrier, proven end to end against a real ClickHouse server.
@@ -200,47 +197,5 @@ public class TenantWriteBarrierIT {
         config.setDatabase(DATABASE);
         config.setManageSchema(manageSchema);
         return config;
-    }
-
-    private static EnrichedFlow flow(final String tenant, final String organisation, final int srcPort) throws Exception {
-        final var now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
-        return EnrichedFlow.builder()
-                .receivedAt(now)
-                .timestamp(now)
-                .firstSwitched(now.minusSeconds(10))
-                .deltaSwitched(now.minusSeconds(10))
-                .lastSwitched(now)
-                .flowProtocol(Flow.FlowProtocol.IPFIX)
-                .tenant(tenant)
-                .organisation(organisation)
-                .zone("default")
-                .system("default")
-                .exporterAddr("203.0.113.7")
-                .srcAddr(InetAddress.getByName("192.0.2.10"))
-                .srcPort(srcPort)
-                .srcAs(64512L)
-                .srcMaskLen(24)
-                .dstAddr(InetAddress.getByName("198.51.100.20"))
-                .dstPort(443)
-                .dstAs(64513L)
-                .dstMaskLen(24)
-                .inputSnmp(1)
-                .outputSnmp(2)
-                .bytes(1234L)
-                .packets(7L)
-                .direction(Flow.Direction.INGRESS)
-                .engineId(0)
-                .engineType(0)
-                .vlan(0)
-                .ipProtocolVersion(4)
-                .protocol(17)
-                .tcpFlags(0)
-                .tos(0)
-                .samplingAlgorithm(Flow.SamplingAlgorithm.Unassigned)
-                .samplingInterval(1.0)
-                .srcLocality(Flow.Locality.PUBLIC)
-                .dstLocality(Flow.Locality.PUBLIC)
-                .flowLocality(Flow.Locality.PUBLIC)
-                .build();
     }
 }


### PR DESCRIPTION
## Phase 4 of the multi-tenant epic (#229) — the last phase before v0.3.0

Phases 1–3 made the **write** side hard (identity columns, admin-owned schema, the CHECK-constraint write barrier). This phase makes the **read** side hard and gives operators the runbook to stand a multi-tenant deployment up. **No riptide production code changes** — the query credentials are admin-provisioned and consumed by Grafana/BI.

## What changes

- **`TenantQueryIsolationIT`** (the testable slice) — proves the hardened BI reader recipe against a real ClickHouse Testcontainer: a `readonly=2`, `allow_ddl=0` user with a per-tenant row policy and catalog `SELECT` grants. Asserts it reads only its own tenant, cannot `INSERT`/DDL as provisioned (`ACCESS_DENIED`), and can introspect `system.columns`. A separate probe (INSERT grant **present**, `readonly=2`) proves `readonly` itself blocks writes (`READONLY`) — so both hardening layers are independently load-bearing, not redundant.
- **`docs/deploy/multi-tenancy.md`** — operator runbook: the four-ID identity model, the `onboard_tenant` recipe (writer + reader + constraints + row policy + quota in one block), replicated access storage, Grafana OSS topology guidance (org/instance-per-tenant is the boundary; per-tenant datasources in one org and dashboard-variable filtering are **not**), and the per-tenant-users → shared-user+`quota_key` scaling ceiling documented as a known future migration.
- **Cross-links** from the ClickHouse config page; a shared `flow()` test fixture used by both tenant ITs.

## Review-found recipe fixes (verified live on ClickHouse 25.3)

The pre-PR structured review (Fable 5) caught two operator-facing docs bugs, both confirmed empirically:
- `written_rows` is **not** a valid quota metric (`SYNTAX_ERROR`) — corrected to `written_bytes` here **and** in the already-merged write-barrier section.
- The replicated access-storage snippet must use `<user_directories replace="replace">` — the default config keeps a node-local `local_directory` where SQL-created users would otherwise land unreplicated.

Plus test-altitude fixes: the DDL-rejection assertion now checks `ACCESS_DENIED` (was `isInstanceOf(Exception)`, vacuous), comments no longer overclaim which layer blocks writes, and the duplicated flow builder is shared.

## Verification

- `make jar` → 640 tests, all gates green.
- `mvn verify -Pe2e` → TenantQueryIsolationIT 5/5, TenantWriteBarrierIT 4/4, ClickhouseRepositoryIT 6/6, Nl6FlowIngestionIT 6/6, VaultSecretResolverIT 3/3.
- `make docs` → clean build, no broken links.

Closes #233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)