### PR TITLE
docs: resolve version placeholder to the latest release at build time

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # tags needed so the docs build can resolve the latest release version
+          fetch-tags: true
+          fetch-depth: 0
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/docs/docs/deploy/linux-packages.md
+++ b/docs/docs/deploy/linux-packages.md
@@ -15,8 +15,8 @@ automatically from your distro or JDK-vendor repositories.
 **Debian / Ubuntu** (Debian 13+, Ubuntu 22.04+):
 
 ```bash
-curl -LO https://github.com/Riptide-Labs/riptide/releases/download/v<version>/riptide_<version>_all.deb
-sudo apt install ./riptide_<version>_all.deb
+curl -LO https://github.com/Riptide-Labs/riptide/releases/download/v%%VERSION%%/riptide_%%VERSION%%_all.deb
+sudo apt install ./riptide_%%VERSION%%_all.deb
 ```
 
 apt pulls `openjdk-25-jre-headless` from the distro archive if no Java 25 is present; an already
@@ -25,7 +25,7 @@ installed Temurin, Corretto, or Zulu 25 also satisfies the dependency.
 **RHEL / Rocky / Alma (9.7+, 10.1+) and Fedora (43+)** — dnf installs directly from the URL:
 
 ```bash
-sudo dnf install https://github.com/Riptide-Labs/riptide/releases/download/v<version>/riptide-<version>-1.noarch.rpm
+sudo dnf install https://github.com/Riptide-Labs/riptide/releases/download/v%%VERSION%%/riptide-%%VERSION%%-1.noarch.rpm
 ```
 
 dnf pulls `java-25-openjdk-headless` from AppStream; Temurin and Zulu 25 also satisfy the

--- a/docs/docs/deploy/plain-jar.md
+++ b/docs/docs/deploy/plain-jar.md
@@ -10,11 +10,12 @@ Riptide is a single Spring Boot jar. Requirements: **Java 25** and a reachable C
 On Debian/Ubuntu or RHEL-family systems, prefer the
 [DEB / RPM packages](linux-packages.md) — same jar, plus a managed systemd service.
 
-Download the jar from a [GitHub release](https://github.com/Riptide-Labs/riptide/releases)
+Download the jar from the latest [GitHub release](https://github.com/Riptide-Labs/riptide/releases)
 and run it:
 
 ```bash
-java -jar riptide-flows-<version>.jar
+curl -LO https://github.com/Riptide-Labs/riptide/releases/download/v%%VERSION%%/riptide-flows-%%VERSION%%.jar
+java -jar riptide-flows-%%VERSION%%.jar
 ```
 
 ## Configuration file

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -3,9 +3,42 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
+import {execSync} from 'child_process';
 import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 import {themes as prismThemes} from 'prism-react-renderer';
+
+// Latest published release version, resolved at build time so install commands
+// stay copy-paste-current without anyone editing the docs. Source of truth is
+// the highest `v*` git tag (CI checks out with fetch-tags); override with
+// RIPTIDE_DOCS_VERSION, and fall back to a literal for shallow/tag-less checkouts.
+function latestVersion(): string {
+  if (process.env.RIPTIDE_DOCS_VERSION) return process.env.RIPTIDE_DOCS_VERSION;
+  try {
+    const tags = execSync("git tag --list 'v*' --sort=-version:refname", {
+      encoding: 'utf8',
+    }).trim();
+    const top = tags.split('\n')[0]?.trim();
+    if (top) return top.replace(/^v/, '');
+  } catch {
+    /* no git / no tags — use the fallback below */
+  }
+  return '0.4.1';
+}
+
+// Substitutes the %%VERSION%% token in prose and code blocks. Dependency-free
+// mdast walk (avoids pulling in unist-util-visit).
+function remarkReplaceVersion({version}: {version: string}) {
+  const walk = (node: {value?: unknown; children?: unknown[]}) => {
+    if (typeof node.value === 'string' && node.value.includes('%%VERSION%%')) {
+      node.value = node.value.split('%%VERSION%%').join(version);
+    }
+    if (Array.isArray(node.children)) node.children.forEach(walk as never);
+  };
+  return (tree: unknown) => walk(tree as never);
+}
+
+const RIPTIDE_VERSION = latestVersion();
 
 const config: Config = {
   title: 'Riptide',
@@ -43,6 +76,7 @@ const config: Config = {
           routeBasePath: '/',
           sidebarPath: './sidebars.ts',
           editUrl: 'https://github.com/Riptide-Labs/riptide/tree/main/docs/',
+          remarkPlugins: [[remarkReplaceVersion, {version: RIPTIDE_VERSION}]],
         },
         blog: false,
         theme: {


### PR DESCRIPTION
## What

Install commands hardcoded a `<version>` placeholder readers had to look up and replace by hand. Now a `%%VERSION%%` token is substituted at build time with the latest published release, so the deb/rpm/jar commands are copy-paste-ready and stay current automatically.

- **Version source:** the highest `v*` git tag (`git tag --list 'v*' --sort=-version:refname`), resolved in `docusaurus.config.ts`. Override with `RIPTIDE_DOCS_VERSION`; falls back to a literal for shallow/tag-less checkouts.
- **Substitution:** a small dependency-free remark plugin replaces `%%VERSION%%` in prose and code blocks.
- **CI:** `docs.yml` now checks out with `fetch-tags`/`fetch-depth: 0` so the runner can resolve the tag.
- **Docs updated:** `deploy/linux-packages.md` (deb + rpm) and `deploy/plain-jar.md` (curl + run).

## Why not GitHub's `/releases/latest/download/` redirect

That would be even cleaner (no version at all), but it needs stable, version-less asset names, and **published releases are immutable** — I confirmed I can't add assets to v0.4.1. Stable-named assets could only appear on a future release, which would leave these docs 404-ing until then. The build-time variable works today against the existing (immutable) versioned assets.

## Verification

`make docs` clean; built HTML renders `v0.4.1` in all three commands with zero leftover `%%VERSION%%` or `<version>`; the resulting deb/rpm/jar URLs all return 302 to their assets.

Note: `operations.md`'s `:<version>` is intentionally left — it documents the container tag-pinning scheme, not a copy-paste command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)