### PR TITLE
feat: tenant onboard/offboard subcommand + role-based provisioning (#239)

### DIFF
--- a/docs/docs/configuration/clickhouse.md
+++ b/docs/docs/configuration/clickhouse.md
@@ -122,45 +122,21 @@ var** — add a `config.d` snippet:
 </clickhouse>
 ```
 
-### Provisioning SQL
+### Provisioning
 
-Run once per `(tenant, org)` as an admin. The `flows` table is created by a riptide manage-mode
-start (or equivalent DDL); the constraints are then added by `ALTER` (they are only evaluated on
-`INSERT`, so no `SQL_tenant` needs to be defined at DDL time):
+The `flows` table is created by a riptide manage-mode start (or equivalent DDL); the barrier
+constraints are added by `ALTER` (evaluated only on `INSERT`, so no `SQL_tenant` need be defined at
+DDL time):
 
 ```sql
--- The barrier: each row's tenant/org must equal the writer credential's pinned settings.
-ALTER TABLE riptide.flows
-  ADD CONSTRAINT tenant_pinned CHECK tenant = getSetting('SQL_tenant');
-ALTER TABLE riptide.flows
-  ADD CONSTRAINT org_pinned    CHECK organisation = getSetting('SQL_org');
-
--- Writer credential for tenant acme / org acme-eu. The SQL_tenant/SQL_org settings are CONST,
--- so the client cannot override them.
-CREATE USER writer_acme IDENTIFIED WITH sha256_password BY '…'
-  SETTINGS SQL_tenant = 'acme' CONST, SQL_org = 'acme-eu' CONST;
-GRANT INSERT ON riptide.flows TO writer_acme;
-
--- Optional: bound the writer's ingest volume (written_bytes — written_rows is not a quota metric).
-CREATE QUOTA acme_ingest FOR INTERVAL 1 hour MAX written_bytes = 50000000000 TO writer_acme;
-
--- Read isolation: a readonly reader scoped to its own tenant by a row policy.
-CREATE USER reader_acme IDENTIFIED WITH sha256_password BY '…';
-GRANT SELECT ON riptide.flows TO reader_acme;
-CREATE ROW POLICY acme_read ON riptide.flows
-  FOR SELECT USING tenant = 'acme' TO reader_acme;
+ALTER TABLE riptide.flows ADD CONSTRAINT tenant_pinned CHECK tenant = getSetting('SQL_tenant');
+ALTER TABLE riptide.flows ADD CONSTRAINT org_pinned    CHECK organisation = getSetting('SQL_org');
 ```
 
-riptide is then configured with the matching identity and the scoped credential in phase-2
-validate mode:
-
-```properties
-riptide.clickhouse.manage-schema=false
-riptide.clickhouse.username=writer_acme
-riptide.clickhouse.password=vault://secret/riptide/clickhouse/acme#password
-riptide.identity.tenant=acme
-riptide.identity.organisation=acme-eu
-```
+The per-tenant writer/reader users, role grants, quota, and row policy are provisioned by the
+[`onboard` subcommand](../deploy/multi-tenancy.md#onboard-a-tenant) — one command per
+`(tenant, org)` that also prints the collector's config stanza. See the
+[Multi-tenancy runbook](../deploy/multi-tenancy.md) for the full recipe.
 
 ### What the barrier guarantees
 

--- a/docs/docs/deploy/multi-tenancy.md
+++ b/docs/docs/deploy/multi-tenancy.md
@@ -64,58 +64,88 @@ for filtering. All four are riptide-populated columns.
 
 ## Onboard a tenant
 
-Run once per `(tenant, organisation)` as an admin. This is the whole boundary — writer, read-side,
-and quota — in one block. It reuses the write barrier from the
-[ClickHouse page](../configuration/clickhouse.md#write-isolation-multi-tenant); the new part here is
-the **hardened BI reader**.
+Use the `onboard` subcommand — it runs the whole recipe idempotently with one substituted
+`(tenant, org)` and prints the config stanza for the tenant's collector. It runs with **admin**
+credentials passed at invocation (never the collector's scoped credential) and, because it needs no
+Spring context, the running collector never contains any provisioning code.
 
-```sql
--- 1. The write barrier (once per table): each row's tenant/org must equal the
---    writer credential's pinned CONST settings.
-ALTER TABLE riptide.flows ADD CONSTRAINT tenant_pinned CHECK tenant = getSetting('SQL_tenant');
-ALTER TABLE riptide.flows ADD CONSTRAINT org_pinned    CHECK organisation = getSetting('SQL_org');
-
--- 2. Per-(tenant, org) writer. SQL_tenant/SQL_org are CONST — the client cannot override them.
-CREATE USER writer_acme IDENTIFIED WITH sha256_password BY '…'
-  SETTINGS SQL_tenant = 'acme' CONST, SQL_org = 'acme-eu' CONST;
-GRANT INSERT ON riptide.flows TO writer_acme;
--- Bound ingest volume (written_bytes, not written_rows — the latter is not a quota metric).
-CREATE QUOTA acme_ingest FOR INTERVAL 1 hour MAX written_bytes = 50000000000 TO writer_acme;
-
--- 3. Hardened BI reader: read-only, no DDL, scoped to its own tenant by a row policy, with the
---    catalog access a query builder (Grafana) needs. readonly = 2 blocks writes and DDL while
---    still tolerating the read-only settings an HTTP client sends per query; readonly = 1 would
---    reject those and break the connection.
-CREATE USER bi_acme IDENTIFIED WITH sha256_password BY '…'
-  SETTINGS readonly = 2, allow_ddl = 0;
-GRANT SELECT ON riptide.flows      TO bi_acme;
-GRANT SELECT ON system.databases   TO bi_acme;
-GRANT SELECT ON system.tables      TO bi_acme;
-GRANT SELECT ON system.columns     TO bi_acme;
-CREATE ROW POLICY acme_bi ON riptide.flows FOR SELECT USING tenant = 'acme' TO bi_acme;
-CREATE QUOTA acme_read FOR INTERVAL 1 hour MAX execution_time = 3600 TO bi_acme;
+```bash
+java -jar riptide.jar onboard \
+  --admin-url https://clickhouse:8443 --admin-user admin --admin-password env://CH_ADMIN_PW \
+  --tenant acme --org acme-eu \
+  --writer-secret env://ACME_WRITER_PW --reader-secret env://ACME_READER_PW
 ```
 
-Then configure the riptide process for this tenant with the scoped writer credential and matching
-identity (validate mode):
-
-```properties
-riptide.clickhouse.manage-schema=false
+```
+# printed to stdout — paste into the tenant's collector config:
 riptide.clickhouse.username=writer_acme
-riptide.clickhouse.password=vault://secret/riptide/clickhouse/acme#password
+riptide.clickhouse.password=env://ACME_WRITER_PW
 riptide.identity.tenant=acme
 riptide.identity.organisation=acme-eu
-riptide.identity.zone=dmz
 ```
+
+Secret references resolve through the built-in resolvers (`plain`, `env://`, `file://`);
+`--writer-secret`/`--reader-secret` are the passwords for the tenant's writer and BI users. Add
+`riptide.clickhouse.manage-schema=false` and `riptide.identity.zone` to the collector config as
+needed.
+
+`onboard` is safe to re-run: it reconciles the writer/reader **passwords** to the current secret, so
+rotating a secret and re-running updates ClickHouse (the users' `CONST` settings and row policy are
+preserved). To remove a tenant: `offboard --admin-url … --tenant acme --yes` (drops its users and
+row policy; the shared roles/constraints/quota stay).
+
+### What it provisions
+
+The recipe is **role-based**: the grants, the reader hardening, the CHECK barrier, and the quota are
+one-time objects, so per-tenant reduces to the scoped users + role grants + one literal row policy.
+`onboard` ensures the one-time objects on first run and adds the per-tenant part:
+
+```sql
+-- Once per cluster (idempotent): roles carry every per-tenant grant and the reader hardening.
+CREATE ROLE IF NOT EXISTS flow_writer;
+GRANT INSERT ON riptide.flows TO flow_writer;
+CREATE ROLE IF NOT EXISTS flow_reader;
+GRANT SELECT ON riptide.flows TO flow_reader;
+GRANT SELECT ON system.databases TO flow_reader;
+GRANT SELECT ON system.tables    TO flow_reader;
+GRANT SELECT ON system.columns   TO flow_reader;   -- the catalog a query builder needs
+-- readonly = 2 blocks writes and DDL while tolerating the read-only settings an HTTP client sends
+-- per query; readonly = 1 would reject those and break the connection.
+ALTER ROLE flow_reader SETTINGS readonly = 2, allow_ddl = 0;
+-- The write barrier: each row's tenant/org must equal the writer credential's pinned CONST setting.
+ALTER TABLE riptide.flows ADD CONSTRAINT IF NOT EXISTS tenant_pinned CHECK tenant = getSetting('SQL_tenant');
+ALTER TABLE riptide.flows ADD CONSTRAINT IF NOT EXISTS org_pinned    CHECK organisation = getSetting('SQL_org');
+-- One quota keyed by user gives every writer its own bucket (written_bytes — written_rows is not a metric).
+CREATE QUOTA IF NOT EXISTS flow_ingest FOR INTERVAL 1 hour MAX written_bytes = 50000000000
+  KEYED BY user_name TO flow_writer;
+
+-- Per tenant (the residual): two scoped users + role grants + one literal row policy.
+CREATE USER IF NOT EXISTS writer_acme IDENTIFIED WITH sha256_password BY '…'
+  SETTINGS SQL_tenant = 'acme' CONST, SQL_org = 'acme-eu' CONST;
+GRANT flow_writer TO writer_acme;
+CREATE USER IF NOT EXISTS bi_acme IDENTIFIED WITH sha256_password BY '…'
+  SETTINGS SQL_tenant = 'acme' CONST, SQL_org = 'acme-eu' CONST;
+GRANT flow_reader TO bi_acme;
+CREATE ROW POLICY IF NOT EXISTS acme_iso ON riptide.flows FOR SELECT USING tenant = 'acme' TO bi_acme;
+```
+
+:::note
+
+A single shared row policy scoped by `getSetting('SQL_tenant')` does **not** work — ClickHouse
+raises `UNKNOWN_SETTING` whenever a principal without that setting evaluates it. The row policy must
+stay a per-tenant literal.
+
+:::
 
 ### What the reader guarantees
 
-The hardened BI credential is a real boundary, not just a filter (proven by
-`TenantQueryIsolationIT`):
+The hardened BI credential is a real boundary, not just a filter (proven by `TenantQueryIsolationIT`
+and, through the subcommand, `TenantOnboardingIT`):
 
 - **Reads stay in-tenant** — the row policy limits `bi_acme` to `tenant = 'acme'` rows, even
   against a shared table holding every tenant.
-- **Cannot write** — no `INSERT` grant and `readonly` mean a write is rejected (`ACCESS_DENIED`).
+- **Cannot write** — the `flow_reader` role grants no `INSERT` and pins `readonly`, so a write is
+  rejected (`ACCESS_DENIED`).
 - **Cannot change schema** — `allow_ddl = 0` rejects any DDL, so a compromised dashboard credential
   cannot alter or drop the table.
 - **Query builder still works** — the `system.databases/tables/columns` grants let Grafana's query

--- a/src/main/java/org/riptide/RiptideApplication.java
+++ b/src/main/java/org/riptide/RiptideApplication.java
@@ -5,6 +5,7 @@
 
 package org.riptide;
 
+import org.riptide.provisioning.ProvisioningCommand;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
@@ -13,6 +14,11 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 @ConfigurationPropertiesScan
 public class RiptideApplication {
     public static void main(final String... args) {
+        // Admin provisioning subcommands run without a Spring context (no collector beans, no admin
+        // capability in the running daemon). Everything else starts the collector as before.
+        if (args.length > 0 && ProvisioningCommand.matches(args[0])) {
+            System.exit(ProvisioningCommand.run(args));
+        }
         SpringApplication.run(RiptideApplication.class, args);
     }
 }

--- a/src/main/java/org/riptide/provisioning/ProvisioningCommand.java
+++ b/src/main/java/org/riptide/provisioning/ProvisioningCommand.java
@@ -86,8 +86,7 @@ public final class ProvisioningCommand {
 
     private static int onboard(final Args parsed, final String database, final TenantProvisioner provisioner,
                                final PrintStream out, final PrintStream err) {
-        final long quotaBytes = parsed.get("quota-bytes") == null
-                ? DEFAULT_QUOTA_BYTES : Long.parseLong(parsed.get("quota-bytes"));
+        final long quotaBytes = parseQuotaBytes(parsed.get("quota-bytes"));
         final var spec = new TenantSpec(
                 parsed.require("tenant"),
                 parsed.require("org"),
@@ -114,6 +113,17 @@ public final class ProvisioningCommand {
         provisioner.offboard(ref);
         err.println("Offboarded tenant '" + ref.tenant() + "' (dropped its users and row policy).");
         return 0;
+    }
+
+    static long parseQuotaBytes(final String value) {
+        if (value == null) {
+            return DEFAULT_QUOTA_BYTES;
+        }
+        try {
+            return Long.parseLong(value);
+        } catch (final NumberFormatException e) {
+            throw new IllegalArgumentException("--quota-bytes must be a number, was: " + value);
+        }
     }
 
     private static void usage(final PrintStream err) {

--- a/src/main/java/org/riptide/provisioning/ProvisioningCommand.java
+++ b/src/main/java/org/riptide/provisioning/ProvisioningCommand.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.provisioning;
+
+import com.clickhouse.client.api.Client;
+import org.riptide.secrets.SecretRef;
+import org.riptide.secrets.SecretResolvers;
+
+import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The {@code onboard}/{@code offboard} subcommands. Runs with no Spring context: it builds an admin
+ * ClickHouse {@link Client} from explicit arguments and resolves secrets through
+ * {@link SecretResolvers#defaults()} ({@code plain}/{@code env}/{@code file}), so the running
+ * collector never instantiates any provisioning code. Admin credentials come from the invocation,
+ * never from {@code riptide.clickhouse.*}.
+ */
+public final class ProvisioningCommand {
+
+    private static final long DEFAULT_QUOTA_BYTES = 50_000_000_000L;
+
+    private ProvisioningCommand() {
+    }
+
+    /** True if {@code arg} names a provisioning subcommand. */
+    public static boolean matches(final String arg) {
+        return "onboard".equals(arg) || "offboard".equals(arg);
+    }
+
+    /** Run the subcommand named by {@code args[0]}. Returns a process exit code. */
+    public static int run(final String[] args) {
+        return run(args, System.out, System.err);
+    }
+
+    /** As {@link #run(String[])} but with explicit streams — the config stanza goes to {@code out}. */
+    public static int run(final String[] args, final PrintStream out, final PrintStream err) {
+        final Args parsed;
+        try {
+            parsed = Args.parse(args);
+        } catch (final IllegalArgumentException e) {
+            err.println("error: " + e.getMessage());
+            usage(err);
+            return 2;
+        }
+
+        final var resolvers = SecretResolvers.defaults();
+        try {
+            // Resolve the admin password inside the try so a missing env var / unknown scheme takes
+            // the clean error path, not an uncaught throw before System.exit.
+            final String adminPassword = parsed.get("admin-password") == null
+                    ? "" : resolvers.resolve(SecretRef.of(parsed.get("admin-password")));
+
+            try (var admin = new Client.Builder()
+                    .addEndpoint(parsed.require("admin-url"))
+                    .setUsername(parsed.getOrDefault("admin-user", "default"))
+                    .setPassword(adminPassword)
+                    .build()) {
+
+                final var provisioner = new TenantProvisioner(admin, resolvers);
+                final String database = parsed.getOrDefault("database", "riptide");
+
+                return switch (parsed.subcommand) {
+                    case "onboard" -> onboard(parsed, database, provisioner, out, err);
+                    case "offboard" -> offboard(parsed, database, provisioner, err);
+                    default -> {
+                        usage(err);
+                        yield 2;
+                    }
+                };
+            }
+        } catch (final IllegalArgumentException e) {
+            err.println("error: " + e.getMessage());
+            return 2;
+        } catch (final TenantProvisioner.ProvisioningException e) {
+            err.println("error: " + e.getMessage());
+            return 1;
+        }
+    }
+
+    private static int onboard(final Args parsed, final String database, final TenantProvisioner provisioner,
+                               final PrintStream out, final PrintStream err) {
+        final long quotaBytes = parsed.get("quota-bytes") == null
+                ? DEFAULT_QUOTA_BYTES : Long.parseLong(parsed.get("quota-bytes"));
+        final var spec = new TenantSpec(
+                parsed.require("tenant"),
+                parsed.require("org"),
+                database,
+                parsed.require("writer-secret"),
+                parsed.require("reader-secret"),
+                quotaBytes);
+
+        final String stanza = provisioner.onboard(spec);
+        err.println("Onboarded tenant '" + spec.tenant() + "' (org '" + spec.organisation()
+                + "'). Add this to the tenant's riptide config:");
+        out.println(stanza);
+        return 0;
+    }
+
+    private static int offboard(final Args parsed, final String database, final TenantProvisioner provisioner,
+                                final PrintStream err) {
+        final var ref = new TenantProvisioner.TenantRef(database, parsed.require("tenant"));
+        if (!parsed.flags.contains("yes")) {
+            err.println("refusing to offboard '" + ref.tenant()
+                    + "' without --yes (this drops the tenant's writer/reader users and row policy)");
+            return 2;
+        }
+        provisioner.offboard(ref);
+        err.println("Offboarded tenant '" + ref.tenant() + "' (dropped its users and row policy).");
+        return 0;
+    }
+
+    private static void usage(final PrintStream err) {
+        err.println("""
+                usage:
+                  riptide onboard  --admin-url URL [--admin-user U] [--admin-password REF] \\
+                                   --tenant T --org O --writer-secret REF --reader-secret REF \\
+                                   [--database DB] [--quota-bytes N]
+                  riptide offboard --admin-url URL [--admin-user U] [--admin-password REF] \\
+                                   --tenant T [--database DB] --yes
+                secret REF: plain literal, env://VAR, or file:///path[#key]""");
+    }
+
+    /** Minimal {@code --key value} / {@code --flag} parser. {@code args[0]} is the subcommand. */
+    private record Args(String subcommand, Map<String, String> options, Set<String> flags) {
+
+        private static final Set<String> KNOWN_FLAGS = Set.of("yes");
+
+        static Args parse(final String[] args) {
+            if (args.length == 0 || !matches(args[0])) {
+                throw new IllegalArgumentException("expected 'onboard' or 'offboard'");
+            }
+            final var options = new HashMap<String, String>();
+            final var flags = new HashSet<String>();
+            int i = 1;
+            while (i < args.length) {
+                final String token = args[i];
+                if (!token.startsWith("--")) {
+                    throw new IllegalArgumentException("unexpected argument: " + token);
+                }
+                final String key = token.substring(2);
+                if (KNOWN_FLAGS.contains(key)) {
+                    flags.add(key);
+                    i += 1;
+                } else {
+                    if (i + 1 >= args.length) {
+                        throw new IllegalArgumentException("missing value for --" + key);
+                    }
+                    options.put(key, args[i + 1]);
+                    i += 2;
+                }
+            }
+            return new Args(args[0], options, flags);
+        }
+
+        String get(final String key) {
+            return this.options.get(key);
+        }
+
+        String getOrDefault(final String key, final String fallback) {
+            return this.options.getOrDefault(key, fallback);
+        }
+
+        String require(final String key) {
+            final String value = this.options.get(key);
+            if (value == null) {
+                throw new IllegalArgumentException("missing required --" + key);
+            }
+            return value;
+        }
+    }
+}

--- a/src/main/java/org/riptide/provisioning/ProvisioningDdl.java
+++ b/src/main/java/org/riptide/provisioning/ProvisioningDdl.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.provisioning;
+
+import java.util.List;
+
+/**
+ * The ClickHouse SQL for role-based tenant provisioning. Pure string builders — no I/O — so the
+ * whole recipe is one auditable place and lifts cleanly into a future {@code riptide-admin} module.
+ *
+ * <p>The model puts every identical-per-tenant part into one-time objects ({@link #ensureShared})
+ * — the {@code flow_writer}/{@code flow_reader} roles carry the grants and the reader hardening,
+ * and a single quota is keyed by user — so {@link #onboardTenant} reduces to the scoped users, two
+ * role grants, and one literal row policy. All statements are idempotent
+ * ({@code IF NOT EXISTS} / {@code ALTER ROLE SETTINGS}), verified on ClickHouse 25.3.
+ *
+ * <p>Tenant/org names are validated ({@link TenantSpec}) to a safe charset; generated identifiers
+ * are backtick-quoted and string literals are escaped, so neither can break out of the statement.
+ */
+public final class ProvisioningDdl {
+
+    private ProvisioningDdl() {
+    }
+
+    /** One-time shared objects: the two roles, the reader hardening, the CHECK barrier, the quota. */
+    public static List<String> ensureShared(final String database, final long quotaBytes) {
+        final String flows = ident(database) + ".flows";
+        return List.of(
+                "CREATE ROLE IF NOT EXISTS flow_writer",
+                "GRANT INSERT ON " + flows + " TO flow_writer",
+                "CREATE ROLE IF NOT EXISTS flow_reader",
+                "GRANT SELECT ON " + flows + " TO flow_reader",
+                "GRANT SELECT ON system.databases TO flow_reader",
+                "GRANT SELECT ON system.tables TO flow_reader",
+                "GRANT SELECT ON system.columns TO flow_reader",
+                // readonly = 2 blocks writes and DDL while tolerating the read-only settings an HTTP
+                // client sends per query (readonly = 1 would reject those and break the connection).
+                "ALTER ROLE flow_reader SETTINGS readonly = 2, allow_ddl = 0",
+                "ALTER TABLE " + flows
+                        + " ADD CONSTRAINT IF NOT EXISTS tenant_pinned CHECK tenant = getSetting('SQL_tenant')",
+                "ALTER TABLE " + flows
+                        + " ADD CONSTRAINT IF NOT EXISTS org_pinned CHECK organisation = getSetting('SQL_org')",
+                "CREATE QUOTA IF NOT EXISTS flow_ingest FOR INTERVAL 1 hour MAX written_bytes = "
+                        + quotaBytes + " KEYED BY user_name TO flow_writer");
+    }
+
+    /**
+     * Per-tenant: the scoped writer/reader users, their role grants, and the literal row policy.
+     * Each user is created if absent and then has its password reconciled with {@code ALTER USER}
+     * — so re-running after a secret rotation updates the credential (a plain
+     * {@code CREATE … IF NOT EXISTS} would silently keep the old password). {@code ALTER USER}
+     * preserves the user's {@code CONST} settings and its row-policy membership.
+     */
+    public static List<String> onboardTenant(final String database, final String tenant, final String organisation,
+                                             final String writerPassword, final String readerPassword) {
+        final String flows = ident(database) + ".flows";
+        final String writer = ident("writer_" + tenant);
+        final String reader = ident("bi_" + tenant);
+        final String policy = ident(tenant + "_iso");
+        final String pinned = " SETTINGS SQL_tenant = " + literal(tenant) + " CONST, SQL_org = "
+                + literal(organisation) + " CONST";
+        return List.of(
+                "CREATE USER IF NOT EXISTS " + writer + " IDENTIFIED WITH sha256_password BY "
+                        + literal(writerPassword) + pinned,
+                "ALTER USER " + writer + " IDENTIFIED WITH sha256_password BY " + literal(writerPassword),
+                "GRANT flow_writer TO " + writer,
+                "CREATE USER IF NOT EXISTS " + reader + " IDENTIFIED WITH sha256_password BY "
+                        + literal(readerPassword) + pinned,
+                "ALTER USER " + reader + " IDENTIFIED WITH sha256_password BY " + literal(readerPassword),
+                "GRANT flow_reader TO " + reader,
+                "CREATE ROW POLICY IF NOT EXISTS " + policy + " ON " + flows
+                        + " FOR SELECT USING tenant = " + literal(tenant) + " TO " + reader);
+    }
+
+    /** Per-tenant teardown: drop the row policy and the two users; shared objects stay. */
+    public static List<String> offboardTenant(final String database, final String tenant) {
+        final String flows = ident(database) + ".flows";
+        return List.of(
+                "DROP ROW POLICY IF EXISTS " + ident(tenant + "_iso") + " ON " + flows,
+                "DROP USER IF EXISTS " + ident("bi_" + tenant),
+                "DROP USER IF EXISTS " + ident("writer_" + tenant));
+    }
+
+    /** Backtick-quote an identifier. The value is pre-validated to exclude backticks. */
+    static String ident(final String name) {
+        return "`" + name + "`";
+    }
+
+    /** Single-quote a string literal, escaping backslash then quote (ClickHouse escaping). */
+    static String literal(final String value) {
+        return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'";
+    }
+}

--- a/src/main/java/org/riptide/provisioning/TenantProvisioner.java
+++ b/src/main/java/org/riptide/provisioning/TenantProvisioner.java
@@ -84,12 +84,13 @@ public final class TenantProvisioner {
 
     /**
      * Never surface a resolved password in an error. Matches the whole escaped string literal after
-     * {@code IDENTIFIED WITH … BY} — {@code (?:\\.|[^'])*} consumes escaped quotes/backslashes and
-     * any other character (including newlines) so a password with a {@code '} or {@code \n} cannot
-     * leak past a naive {@code '.*?'}.
+     * {@code IDENTIFIED WITH … BY}: {@code \\.} consumes an escaped char and {@code [^'\\]} any
+     * other (including newlines). The two branches are disjoint (the "other" branch excludes the
+     * backslash), so there is no ambiguity that could cause catastrophic backtracking, and a
+     * password with a {@code '} or {@code \n} cannot leak past a naive {@code '.*?'}.
      */
     static String redact(final String sql) {
-        return sql.replaceAll("(?is)(IDENTIFIED WITH \\w+ BY )'(?:\\\\.|[^'])*'", "$1'***'");
+        return sql.replaceAll("(?is)(IDENTIFIED WITH \\w+ BY )'(?:\\\\.|[^'\\\\])*'", "$1'***'");
     }
 
     /** A validated reference to an existing tenant, for teardown. */

--- a/src/main/java/org/riptide/provisioning/TenantProvisioner.java
+++ b/src/main/java/org/riptide/provisioning/TenantProvisioner.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.provisioning;
+
+import com.clickhouse.client.api.Client;
+import org.riptide.secrets.SecretRef;
+import org.riptide.secrets.SecretResolvers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Provisions and de-provisions a tenant against ClickHouse using an admin connection. This is the
+ * whole admin-side of multi-tenancy: it ensures the one-time role/constraint/quota objects, then
+ * creates (or drops) the per-tenant scoped users and row policy. It depends only on a ClickHouse
+ * {@link Client} and {@link SecretResolvers}, so it carries no Spring coupling and lifts cleanly
+ * into a future {@code riptide-admin} module.
+ *
+ * <p>The caller owns the admin {@link Client} (built from admin credentials supplied explicitly at
+ * invocation — never the collector's scoped credential) and its lifecycle.
+ */
+public final class TenantProvisioner {
+
+    private final Client admin;
+    private final SecretResolvers secretResolvers;
+
+    public TenantProvisioner(final Client admin, final SecretResolvers secretResolvers) {
+        this.admin = Objects.requireNonNull(admin, "admin");
+        this.secretResolvers = Objects.requireNonNull(secretResolvers, "secretResolvers");
+    }
+
+    /**
+     * Ensure the shared objects and this tenant's users/policy exist (idempotent). Returns the
+     * riptide configuration stanza for the tenant's collector, referencing the same writer secret.
+     */
+    public String onboard(final TenantSpec spec) {
+        final String writerPassword = resolve(spec.writerSecret());
+        final String readerPassword = resolve(spec.readerSecret());
+
+        final var statements = new ArrayList<String>();
+        statements.addAll(ProvisioningDdl.ensureShared(spec.database(), spec.quotaBytes()));
+        statements.addAll(ProvisioningDdl.onboardTenant(
+                spec.database(), spec.tenant(), spec.organisation(), writerPassword, readerPassword));
+        execute(statements);
+
+        return configStanza(spec);
+    }
+
+    /** Drop the tenant's users and row policy; the shared roles/constraints/quota are left intact. */
+    public void offboard(final TenantRef ref) {
+        execute(ProvisioningDdl.offboardTenant(ref.database(), ref.tenant()));
+    }
+
+    private void execute(final List<String> statements) {
+        for (final String sql : statements) {
+            try {
+                this.admin.execute(sql).get();
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new ProvisioningException("Interrupted while provisioning", e);
+            } catch (final ExecutionException e) {
+                throw new ProvisioningException("Provisioning statement failed: " + redact(sql), e.getCause());
+            }
+        }
+    }
+
+    private String resolve(final String ref) {
+        return this.secretResolvers.resolve(SecretRef.of(ref));
+    }
+
+    private static String configStanza(final TenantSpec spec) {
+        // Built by concatenation (not String.format) so the line separators stay literal '\n' — a
+        // config stanza the operator pastes, not platform-dependent output.
+        return "riptide.clickhouse.username=writer_" + spec.tenant() + "\n"
+                + "riptide.clickhouse.password=" + spec.writerSecret() + "\n"
+                + "riptide.identity.tenant=" + spec.tenant() + "\n"
+                + "riptide.identity.organisation=" + spec.organisation();
+    }
+
+    /**
+     * Never surface a resolved password in an error. Matches the whole escaped string literal after
+     * {@code IDENTIFIED WITH … BY} — {@code (?:\\.|[^'])*} consumes escaped quotes/backslashes and
+     * any other character (including newlines) so a password with a {@code '} or {@code \n} cannot
+     * leak past a naive {@code '.*?'}.
+     */
+    static String redact(final String sql) {
+        return sql.replaceAll("(?is)(IDENTIFIED WITH \\w+ BY )'(?:\\\\.|[^'])*'", "$1'***'");
+    }
+
+    /** A validated reference to an existing tenant, for teardown. */
+    public record TenantRef(String database, String tenant) {
+        public TenantRef {
+            TenantSpec.requireSafe("database", database);
+            TenantSpec.requireSafe("tenant", tenant);
+        }
+    }
+
+    /** Thrown when a provisioning statement fails; the message never contains a resolved secret. */
+    public static final class ProvisioningException extends RuntimeException {
+        public ProvisioningException(final String message, final Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/src/main/java/org/riptide/provisioning/TenantSpec.java
+++ b/src/main/java/org/riptide/provisioning/TenantSpec.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.provisioning;
+
+import java.util.regex.Pattern;
+
+/**
+ * A validated request to onboard a {@code (tenant, organisation)}. The tenant and organisation are
+ * constrained to a safe charset so they cannot break out of the generated identifiers or literals
+ * (this tool runs with admin credentials — an unvalidated tenant name would be an injection vector).
+ *
+ * @param tenant         tenant id (hard isolation); becomes part of the {@code writer_}/{@code bi_}
+ *                       user names and the row-policy name
+ * @param organisation   organisation id (hard isolation)
+ * @param database       ClickHouse database holding the {@code flows} table
+ * @param writerSecret   secret reference resolving to the writer user's password
+ * @param readerSecret   secret reference resolving to the reader (BI) user's password
+ * @param quotaBytes     per-writer hourly ingest ceiling for the shared keyed quota
+ */
+public record TenantSpec(String tenant,
+                         String organisation,
+                         String database,
+                         String writerSecret,
+                         String readerSecret,
+                         long quotaBytes) {
+
+    /** Tenant/org/database: letters, digits, underscore, hyphen — no quotes, backticks, or spaces. */
+    private static final Pattern SAFE_NAME = Pattern.compile("[A-Za-z0-9_-]+");
+
+    public TenantSpec {
+        requireSafe("tenant", tenant);
+        requireSafe("organisation", organisation);
+        requireSafe("database", database);
+        if (writerSecret == null || writerSecret.isBlank()) {
+            throw new IllegalArgumentException("writerSecret must not be blank");
+        }
+        if (readerSecret == null || readerSecret.isBlank()) {
+            throw new IllegalArgumentException("readerSecret must not be blank");
+        }
+        if (quotaBytes <= 0) {
+            throw new IllegalArgumentException("quotaBytes must be positive, was " + quotaBytes);
+        }
+    }
+
+    /** The tenant/org/database injection boundary — the single charset check for the package. */
+    static void requireSafe(final String field, final String value) {
+        if (value == null || !SAFE_NAME.matcher(value).matches()) {
+            throw new IllegalArgumentException(
+                    field + " must match [A-Za-z0-9_-]+ (letters, digits, underscore, hyphen), was: " + value);
+        }
+    }
+}

--- a/src/test/java/org/riptide/provisioning/ProvisioningCommandTest.java
+++ b/src/test/java/org/riptide/provisioning/ProvisioningCommandTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.provisioning;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Argument handling for the subcommands. These paths fail during parsing — before any ClickHouse
+ * connection is built — so they need no server; the live provisioning flow is covered by
+ * {@code TenantOnboardingIT}.
+ */
+class ProvisioningCommandTest {
+
+    @Test
+    void matchesOnlyKnownSubcommands() {
+        assertThat(ProvisioningCommand.matches("onboard")).isTrue();
+        assertThat(ProvisioningCommand.matches("offboard")).isTrue();
+        assertThat(ProvisioningCommand.matches("collect")).isFalse();
+    }
+
+    @Test
+    void missingValueForOptionExitsTwoWithUsage() {
+        final var err = new ByteArrayOutputStream();
+        final int code = ProvisioningCommand.run(
+                new String[] {"onboard", "--tenant"}, discard(), new PrintStream(err, true, StandardCharsets.UTF_8));
+        assertThat(code).isEqualTo(2);
+        assertThat(err.toString(StandardCharsets.UTF_8)).contains("missing value for --tenant").contains("usage:");
+    }
+
+    @Test
+    void unexpectedPositionalArgExitsTwo() {
+        final var err = new ByteArrayOutputStream();
+        final int code = ProvisioningCommand.run(
+                new String[] {"onboard", "oops"}, discard(), new PrintStream(err, true, StandardCharsets.UTF_8));
+        assertThat(code).isEqualTo(2);
+        assertThat(err.toString(StandardCharsets.UTF_8)).contains("unexpected argument: oops");
+    }
+
+    private static PrintStream discard() {
+        return new PrintStream(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8);
+    }
+}

--- a/src/test/java/org/riptide/provisioning/ProvisioningCommandTest.java
+++ b/src/test/java/org/riptide/provisioning/ProvisioningCommandTest.java
@@ -45,6 +45,15 @@ class ProvisioningCommandTest {
         assertThat(err.toString(StandardCharsets.UTF_8)).contains("unexpected argument: oops");
     }
 
+    @Test
+    void parseQuotaBytesDefaultsAndRejectsNonNumeric() {
+        assertThat(ProvisioningCommand.parseQuotaBytes(null)).isPositive();
+        assertThat(ProvisioningCommand.parseQuotaBytes("500")).isEqualTo(500L);
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> ProvisioningCommand.parseQuotaBytes("lots"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("--quota-bytes must be a number");
+    }
+
     private static PrintStream discard() {
         return new PrintStream(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8);
     }

--- a/src/test/java/org/riptide/provisioning/ProvisioningDdlTest.java
+++ b/src/test/java/org/riptide/provisioning/ProvisioningDdlTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.provisioning;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The provisioning SQL is generated, so its escaping and shape are unit-checked here — the live
+ * behaviour is proven in {@code TenantOnboardingIT}. The load-bearing property is that a resolved
+ * password lands as a properly-escaped literal and generated identifiers are backtick-quoted.
+ */
+class ProvisioningDdlTest {
+
+    @Test
+    void literalEscapesQuoteAndBackslash() {
+        assertThat(ProvisioningDdl.literal("s3cr3t")).isEqualTo("'s3cr3t'");
+        assertThat(ProvisioningDdl.literal("a'b")).isEqualTo("'a\\'b'");
+        assertThat(ProvisioningDdl.literal("a\\b")).isEqualTo("'a\\\\b'");
+    }
+
+    @Test
+    void identIsBacktickQuoted() {
+        assertThat(ProvisioningDdl.ident("writer_acme")).isEqualTo("`writer_acme`");
+    }
+
+    @Test
+    void ensureSharedHasRolesConstraintsAndKeyedQuota() {
+        final List<String> sql = ProvisioningDdl.ensureShared("riptide", 50_000_000_000L);
+        assertThat(sql).anyMatch(s -> s.contains("CREATE ROLE IF NOT EXISTS flow_writer"));
+        assertThat(sql).anyMatch(s -> s.contains("ALTER ROLE flow_reader SETTINGS readonly = 2, allow_ddl = 0"));
+        assertThat(sql).anyMatch(s -> s.contains("ADD CONSTRAINT IF NOT EXISTS tenant_pinned"));
+        assertThat(sql).anyMatch(s -> s.contains("KEYED BY user_name TO flow_writer"));
+        assertThat(sql).anyMatch(s -> s.contains("MAX written_bytes = 50000000000"));
+    }
+
+    @Test
+    void onboardTenantScopesUsersPolicyWithEscapedPassword() {
+        final List<String> sql = ProvisioningDdl.onboardTenant("riptide", "acme", "acme-eu", "p'w", "r'w");
+        assertThat(sql).hasSize(7);
+        assertThat(sql.get(0))
+                .contains("CREATE USER IF NOT EXISTS `writer_acme`")
+                .contains("IDENTIFIED WITH sha256_password BY 'p\\'w'")
+                .contains("SQL_tenant = 'acme' CONST, SQL_org = 'acme-eu' CONST");
+        // Password reconciled with ALTER USER so a re-run after rotation updates the credential.
+        assertThat(sql.get(1)).isEqualTo("ALTER USER `writer_acme` IDENTIFIED WITH sha256_password BY 'p\\'w'");
+        assertThat(sql.get(2)).isEqualTo("GRANT flow_writer TO `writer_acme`");
+        assertThat(sql.get(4)).isEqualTo("ALTER USER `bi_acme` IDENTIFIED WITH sha256_password BY 'r\\'w'");
+        assertThat(sql.get(6))
+                .contains("CREATE ROW POLICY IF NOT EXISTS `acme_iso` ON `riptide`.flows")
+                .contains("USING tenant = 'acme' TO `bi_acme`");
+    }
+
+    @Test
+    void offboardDropsPolicyThenUsers() {
+        assertThat(ProvisioningDdl.offboardTenant("riptide", "acme")).containsExactly(
+                "DROP ROW POLICY IF EXISTS `acme_iso` ON `riptide`.flows",
+                "DROP USER IF EXISTS `bi_acme`",
+                "DROP USER IF EXISTS `writer_acme`");
+    }
+}

--- a/src/test/java/org/riptide/provisioning/TenantProvisionerTest.java
+++ b/src/test/java/org/riptide/provisioning/TenantProvisionerTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.provisioning;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link TenantProvisioner#redact} must never leak a resolved password into an error message,
+ * including the tricky cases a naive {@code '.*?'} misses: an escaped quote inside the literal and
+ * a newline in the password.
+ */
+class TenantProvisionerTest {
+
+    @Test
+    void redactsPlainPassword() {
+        final String sql = "CREATE USER `writer_acme` IDENTIFIED WITH sha256_password BY 's3cr3t' SETTINGS x = 1";
+        assertThat(TenantProvisioner.redact(sql))
+                .isEqualTo("CREATE USER `writer_acme` IDENTIFIED WITH sha256_password BY '***' SETTINGS x = 1")
+                .doesNotContain("s3cr3t");
+    }
+
+    @Test
+    void redactsPasswordContainingEscapedQuote() {
+        // literal("a'b") -> 'a\'b' ; the escaped quote must not end the redaction early.
+        final String sql = "ALTER USER `writer_acme` IDENTIFIED WITH sha256_password BY 'a\\'b'";
+        assertThat(TenantProvisioner.redact(sql))
+                .isEqualTo("ALTER USER `writer_acme` IDENTIFIED WITH sha256_password BY '***'")
+                .doesNotContain("a\\'b").doesNotContain("b'");
+    }
+
+    @Test
+    void redactsPasswordContainingNewline() {
+        final String sql = "ALTER USER `writer_acme` IDENTIFIED WITH sha256_password BY 'pre\npost'";
+        assertThat(TenantProvisioner.redact(sql))
+                .isEqualTo("ALTER USER `writer_acme` IDENTIFIED WITH sha256_password BY '***'")
+                .doesNotContain("post");
+    }
+}

--- a/src/test/java/org/riptide/provisioning/TenantSpecTest.java
+++ b/src/test/java/org/riptide/provisioning/TenantSpecTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.provisioning;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * {@link TenantSpec} validation is a security boundary: the tool runs as admin and interpolates the
+ * tenant/org into ClickHouse identifiers and literals, so an unsafe name must be rejected at
+ * construction rather than reaching the SQL.
+ */
+class TenantSpecTest {
+
+    @Test
+    void acceptsSafeNames() {
+        assertThatCode(() -> new TenantSpec("acme", "acme-eu", "riptide", "w", "r", 1L))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void rejectsUnsafeTenant() {
+        for (final String bad : new String[] {"a'b", "a`b", "a b", "a;b", "", "acme\""}) {
+            assertThatThrownBy(() -> new TenantSpec(bad, "acme-eu", "riptide", "w", "r", 1L))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("tenant");
+        }
+    }
+
+    @Test
+    void rejectsUnsafeOrganisationAndDatabase() {
+        assertThatThrownBy(() -> new TenantSpec("acme", "bad org", "riptide", "w", "r", 1L))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("organisation");
+        assertThatThrownBy(() -> new TenantSpec("acme", "acme-eu", "bad db", "w", "r", 1L))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("database");
+    }
+
+    @Test
+    void rejectsBlankSecretsAndNonPositiveQuota() {
+        assertThatThrownBy(() -> new TenantSpec("acme", "acme-eu", "riptide", " ", "r", 1L))
+                .hasMessageContaining("writerSecret");
+        assertThatThrownBy(() -> new TenantSpec("acme", "acme-eu", "riptide", "w", "", 1L))
+                .hasMessageContaining("readerSecret");
+        assertThatThrownBy(() -> new TenantSpec("acme", "acme-eu", "riptide", "w", "r", 0L))
+                .hasMessageContaining("quotaBytes");
+    }
+}

--- a/src/test/java/org/riptide/repository/clickhouse/TenantOnboardingIT.java
+++ b/src/test/java/org/riptide/repository/clickhouse/TenantOnboardingIT.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.repository.clickhouse;
+
+import com.clickhouse.client.api.Client;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.riptide.config.ClickhouseConfig;
+import org.riptide.provisioning.ProvisioningCommand;
+import org.riptide.secrets.SecretRef;
+import org.riptide.secrets.SecretResolvers;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.MountableFile;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.riptide.repository.clickhouse.ClickhouseItFlows.flow;
+
+/**
+ * The {@code onboard}/{@code offboard} subcommands, proven end to end against a real ClickHouse. The
+ * admin provisions the base {@code flows} table (as in production), then the CLI is driven exactly
+ * as an operator would: {@code onboard} a tenant, and the resulting scoped credentials must satisfy
+ * the full isolation matrix — honest write persists, cross-tenant write is rejected (469), the
+ * reader sees only its tenant and cannot write/DDL — and {@code offboard} must revoke access.
+ *
+ * <p>The server needs {@code custom_settings_prefixes: SQL_} for the CHECK barrier the onboarding
+ * recipe installs; it is mounted from the classpath, as in {@link TenantWriteBarrierIT}.
+ */
+@Testcontainers
+public class TenantOnboardingIT {
+
+    private static final String DATABASE = "onb";
+    private static final SecretResolvers RESOLVERS = SecretResolvers.defaults();
+
+    @Container
+    private static final GenericContainer<?> CLICKHOUSE = new GenericContainer<>("clickhouse/clickhouse-server:25.3")
+            .withEnv("CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT", "1")
+            .withCopyFileToContainer(
+                    MountableFile.forClasspathResource("clickhouse/custom-settings.xml"),
+                    "/etc/clickhouse-server/config.d/custom-settings.xml")
+            .withExposedPorts(8123)
+            .waitingFor(Wait.forHttp("/ping").forPort(8123).forStatusCode(200));
+
+    private static Client admin;
+
+    @BeforeAll
+    static void createBaseTable() throws Exception {
+        admin = new Client.Builder().addEndpoint(endpoint()).setUsername("default").setPassword("").build();
+        admin.execute("CREATE DATABASE IF NOT EXISTS " + DATABASE).get();
+        // The flows table is admin-owned (manage mode), as it would be before any tenant onboards.
+        new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), adminConfig(), RESOLVERS).start();
+    }
+
+    @Test
+    void onboardedTenantWritesHonestlyAndIsIsolated() throws Exception {
+        Assertions.assertThat(onboard("acme", "acme-eu", "wA", "rA")).isZero();
+        Assertions.assertThat(onboard("other", "other-eu", "wO", "rO")).isZero();
+
+        // Honest writes through the role-granted, CONST-pinned writers.
+        writerRepository("acme", "wA").persist(List.of(flow("acme", "acme-eu", 31001)));
+        writerRepository("other", "wO").persist(List.of(flow("other", "other-eu", 31002)));
+
+        // Cross-tenant write (config lies about tenant) is rejected by the CHECK barrier.
+        Assertions.assertThatThrownBy(() -> writerRepository("acme", "wA").persist(List.of(flow("evil", "acme-eu", 31003))))
+                .hasStackTraceContaining("469")
+                .hasStackTraceContaining("VIOLATED_CONSTRAINT");
+
+        // The reader sees only its own tenant (row policy) and cannot write or DDL (readonly role).
+        try (var reader = rawClient("bi_acme", "rA")) {
+            final var rows = reader.queryAll(
+                    "SELECT tenant FROM " + DATABASE + ".flows WHERE srcPort IN (31001, 31002)");
+            Assertions.assertThat(rows).hasSize(1);
+            Assertions.assertThat(rows.getFirst().getString("tenant")).isEqualTo("acme");
+
+            Assertions.assertThatThrownBy(
+                            () -> reader.execute("INSERT INTO " + DATABASE + ".flows (tenant) VALUES ('acme')").get())
+                    .hasStackTraceContaining("ACCESS_DENIED");
+            Assertions.assertThatThrownBy(
+                            () -> reader.execute("ALTER TABLE " + DATABASE + ".flows ADD COLUMN hacked String").get())
+                    .hasStackTraceContaining("ACCESS_DENIED");
+        }
+    }
+
+    @Test
+    void onboardEmitsConfigStanzaAndIsIdempotent() {
+        final var out = new ByteArrayOutputStream();
+        final int code = ProvisioningCommand.run(
+                onboardArgs("cfg", "cfg-eu", "wC", "rC"),
+                new PrintStream(out, true, StandardCharsets.UTF_8),
+                discard());
+        Assertions.assertThat(code).isZero();
+        Assertions.assertThat(out.toString(StandardCharsets.UTF_8))
+                .contains("riptide.clickhouse.username=writer_cfg")
+                .contains("riptide.clickhouse.password=wC")
+                .contains("riptide.identity.tenant=cfg")
+                .contains("riptide.identity.organisation=cfg-eu");
+
+        // Re-running is a no-op that still succeeds (IF NOT EXISTS everywhere).
+        Assertions.assertThat(onboard("cfg", "cfg-eu", "wC", "rC")).isZero();
+    }
+
+    @Test
+    void reonboardRotatesTheWriterPassword() throws Exception {
+        Assertions.assertThat(onboard("rot", "rot-eu", "pw1", "rr1")).isZero();
+        try (var writer = rawClient("writer_rot", "pw1")) {
+            Assertions.assertThat(writer.queryAll("SELECT 1 AS c").getFirst().getLong("c")).isEqualTo(1);
+        }
+
+        // Re-onboard with a rotated writer secret: the new password must take effect...
+        Assertions.assertThat(onboard("rot", "rot-eu", "pw2", "rr1")).isZero();
+        try (var writer = rawClient("writer_rot", "pw2")) {
+            Assertions.assertThat(writer.queryAll("SELECT 1 AS c").getFirst().getLong("c")).isEqualTo(1);
+        }
+        // ...and the old one must stop working.
+        try (var stale = rawClient("writer_rot", "pw1")) {
+            Assertions.assertThatThrownBy(() -> stale.queryAll("SELECT 1 AS c"))
+                    .hasStackTraceContaining("AUTHENTICATION_FAILED");
+        }
+    }
+
+    @Test
+    void offboardRevokesAccessOnlyWithYes() throws Exception {
+        Assertions.assertThat(onboard("temp", "temp-eu", "wT", "rT")).isZero();
+        try (var reader = rawClient("bi_temp", "rT")) {
+            Assertions.assertThat(reader.queryAll("SELECT 1 AS c").getFirst().getLong("c")).isEqualTo(1);
+        }
+
+        // Without --yes it refuses and changes nothing.
+        Assertions.assertThat(ProvisioningCommand.run(
+                new String[] {"offboard", "--admin-url", endpoint(), "--database", DATABASE, "--tenant", "temp"},
+                discard(), discard())).isEqualTo(2);
+        try (var reader = rawClient("bi_temp", "rT")) {
+            Assertions.assertThat(reader.queryAll("SELECT 1 AS c").getFirst().getLong("c")).isEqualTo(1);
+        }
+
+        // With --yes the user is gone and can no longer authenticate.
+        Assertions.assertThat(ProvisioningCommand.run(
+                new String[] {"offboard", "--admin-url", endpoint(), "--database", DATABASE, "--tenant", "temp", "--yes"},
+                discard(), discard())).isZero();
+        try (var reader = rawClient("bi_temp", "rT")) {
+            Assertions.assertThatThrownBy(() -> reader.queryAll("SELECT 1 AS c"))
+                    .hasStackTraceContaining("bi_temp");
+        }
+    }
+
+    private static int onboard(final String tenant, final String org, final String writerPw, final String readerPw) {
+        return ProvisioningCommand.run(onboardArgs(tenant, org, writerPw, readerPw), discard(), discard());
+    }
+
+    private static String[] onboardArgs(final String tenant, final String org, final String writerPw, final String readerPw) {
+        return new String[] {
+                "onboard", "--admin-url", endpoint(), "--database", DATABASE,
+                "--tenant", tenant, "--org", org, "--writer-secret", writerPw, "--reader-secret", readerPw};
+    }
+
+    private static ClickhouseRepository writerRepository(final String tenant, final String password) {
+        final var config = new ClickhouseConfig();
+        config.setEndpoint(endpoint());
+        config.setUsername(SecretRef.of("writer_" + tenant));
+        config.setPassword(SecretRef.of(password));
+        config.setDatabase(DATABASE);
+        config.setManageSchema(false);
+        final var repository = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), config, RESOLVERS);
+        repository.start();
+        return repository;
+    }
+
+    private static Client rawClient(final String user, final String password) {
+        return new Client.Builder()
+                .addEndpoint(endpoint())
+                .setUsername(user)
+                .setPassword(password)
+                .setDefaultDatabase(DATABASE)
+                .build();
+    }
+
+    private static ClickhouseConfig adminConfig() {
+        final var config = new ClickhouseConfig();
+        config.setEndpoint(endpoint());
+        config.setUsername(SecretRef.of("default"));
+        config.setDatabase(DATABASE);
+        config.setManageSchema(true);
+        return config;
+    }
+
+    private static PrintStream discard() {
+        return new PrintStream(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8);
+    }
+
+    private static String endpoint() {
+        return "http://" + CLICKHOUSE.getHost() + ":" + CLICKHOUSE.getMappedPort(8123);
+    }
+}


### PR DESCRIPTION
Closes #239. Makes the multi-tenant onboarding shipped in v0.3.0 *operable*: one command instead of a ~14-statement hand-copied SQL block (with ~8 substitution points, each a chance to silently weaken isolation), plus an offboarding path.

## What changes

**Role-based provisioning (Axis A).** The identical-per-tenant parts move into one-time objects: `flow_writer`/`flow_reader` roles (grants + the reader's `readonly=2, allow_ddl=0` hardening) and a single quota `KEYED BY user_name`. Per-tenant then reduces to the scoped users + role grants + one literal row policy.

**`onboard`/`offboard` subcommand (Axis B).** `java -jar riptide.jar onboard --admin-url … --tenant acme --org acme-eu --writer-secret … --reader-secret …`:
- Dispatched from `RiptideApplication.main` **before Spring starts** — the running collector never instantiates provisioning code (verified: no context, no daemon beans).
- Runs with **admin** credentials supplied explicitly at invocation, never `riptide.clickhouse.*`.
- Ensures the shared objects idempotently, resolves writer/reader secrets via `SecretResolvers` (`plain`/`env`/`file`), prints the collector's config stanza. `offboard` drops the per-tenant objects behind `--yes`.
- Re-running **reconciles the writer/reader password** (`ALTER USER`), so a rotated secret takes effect — while the `CONST` settings and row policy are preserved (verified on 25.3).

**Packaging:** subcommand in the riptide jar, factored behind `TenantProvisioner` + `ProvisioningDdl` so it can later be lifted into a separate `riptide-admin` module without reopening the release pipeline.

**Docs:** the runbook switches to the role-based recipe + subcommand; the `getSetting`-row-policy dead end is documented (it raises `UNKNOWN_SETTING`).

## Security

The tool runs as admin and builds DDL from input, so: tenant/org/database are charset-validated at a **single** injection boundary (`TenantSpec.requireSafe`, shared with `TenantRef`); generated identifiers are backtick-quoted and string literals escaped (`literal()` escaping verified correct on 25.3); resolved passwords are redacted from error messages (grammar-aware, handles escaped quotes + newlines) and never logged.

## Review

Implemented with Opus 4.8, reviewed with `/code-review medium` (Fable 5). All four findings fixed and verified live on ClickHouse 25.3: the redaction leak, the admin-password error path, the rotation footgun (`CREATE IF NOT EXISTS` kept the old password), and the duplicated validation regex.

## Verification

- `make jar` → 655 tests, all gates green (checkstyle, Error Prone, SpotBugs, JaCoCo).
- `mvn verify -Pe2e` → TenantOnboardingIT 4/4 (honest write, cross-tenant 469, reader isolation + no write/DDL, config stanza, rotation, offboard revoke), all existing ITs green.
- `make docs` → clean, no broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)