### PR TITLE
feat: build from source with a Nix flake and NixOS module

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,32 @@
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Builds the flake and runs its checks on PRs that touch the Nix files or the
+# pom. The pom trigger is the point: a Maven dependency change staled the
+# `mvnHash` in nix/package.nix, and this job fails loudly on that PR instead of
+# at some consumer's `nix build`.
+name: Riptide Nix
+run-name: Build the flake and run flake checks
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ 'main' ]
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'nix/**'
+      - 'pom.xml'
+      - '.github/workflows/nix.yml'
+jobs:
+  nix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@786fff0690178f1234e4e1fe9b536e94f5433196 # v20
+      - name: Build the package
+        run: |
+          make nix
+      - name: Run flake checks
+        run: |
+          make nix-check

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,10 @@ pom.xml.versionsBackup
 ### riptide files ###
 application-local.properties
 
+### Nix ###
+result
+result-*
+
 ### Docker Compose Override ###
 compose.override.y*ml
 docker-compose.override.y*ml

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,8 @@ help:
 	@echo "  oci:          Build OCI container image"
 	@echo "  packages:     Build DEB and RPM packages from the jar (requires Docker)"
 	@echo "  packages-smoke: Install the packages in Debian and Rocky containers and smoke-test them (requires Docker)"
+	@echo "  nix:          Build the flake package from source (requires Nix)"
+	@echo "  nix-check:    Run the flake checks incl. the NixOS module eval (requires Nix)"
 	@echo "  coverage:     Run the unit test suite and render the JaCoCo coverage report"
 	@echo "  e2e:          Run integration and e2e tests (*IT, requires Docker) in addition to the unit suite"
 	@echo "  docs:         Build the Docusaurus documentation site into docs/build"
@@ -113,6 +115,18 @@ packages: deps-oci
 .PHONY: packages-smoke
 packages-smoke: deps-oci
 	deployment/package/smoke-test.sh $(PKG_VERSION)
+
+.PHONY: deps-nix
+deps-nix:
+	@command -v nix >/dev/null || { echo "Please install Nix — https://nixos.org/download"; exit 1; }
+
+.PHONY: nix
+nix: deps-nix
+	nix build .#default --print-build-logs
+
+.PHONY: nix-check
+nix-check: deps-nix
+	nix flake check --print-build-logs
 
 .PHONY: release
 release:

--- a/docs/docs/deploy/multi-tenancy.md
+++ b/docs/docs/deploy/multi-tenancy.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 title: Multi-tenancy
 ---
 

--- a/docs/docs/deploy/nixos.md
+++ b/docs/docs/deploy/nixos.md
@@ -1,0 +1,80 @@
+---
+sidebar_position: 4
+title: NixOS
+---
+
+# Deploy on NixOS
+
+Riptide ships a [flake](https://github.com/Riptide-Labs/riptide/blob/main/flake.nix) that builds
+the engine from source and exposes a NixOS module. Nix/NixOS is a separate track from the
+[DEB/RPM packages](linux-packages.md) — there is no `.nix` artifact to download; you reference the
+flake by revision.
+
+## Run it directly
+
+```bash
+nix run github:Riptide-Labs/riptide -- --help
+```
+
+`nix build github:Riptide-Labs/riptide#default` produces `result/bin/riptide` (a `java -jar`
+launcher over the fat jar) and requires no local JDK. Pin a release by ref:
+`github:Riptide-Labs/riptide?ref=v0.3.1`.
+
+## NixOS module
+
+Add the flake as an input and import `nixosModules.default`:
+
+```nix
+{
+  inputs.riptide.url = "github:Riptide-Labs/riptide";
+
+  outputs = { nixpkgs, riptide, ... }: {
+    nixosConfigurations.collector = nixpkgs.lib.nixosSystem {
+      modules = [
+        riptide.nixosModules.default
+        {
+          services.riptide = {
+            enable = true;
+            settings = {
+              riptide.clickhouse.endpoint = "http://clickhouse:8123";
+              riptide.receivers.ipfix = { type = "ipfix"; host = "0.0.0.0"; port = 4739; };
+            };
+            environmentFile = "/run/secrets/riptide.env";
+          };
+        }
+      ];
+    };
+  };
+}
+```
+
+`settings` is freeform — everything from the [configuration chapters](../configuration/receivers.md)
+goes there. It is rendered to YAML and exposed at `/etc/riptide/config.yaml`, so the configuration
+reference applies verbatim. The service runs under `DynamicUser` with the same sandboxing as the
+packaged unit (`NoNewPrivileges`, `PrivateTmp`, `ProtectSystem=strict`, `ProtectHome`), and restarts
+automatically when `settings` change.
+
+## Secrets
+
+The rendered config lives in the world-readable Nix store, so **do not put credentials in
+`settings`**. Use `environmentFile` (kept out of the store) for values like passwords, or a
+[secret reference](../configuration/secret-references.md) (`env://`, `file://`, `vault://`,
+`sops://`) that Riptide resolves at runtime.
+
+## Firewall
+
+Receiver ports depend on your configuration; the module does not open any. Add the ones you use:
+
+```nix
+networking.firewall.allowedUDPPorts = [ 4739 ];
+```
+
+## Development shell
+
+The flake's dev shell mirrors the toolchain in `shell.nix` (JDK 25, Maven, protobuf, and the pcap
+tooling):
+
+```bash
+nix develop
+make
+```

