### PR TITLE
feat: ship DEB/RPM packages with a managed systemd service

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,6 @@
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
@@ -12,6 +15,15 @@ updates:
       - "dependency update"
     commit-message:
       prefix: "ci"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker" # nfpm pin used by `make packages` (Dockerfile.nfpm)
+    directory: "/deployment/package"
+    target-branch: "main"
+    labels:
+      - "dependency update"
+    commit-message:
+      prefix: "build"
     schedule:
       interval: "weekly"
   - package-ecosystem: "maven" # See documentation for possible values

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,0 +1,38 @@
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Validates the DEB/RPM packaging path on PRs that touch it — most importantly
+# Dependabot's nfpm image bumps, which would otherwise merge unvalidated and
+# first run inside the tag-triggered release workflow.
+name: Riptide Packages
+run-name: Build and smoke-test DEB/RPM packages
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ 'main' ]
+    paths:
+      - 'nfpm.yaml'
+      - 'deployment/package/**'
+      - 'Makefile'
+      - '.github/workflows/packages.yml'
+jobs:
+  packages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up JDK 25 for x64
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          architecture: x64
+          cache: maven
+      - name: Build jar (tests run in the build workflow)
+        run: |
+          make jar BUILD_OPTS="-DskipTests=true"
+      - name: Build DEB and RPM packages
+        run: |
+          make packages
+      - name: Smoke-test packages
+        run: |
+          make packages-smoke

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,6 @@
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 name: Riptide Release
 run-name: Release Workflow
 on:
@@ -20,7 +23,7 @@ jobs:
       - name: Check if you accidentally want to release a SNAPSHOT version
         run: |
           POM_VERSION="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
-          if [[ "${VERSION}" == *"SNAPSHOT"* ]]; then
+          if [[ "${POM_VERSION}" == *"SNAPSHOT"* ]]; then
             echo "Error: Your pom has a SNAPSHOT release. Set the pom to a version number without SNAPSHOT."
             exit 1
           else
@@ -33,6 +36,9 @@ jobs:
       - name: Build with tests
         run: |
           make
