### PR TITLE
docs: add ClickHouse access config to the package install page

### DIFF
--- a/docs/docs/deploy/linux-packages.md
+++ b/docs/docs/deploy/linux-packages.md
@@ -46,11 +46,44 @@ yourself — or let dnf install `java-25-openjdk-headless` alongside.
 | `/etc/riptide/config.yaml` | configuration (root:riptide 0640 — may hold credentials) |
 | `/etc/riptide/riptide.env` | JVM options and environment variables for the service |
 
-## Configure, enable, start
+## Configure ClickHouse access
 
-Installation is deliberately passive: nothing is enabled or started until Riptide can do something
-useful. Point `/etc/riptide/config.yaml` at your ClickHouse and define receivers — everything from
-the [configuration chapters](../configuration/receivers.md) goes there — then:
+Installation is deliberately passive: nothing starts until Riptide can reach a ClickHouse. Edit
+`/etc/riptide/config.yaml` (installed `root:riptide 0640`, so it may hold credentials) and point it
+at your database over the HTTP interface (port 8123):
+
+```yaml
+riptide:
+  clickhouse:
+    endpoint: http://clickhouse.example.com:8123
+    database: riptide
+    username: default
+    # password: left unset = the default user's empty password
+```
+
+By default Riptide manages its own schema (`manage-schema: true`), creating the `flows` table on
+first start — no manual DDL needed.
+
+For a password-protected user, prefer a [secret reference](../configuration/secret-references.md)
+over an inline literal so no plaintext lives in the file:
+
+```yaml
+riptide:
+  clickhouse:
+    endpoint: http://clickhouse.example.com:8123
+    database: riptide
+    username: riptide
+    password: vault://secret/riptide/clickhouse#password   # or env://, file://, sops://
+```
+
+A ClickHouse credential that cannot be resolved is **fatal at startup** (unlike SNMP, which
+degrades). See [ClickHouse configuration](../configuration/clickhouse.md) for schema ownership,
+multi-tenant write isolation, and the identity columns.
+
+## Enable and start
+
+Define at least one receiver in the same file (everything from the
+[configuration chapters](../configuration/receivers.md) goes there), then start the service:
 
 ```bash
 sudo systemctl enable --now riptide


### PR DESCRIPTION
## What

After installing the DEB/RPM package, the docs said to "point `/etc/riptide/config.yaml` at your ClickHouse" but never showed how — and the authoritative [ClickHouse reference](https://riptide.space/docs/configuration/clickhouse) uses `.properties` syntax, while the package ships a **YAML** `config.yaml`.

Adds a **Configure ClickHouse access** section to `deploy/linux-packages.md`, between install and enable/start, with concrete YAML for the package's `config.yaml`:
- endpoint (HTTP interface :8123), database, username, unset-password default
- the `manage-schema: true` default (schema auto-created, no manual DDL)
- the secret-reference form (`vault://`/`env://`/`file://`/`sops://`) for password-protected users, and that an unresolvable credential is fatal at startup
- a link to the full ClickHouse reference for schema ownership, multi-tenancy, and identity columns

The former "Configure, enable, start" section is split into "Configure ClickHouse access" and "Enable and start".

## Verification

`make docs` clean (so all internal links resolve — `onBrokenLinks: throw`); rendered text confirmed to contain the new section, the YAML endpoint, the secret reference, and the schema/startup notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)