--- a/docs/docs/deploy/operations.md
+++ b/docs/docs/deploy/operations.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 title: Operations
 ---
 

--- a/docs/docs/develop/environment.md
+++ b/docs/docs/develop/environment.md
@@ -13,6 +13,9 @@ make            # compile with tests → runnable jar in target/
 make help       # all goals
 ```
 
+Nix users can get the full toolchain (JDK 25, Maven, protobuf, pcap tooling) with
+`nix develop` (flake) or `nix-shell` (the `shell.nix`), then run `make` as above.
+
 | Goal | What it does |
 |---|---|
 | `make` / `make jar` | full build with tests and all quality gates |

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -17,6 +17,7 @@ Deploy the published image or jar — no build toolchain needed.
   configuration
 - [**DEB / RPM packages**](deploy/linux-packages.md) — `apt`/`dnf` install with a managed
   systemd service
+- [**NixOS**](deploy/nixos.md) — flake package plus a `services.riptide` module
 - [Operations notes](deploy/operations.md) — image tags, restarts, upgrades
 
 ## 🛠 I want to work on Riptide

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1784007870,
+        "narHash": "sha256-djcLt/JJphyNt4eDY9XTly+/WbCK5lqWq9lSgCmJkkQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18b9261cb3294b6d2a06d03f96872827b8fe2698",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18b9261cb3294b6d2a06d03f96872827b8fe2698",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,75 @@
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+{
+  description = "Riptide — NetFlow analysis engine";
+
+  # Pinned to a nixos-unstable rev that carries jdk25_headless. flake.lock is the
+  # real pin; bump it manually with `nix flake update` (no Dependabot flake support).
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/18b9261cb3294b6d2a06d03f96872827b8fe2698";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forAllSystems =
+        f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = forAllSystems (pkgs: {
+        default = pkgs.callPackage ./nix/package.nix { };
+        riptide = self.packages.${pkgs.system}.default;
+      });
+
+      # `nix develop` — reuse shell.nix so the two toolchains cannot drift.
+      devShells = forAllSystems (pkgs: {
+        default = import ./shell.nix { inherit pkgs; };
+      });
+
+      # Wrap the bare module so its package default resolves to this flake's
+      # build — a stock consumer's nixpkgs has no `riptide` attribute.
+      nixosModules.default =
+        { pkgs, lib, ... }:
+        {
+          imports = [ ./nix/module.nix ];
+          services.riptide.package = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+        };
+
+      # Eval-based module check (no KVM needed): builds a NixOS system that
+      # enables the service and asserts the rendered unit + config land.
+      checks = forAllSystems (pkgs: {
+        module-eval =
+          let
+            sys = nixpkgs.lib.nixosSystem {
+              inherit (pkgs) system;
+              modules = [
+                self.nixosModules.default
+                (
+                  { ... }:
+                  {
+                    # Container stub keeps the eval light (no bootloader/fs assertions).
+                    boot.isContainer = true;
+                    system.stateVersion = "24.11";
+                    services.riptide = {
+                      enable = true;
+                      settings.riptide.clickhouse.endpoint = "http://clickhouse:8123";
+                    };
+                  }
+                )
+              ];
+            };
+            svc = sys.config.systemd.services.riptide.serviceConfig;
+          in
+          assert svc.DynamicUser == true;
+          assert nixpkgs.lib.hasSuffix "/bin/riptide" svc.ExecStart;
+          assert sys.config.environment.etc ? "riptide/config.yaml";
+          pkgs.runCommand "riptide-module-eval-ok" { } ''
+            echo "module renders: DynamicUser, ExecStart=${svc.ExecStart}, /etc/riptide/config.yaml wired" > $out
+          '';
+      });
+
+      formatter = forAllSystems (pkgs: pkgs.nixfmt-rfc-style);
+    };
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,84 @@
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.riptide;
+  format = pkgs.formats.yaml { };
+  configFile = format.generate "riptide-config.yaml" cfg.settings;
+in
+{
+  options.services.riptide = {
+    enable = lib.mkEnableOption "the Riptide NetFlow analysis engine";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.riptide;
+      defaultText = lib.literalExpression "pkgs.riptide";
+      description = "The Riptide package to run.";
+    };
+
+    settings = lib.mkOption {
+      type = format.type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          riptide.clickhouse.endpoint = "http://clickhouse:8123";
+          riptide.receivers.ipfix = { type = "ipfix"; host = "0.0.0.0"; port = 4739; };
+        }
+      '';
+      description = ''
+        Riptide configuration, rendered to YAML and exposed at
+        `/etc/riptide/config.yaml`. See the configuration reference at
+        <https://riptide.space/docs/configuration/receivers>.
+
+        The rendered file is world-readable in the Nix store; keep inline
+        credentials out of it and use {option}`services.riptide.environmentFile`
+        or secret references (`env://`, `file://`, `vault://`, `sops://`) instead.
+      '';
+    };
+
+    environmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/run/secrets/riptide.env";
+      description = ''
+        Environment file (JAVA_OPTS, secret values) sourced by the service.
+        Kept outside the world-readable Nix store.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.etc."riptide/config.yaml".source = configFile;
+
+    systemd.services.riptide = {
+      description = "Riptide NetFlow analysis engine";
+      documentation = [ "https://riptide.space/docs/" ];
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+
+      # New config renders a new /etc link; restart the unit to pick it up.
+      restartTriggers = [ configFile ];
+
+      serviceConfig = {
+        ExecStart = lib.getExe cfg.package;
+        Restart = "on-failure";
+        SuccessExitStatus = 143; # JVM exit on SIGTERM
+        EnvironmentFile = lib.mkIf (cfg.environmentFile != null) cfg.environmentFile;
+
+        DynamicUser = true;
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+      };
+    };
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,71 @@
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+{
+  lib,
+  maven,
+  jdk25_headless,
+  makeWrapper,
+}:
+
+let
+  # Project version straight from the pom (source of truth); string-split avoids
+  # nix regex's lack of dotall.
+  pom = builtins.readFile ../pom.xml;
+  afterId = lib.elemAt (lib.splitString "<artifactId>riptide-flows</artifactId>" pom) 1;
+  version = lib.elemAt (lib.splitString "</version>" (lib.elemAt (lib.splitString "<version>" afterId) 1)) 0;
+in
+maven.buildMavenPackage {
+  pname = "riptide-flows";
+  inherit version;
+
+  # Flake source = the git tree; drop build/doc trees so the deps hash and store
+  # copy stay stable and small.
+  src = lib.cleanSourceWith {
+    src = ../.;
+    filter =
+      path: type:
+      let
+        base = baseNameOf path;
+      in
+      !(builtins.elem base [
+        "target"
+        "docs"
+        "openspec"
+        "deployment"
+        "artwork"
+        "result"
+      ]);
+  };
+
+  # JAVA_HOME for the deps + build phases (Maven honors it over maven's bundled JDK).
+  mvnJdk = jdk25_headless;
+
+  # Tests need Docker/ClickHouse testcontainers, unavailable in the nix sandbox.
+  doCheck = false;
+
+  # git-commit-id plugin reads .git, which is not part of the store source.
+  mvnParameters = "-Dmaven.gitcommitid.skip=true";
+
+  # Verified for the pinned nixpkgs rev (spike A.1). Regenerate with lib.fakeHash
+  # whenever pom dependencies change; the nix CI job fails the PR if it drifts.
+  mvnHash = "sha256-4O+27yuFr346270TKJMQqM/D7kTUsS7C0Yz1/I/Mll4=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/riptide
+    cp target/riptide-flows-*.jar $out/share/riptide/riptide.jar
+    makeWrapper ${jdk25_headless}/bin/java $out/bin/riptide \
+      --add-flags "-jar $out/share/riptide/riptide.jar"
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "NetFlow analysis engine";
+    homepage = "https://github.com/Riptide-Labs/riptide";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "riptide";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## What

Adds a Nix flake so Nix/NixOS users get a first-class deployment path alongside the container image, plain jar, and [DEB/RPM packages](https://github.com/Riptide-Labs/riptide/pull/243). nfpm can't produce a Nix package — a Nix package is a build recipe, not an archive — so this is a separate track built from source.

- **`flake.nix` + `nix/package.nix`** — `packages.default` builds Riptide from the checked-out source with `maven.buildMavenPackage` (JDK 25 via `mvnJdk`, `doCheck = false`, `-Dmaven.gitcommitid.skip=true`), exposing a `riptide` launcher for `nix run`. Version is parsed from `pom.xml`; `mvnHash` pins the dependency closure.
- **`nix/module.nix`** — `services.riptide` with `enable`/`package`/`settings` (freeform → YAML at `/etc/riptide/config.yaml`, so the configuration reference applies verbatim) / `environmentFile`, running under `DynamicUser` with the same sandboxing as the packaged unit and restarting on config change. The flake wraps the module so its `package` default resolves to this flake's build — a stock consumer's nixpkgs has no `riptide` attribute.
- **`devShells.default`** reuses `shell.nix` (one toolchain, no drift); `shell.nix` stays for non-flake users.
- **CI** — `make nix` / `make nix-check` targets and a path-filtered `nix.yml` (flake files + `pom.xml`), so a stale `mvnHash` after a dependency change fails the PR rather than a consumer's build.
- **Docs** — new [Deploy → NixOS] page; Getting started and the dev environment page link it.

## Verification

Verified **natively on a NixOS aarch64 host with `sandbox = true`** (CI-equivalent), not just in eval:

- `nix build .#default` — builds the Spring Boot executable jar (JarLauncher main-class, Start-Class `org.riptide.RiptideApplication`); the store hash reproduces the earlier container build.
- `nix flake check` — packages, devShell, formatter, and the NixOS module-eval check all green. The module-eval passes **without** any consumer overlay, confirming the module self-wires its package.
- `result/bin/riptide` boots: "Starting RiptideApplication v0.3.2-SNAPSHOT using Java 25.0.4".
- `make docs` green (new page, links, sidebar renumbering).

Medium code review run pre-PR; 5 findings applied (module self-wiring, `make`-target CI, devShell reuse, comment fix, sandbox verification).

Non-goals (v1): no nixpkgs upstreaming, no binary cache, no Home Manager module. `flake.lock` is bumped manually with `nix flake update` (Dependabot has no flake support).

🤖 Generated with [Claude Code](https://claude.com/claude-code)