+      - name: Build DEB and RPM packages
+        run: |
+          make packages
       - name: Persist JAR artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -67,3 +73,5 @@ jobs:
         with:
           files: |
             target/*.jar
+            target/*.deb
+            target/*.rpm

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,14 @@
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 .DEFAULT_GOAL := jar
 
 SHELL               := bash -o nounset -o pipefail -o errexit
-VERSION             ?= $(shell mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+# Lazy one-shot: targets that never expand VERSION pay no mvn call; the first
+# expansion runs mvn once and caches (env/CLI overrides still win).
+ifeq ($(origin VERSION),undefined)
+VERSION              = $(eval VERSION := $(shell mvn help:evaluate -Dexpression=project.version -q -DforceStdout))$(VERSION)
+endif
 GIT_BRANCH          := $(shell git branch --show-current)
 GIT_SHORT_HASH      := $(shell git rev-parse --short HEAD)
 RELEASE_VERSION     := UNSET.0.0
@@ -18,6 +25,12 @@ OK                  := "[ 👍 ]"
 SKIP                := "[ ⏭️ ]"
 FAIL                := "[ ❌ ]"
 BUILD_OPTS          := "-DskipTests=false"
+# rpm forbids '-' in versions; tilde sorts before the release (correct upgrade semantic)
+PKG_VERSION          = $(subst -SNAPSHOT,~SNAPSHOT,$(VERSION))
+# nfpm runs via its OCI image; the pin lives in Dockerfile.nfpm so Dependabot bumps it
+NFPM_IMAGE           = $(shell awk '/^FROM/ {print $$2; exit}' deployment/package/Dockerfile.nfpm)
+# --user: without it, rootful Docker on Linux leaves root-owned files in target/
+NFPM                 = docker run --rm --user "$(shell id -u):$(shell id -g)" -v $(CURDIR):/work -w /work -e VERSION $(NFPM_IMAGE)
 
 REQUIRED_BINS := java javac mvn
 $(foreach bin,$(REQUIRED_BINS),\
@@ -33,6 +46,8 @@ help:
 	@echo "  help:         Show this help with explaining the build goals"
 	@echo "  jar:          Compile Riptide from source with tests and generate a runnable jar file in the target directory"
 	@echo "  oci:          Build OCI container image"
+	@echo "  packages:     Build DEB and RPM packages from the jar (requires Docker)"
+	@echo "  packages-smoke: Install the packages in Debian and Rocky containers and smoke-test them (requires Docker)"
 	@echo "  coverage:     Run the unit test suite and render the JaCoCo coverage report"
 	@echo "  e2e:          Run integration and e2e tests (*IT, requires Docker) in addition to the unit suite"
 	@echo "  docs:         Build the Docusaurus documentation site into docs/build"
@@ -86,6 +101,18 @@ oci: deps-oci jar
       --build-arg="GIT_SHORT_HASH"=$(GIT_SHORT_HASH) \
       --build-arg="DATE=$(DATE)" \
       .
+
+.PHONY: packages
+packages: deps-oci
+	@test -f target/riptide-flows-$(VERSION).jar || { echo "target/riptide-flows-$(VERSION).jar missing — run make jar first"; exit 1; }
+	mkdir -p target/package
+	cp target/riptide-flows-$(VERSION).jar target/package/riptide.jar
+	VERSION=$(PKG_VERSION) $(NFPM) package -f nfpm.yaml -p deb -t target/
+	VERSION=$(PKG_VERSION) $(NFPM) package -f nfpm.yaml -p rpm -t target/
+
+.PHONY: packages-smoke
+packages-smoke: deps-oci
+	deployment/package/smoke-test.sh $(PKG_VERSION)
 
 .PHONY: release
 release:

--- a/deployment/package/Dockerfile.nfpm
+++ b/deployment/package/Dockerfile.nfpm
@@ -1,0 +1,7 @@
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Single source of truth for the nfpm version used by `make packages`: the
+# Makefile parses this FROM line and runs nfpm through the image. The file
+# exists so Dependabot's docker ecosystem keeps the pin (tag + digest) current.
+FROM goreleaser/nfpm:v2.47.0@sha256:a662cb167d7b6d3a83920c83d76b12d02b8ac5dd2c13e5c62c15270b23f6df0c

--- a/deployment/package/config.yaml
+++ b/deployment/package/config.yaml
@@ -1,0 +1,19 @@
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Riptide configuration — see https://riptide.space/docs/configuration/receivers
+# Every riptide.* property can live here (receivers, nodes & SNMP, secret
+# references, ClickHouse). The service watches this file and hot-reloads most
+# changes; see the operations chapter of the documentation.
+#
+# Minimal example:
+#
+# riptide:
+#   clickhouse:
+#     endpoint: http://clickhouse.example.com:8123
+#     database: riptide
+#   receivers:
+#     ipfix:
+#       type: ipfix
+#       host: 0.0.0.0
+#       port: 4739

--- a/deployment/package/postinstall.sh
+++ b/deployment/package/postinstall.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+set -e
+
+if [ -d /run/systemd/system ]; then
+    systemctl daemon-reload || true
+fi
+
+# Passive install by design: Riptide cannot do anything useful before
+# /etc/riptide/config.yaml points at a ClickHouse, so it is neither enabled
+# nor started here.
+echo "Riptide is installed but not enabled or started."
+echo "Configure /etc/riptide/config.yaml, then run: systemctl enable --now riptide"

--- a/deployment/package/postremove.sh
+++ b/deployment/package/postremove.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+set -e
+
+if [ -d /run/systemd/system ]; then
+    systemctl daemon-reload || true
+fi

--- a/deployment/package/preinstall.sh
+++ b/deployment/package/preinstall.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+set -e
+
+# Runs before unpack on both families (deb preinst / rpm %pre) so the group
+# exists when the package manager applies the declared root:riptide ownership
+# on /etc/riptide.
+if ! getent group riptide >/dev/null; then
+    groupadd --system riptide
+fi
+if ! getent passwd riptide >/dev/null; then
+    useradd --system --gid riptide --no-create-home --home-dir /nonexistent \
+        --shell /usr/sbin/nologin --comment "Riptide NetFlow analysis engine" riptide
+fi

--- a/deployment/package/preremove.sh
+++ b/deployment/package/preremove.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+set -e
+
+# Stop and disable only on real removal, not upgrade: deb prerm gets "remove",
+# rpm %preun gets "0".
+if [ "$1" = "remove" ] || [ "$1" = "0" ]; then
+    if [ -d /run/systemd/system ]; then
+        # deb-systemd-invoke respects policy-rc.d (container image builds)
+        if command -v deb-systemd-invoke >/dev/null 2>&1; then
+            deb-systemd-invoke stop riptide.service >/dev/null 2>&1 || true
+        else
+            systemctl stop riptide.service >/dev/null 2>&1 || true
+        fi
+    fi
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl disable riptide.service >/dev/null 2>&1 || true
+    fi
+fi

--- a/deployment/package/riptide.env
+++ b/deployment/package/riptide.env
@@ -1,0 +1,11 @@
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Environment for riptide.service (systemd EnvironmentFile syntax).
+#
+# JVM options:
+#JAVA_OPTS=-Xmx2g
+#
+# Any riptide.* property can also be set as an environment variable here
+# (Spring relaxed binding), e.g.:
+#RIPTIDE_CLICKHOUSE_ENDPOINT=http://clickhouse.example.com:8123

--- a/deployment/package/riptide.service
+++ b/deployment/package/riptide.service
@@ -1,0 +1,26 @@
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+[Unit]
+Description=Riptide NetFlow analysis engine
+Documentation=https://riptide.space/docs/
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+User=riptide
+Group=riptide
+EnvironmentFile=-/etc/riptide/riptide.env
+ExecStart=/usr/bin/java $JAVA_OPTS -jar /usr/share/riptide/riptide.jar
+Restart=on-failure
+# JVM exits 143 on SIGTERM after running shutdown hooks — that is a clean stop
+SuccessExitStatus=143
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=yes
+ReadOnlyPaths=/etc/riptide
+
+[Install]
+WantedBy=multi-user.target

--- a/deployment/package/smoke-test.sh
+++ b/deployment/package/smoke-test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Installs the freshly built deb/rpm in Debian and Rocky containers and
+# asserts: the Java 25 dependency resolves from the distro repos, file layout
+# and ownership match the design, and the app boots as the riptide user.
+# Invoked via `make packages-smoke` with the mangled package version.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+VERSION="${1:?usage: smoke-test.sh <package-version>}"
+
+test -f "target/riptide_${VERSION}_all.deb" || { echo "deb for ${VERSION} missing — run make packages first"; exit 1; }
+ls target/riptide-"${VERSION}"-*.noarch.rpm >/dev/null || { echo "rpm for ${VERSION} missing — run make packages first"; exit 1; }
+
+# Shared assertions; runs inside both containers after package installation.
+ASSERTIONS='
+  java --version | head -1 | grep -q "openjdk 25" || { echo "FAIL: no Java 25 runtime"; exit 1; }
+  test -f /usr/share/riptide/riptide.jar
+  test -f /usr/lib/systemd/system/riptide.service
+  [ "$(stat -c "%U:%G %a" /etc/riptide/config.yaml)" = "root:riptide 640" ]
+  [ "$(stat -c "%U:%G %a" /etc/riptide/riptide.env)" = "root:riptide 640" ]
+  id riptide >/dev/null
+  runuser -u riptide -- timeout 30 java -jar /usr/share/riptide/riptide.jar >/tmp/boot.log 2>&1 || true
+  grep -q "Starting RiptideApplication" /tmp/boot.log || { echo "FAIL: app did not boot"; cat /tmp/boot.log; exit 1; }
+  echo "assertions OK"
+'
+
+echo "=== smoke: debian:trixie (apt dependency resolution + install) ==="
+docker run --rm -v "$PWD/target:/pkgs:ro" -e "VERSION=${VERSION}" debian:trixie bash -euc "
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update -q
+  apt-get install -yq /pkgs/riptide_\${VERSION}_all.deb systemd
+  systemd-analyze verify /usr/lib/systemd/system/riptide.service
+  ${ASSERTIONS}
+"
+
+echo "=== smoke: rockylinux:9 (dnf dependency resolution + install) ==="
+docker run --rm -v "$PWD/target:/pkgs:ro" -e "VERSION=${VERSION}" rockylinux:9 bash -euc "
+  dnf install -yq /pkgs/riptide-\${VERSION}-*.noarch.rpm
+  ${ASSERTIONS}
+"
+
+echo "=== smoke: OK (deb + rpm) ==="

--- a/docs/docs/deploy/linux-packages.md
+++ b/docs/docs/deploy/linux-packages.md
@@ -1,0 +1,89 @@
+---
+sidebar_position: 3
+title: DEB / RPM packages
+---
+
+# Deploy with DEB / RPM packages
+
+Every [GitHub release](https://github.com/Riptide-Labs/riptide/releases) ships
+architecture-independent `.deb` and `.rpm` packages (one package serves amd64 and arm64). They
+install the jar, a hardened systemd service, and a configuration skeleton — Java 25 is resolved
+automatically from your distro or JDK-vendor repositories.
+
+## Install
+
+**Debian / Ubuntu** (Debian 13+, Ubuntu 22.04+):
+
+```bash
+curl -LO https://github.com/Riptide-Labs/riptide/releases/download/v<version>/riptide_<version>_all.deb
+sudo apt install ./riptide_<version>_all.deb
+```
+
+apt pulls `openjdk-25-jre-headless` from the distro archive if no Java 25 is present; an already
+installed Temurin, Corretto, or Zulu 25 also satisfies the dependency.
+
+**RHEL / Rocky / Alma (9.7+, 10.1+) and Fedora (43+)** — dnf installs directly from the URL:
+
+```bash
+sudo dnf install https://github.com/Riptide-Labs/riptide/releases/download/v<version>/riptide-<version>-1.noarch.rpm
+```
+
+dnf pulls `java-25-openjdk-headless` from AppStream; Temurin and Zulu 25 also satisfy the
+dependency.
+
+:::note Amazon Corretto on RPM systems
+Corretto's rpm does not provide the `jre-25-headless` virtual the package depends on. If Corretto
+is your runtime, install the package with `rpm -i --nodeps` and manage the Java requirement
+yourself — or let dnf install `java-25-openjdk-headless` alongside.
+:::
+
+## What the package installs
+
+| Path | Purpose |
+|---|---|
+| `/usr/share/riptide/riptide.jar` | the engine |
+| `/usr/lib/systemd/system/riptide.service` | sandboxed unit, runs as the `riptide` system user |
+| `/etc/riptide/config.yaml` | configuration (root:riptide 0640 — may hold credentials) |
+| `/etc/riptide/riptide.env` | JVM options and environment variables for the service |
+
+## Configure, enable, start
+
+Installation is deliberately passive: nothing is enabled or started until Riptide can do something
+useful. Point `/etc/riptide/config.yaml` at your ClickHouse and define receivers — everything from
+the [configuration chapters](../configuration/receivers.md) goes there — then:
+
+```bash
+sudo systemctl enable --now riptide
+journalctl -u riptide -f
+```
+
+File-based configuration [hot-reloads](operations.md#config-hot-reload). `riptide.env` takes
+`JAVA_OPTS` and [environment-variable configuration](plain-jar.md#environment-variables); changes
+there need a `systemctl restart riptide`.
+
+## Upgrades
+
+Install the newer package the same way, then restart the service — the running JVM keeps
+executing the old jar until you do:
+
+```bash
+sudo systemctl restart riptide
+```
+
+Your edited `/etc/riptide` files are preserved by default: rpm writes new defaults as `.rpmnew`
+next to them; dpkg keeps your version unless the packaged default changed too, in which case it
+asks (unattended upgrades can pass `-o Dpkg::Options::=--force-confold` to always keep yours).
+
+## Receivers on privileged ports
+
+The unit runs unprivileged; the conventional receiver ports (IPFIX 4739, NetFlow v9 2055,
+sFlow 6343) need no special rights. To bind a port below 1024, add a drop-in:
+
+```bash
+sudo systemctl edit riptide
+```
+
+```ini
+[Service]
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+```

--- a/docs/docs/deploy/multi-tenancy.md
+++ b/docs/docs/deploy/multi-tenancy.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 title: Multi-tenancy
 ---
 

--- a/docs/docs/deploy/operations.md
+++ b/docs/docs/deploy/operations.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 title: Operations
 ---
 

--- a/docs/docs/deploy/plain-jar.md
+++ b/docs/docs/deploy/plain-jar.md
@@ -7,6 +7,9 @@ title: Plain JAR
 
 Riptide is a single Spring Boot jar. Requirements: **Java 25** and a reachable ClickHouse.
 
+On Debian/Ubuntu or RHEL-family systems, prefer the
+[DEB / RPM packages](linux-packages.md) — same jar, plus a managed systemd service.
+
 Download the jar from a [GitHub release](https://github.com/Riptide-Labs/riptide/releases)
 and run it:
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -15,6 +15,8 @@ Deploy the published image or jar — no build toolchain needed.
   UI + Grafana) in one `docker compose up`
 - [**Plain JAR**](deploy/plain-jar.md) — `java -jar` with file- or env-var-based
   configuration
+- [**DEB / RPM packages**](deploy/linux-packages.md) — `apt`/`dnf` install with a managed
+  systemd service
 - [Operations notes](deploy/operations.md) — image tags, restarts, upgrades
 
 ## 🛠 I want to work on Riptide

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -1,0 +1,66 @@
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# nfpm packaging descriptor — https://nfpm.goreleaser.com/configuration/
+# Invoked via `make packages`, which stages the jar and injects VERSION
+# (with -SNAPSHOT mangled to ~SNAPSHOT so rpm accepts it).
+name: riptide
+# Architecture-independent fat jar: one package serves amd64 and arm64.
+# nfpm maps "all" to deb "all" / rpm "noarch".
+arch: all
+platform: linux
+version: ${VERSION}
+section: net
+priority: optional
+maintainer: Ronny Trommer <ronny@no42.org>
+vendor: Riptide Labs
+homepage: https://github.com/Riptide-Labs/riptide
+license: GPL-3.0-or-later
+description: |
+  NetFlow analysis engine.
+  Receives NetFlow/IPFIX/sFlow traffic, enriches flows with node and SNMP
+  metadata, and persists them to ClickHouse.
+
+contents:
+  - src: target/package/riptide.jar
+    dst: /usr/share/riptide/riptide.jar
+  - src: deployment/package/riptide.service
+    dst: /usr/lib/systemd/system/riptide.service
+  # config.yaml may hold inline credentials: root:riptide 0640, never
+  # overwritten on upgrade (dpkg keeps the edited file, rpm writes .rpmnew).
+  - src: deployment/package/config.yaml
+    dst: /etc/riptide/config.yaml
+    type: config|noreplace
+    file_info:
+      mode: 0640
+      owner: root
+      group: riptide
+  - src: deployment/package/riptide.env
+    dst: /etc/riptide/riptide.env
+    type: config|noreplace
+    file_info:
+      mode: 0640
+      owner: root
+      group: riptide
+
+scripts:
+  preinstall: deployment/package/preinstall.sh
+  postinstall: deployment/package/postinstall.sh
+  preremove: deployment/package/preremove.sh
+  postremove: deployment/package/postremove.sh
+
+# Java 25 runtime dependency strings are verified against live repo metadata
+# (July 2026) — see openspec design for the virtual-provides matrix. Do not
+# simplify without re-verifying. Bump both when <java.version> moves.
+overrides:
+  deb:
+    depends:
+      # 1st: concrete package apt auto-installs (Ubuntu 22.04+/Debian 13+);
+      # 2nd: distro OpenJDK 25 and newer majors, Temurin;
+      # 3rd: Corretto/Zulu (unversioned Provides can't satisfy the 2nd).
+      - openjdk-25-jre-headless | java-runtime-headless (>= 25) | java25-runtime-headless
+  rpm:
+    depends:
+      # distro OpenJDK (RHEL 9.7+/10.1+, Fedora 43+), Temurin, Zulu.
+      # Corretto provides no *-headless virtual — documented caveat.
+      - jre-25-headless


### PR DESCRIPTION
## What

Every release now publishes architecture-independent `.deb` and `.rpm` packages (one noarch artifact serves amd64+arm64) alongside the jar, giving bare-metal operators an `apt install` / `dnf install`-and-go experience with a managed systemd service.

- **`nfpm.yaml`** — jar under `/usr/share/riptide/`, hardened `riptide.service`, `config|noreplace` `/etc/riptide` files at `root:riptide 0640`. Java 25 resolves from distro/vendor repos via per-format virtual provides, verified against live repo metadata (deb covers distro OpenJDK/Temurin/Corretto/Zulu; rpm covers all but Corretto — documented caveat).
- **`deployment/package/`** — systemd unit (static `riptide` user, `SuccessExitStatus=143`, `ProtectSystem=strict` sandbox), maintainer scripts (user creation in preinstall so declared ownership applies at unpack; passive install — no auto-enable/start), starter config, container smoke test.
- **`make packages` / `make packages-smoke`** — nfpm runs via its OCI image pinned (tag+digest) in `Dockerfile.nfpm`; Dependabot's docker ecosystem keeps the pin current. The smoke test installs the packages on `debian:trixie` and `rockylinux:9`, asserting dependency resolution, layout/ownership, and app boot as the `riptide` user.
- **CI** — `release.yml` attaches packages to release assets; new path-filtered `packages.yml` validates the packaging path on PRs (including Dependabot nfpm bumps).
- **Docs** — new [Deploy → DEB / RPM packages] page; Getting started and Plain JAR link to it.

Also fixes the pre-existing `release.yml` SNAPSHOT guard (tested unset `VERSION` instead of `POM_VERSION`, could never trip) and memoizes the Makefile `VERSION` lookup (one `mvn help:evaluate` instead of five per `make packages`).

## Verification

- `make packages` → `riptide_0.3.2~SNAPSHOT_all.deb` + `riptide-0.3.2~SNAPSHOT-1.noarch.rpm` (tilde mangling for rpm).
- `make packages-smoke` green on both debian:trixie (apt resolved `openjdk-25-jre-headless`, `systemd-analyze verify` clean) and rockylinux:9 (dnf resolved `java-25-openjdk-headless` from AppStream); both assert `root:riptide 640` config ownership and a real boot as the `riptide` user.
- `make docs` green.
- Structured review (medium) run pre-PR; all 8 findings applied.

Non-goals (v1): apt/yum repo hosting (release assets only; nothing precludes a repo later), bundled/jlink runtime, apk/arch outputs, RC packages. Nix flake is tracked as a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)