### PR TITLE
docs: fix admonition titles for Docusaurus 3 (bracket syntax)

### DIFF
--- a/docs/docs/configuration/nodes-and-snmp.md
+++ b/docs/docs/configuration/nodes-and-snmp.md
@@ -35,7 +35,7 @@ domain (source ID). For **sFlow** both come from the datagram payload: subnets m
 the `agent_address` — which may differ from the UDP source — and `observation-domain`
 pins the `sub_agent_id`.
 
-:::warning The pin key is shared across protocols
+:::warning[The pin key is shared across protocols]
 `observation-domain: 0` pins *both* NetFlow v5 exporters with engine type/ID 0 (their
 domain maps to `0`) *and* sFlow agents with the near-universal default
 `sub_agent_id = 0` — and a matching pin beats every wildcard node, even a
@@ -67,7 +67,7 @@ riptide.nodes.core-router.interfaces.10.high-speed=10000
 Fields set here **override** live SNMP values per field; SNMP fills the rest
 ([enrichment ladder](../enrichment.md#the-enrichment-ladder)).
 
-:::tip Keep the inventory in its own file
+:::tip[Keep the inventory in its own file]
 
 Stock Spring lets you split the node map out of the main configuration:
 

--- a/docs/docs/deploy/linux-packages.md
+++ b/docs/docs/deploy/linux-packages.md
@@ -31,7 +31,7 @@ sudo dnf install https://github.com/Riptide-Labs/riptide/releases/download/v<ver
 dnf pulls `java-25-openjdk-headless` from AppStream; Temurin and Zulu 25 also satisfy the
 dependency.
 
-:::note Amazon Corretto on RPM systems
+:::note[Amazon Corretto on RPM systems]
 Corretto's rpm does not provide the `jre-25-headless` virtual the package depends on. If Corretto
 is your runtime, install the package with `rpm -i --nodeps` and manage the Java requirement
 yourself — or let dnf install `java-25-openjdk-headless` alongside.


### PR DESCRIPTION
## What

Titled admonitions were rendering as literal `:::note …` text instead of styled callouts (see the Corretto note on the Linux-packages page). Root cause: Docusaurus 3 / MDX 3 dropped the space-separated title form `:::note Title`; the title must now use bracket syntax `:::note[Title]`. Title-less admonitions were unaffected.

Fixes all three space-titled admonitions in the docs:
- `deploy/linux-packages.md` — Amazon Corretto note
- `configuration/nodes-and-snmp.md` — pin-key warning + inventory tip (pre-existing, same defect)

## Verification

`make docs` clean; in the built HTML all three now emit `theme-admonition` elements with zero literal `:::` remaining, and a repo-wide grep confirms no space-titled admonitions are left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)