### PR TITLE
fix: load external config via spring.config.import (closes #252)

### DIFF
--- a/src/main/java/org/riptide/config/ConfigFileReloader.java
+++ b/src/main/java/org/riptide/config/ConfigFileReloader.java
@@ -40,7 +40,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Opt-in hot-reload of the external config file ({@code spring.config.additional-location}):
+ * Opt-in hot-reload of the external config file ({@code spring.config.import}):
  * node and routing changes apply without a restart.
  *
  * <p><b>Trigger</b>: an mtime-independent content-hash poll — the path is re-resolved
@@ -53,7 +53,7 @@ import java.util.concurrent.TimeUnit;
  * live property-source stack with exactly the file layer swapped — environment-variable
  * overrides keep their boot-time precedence because the candidate bind runs the same
  * binder over the same sources. A file created after boot is inserted at the
- * additional-location slot: above classpath defaults, below environment variables.</p>
+ * imported-file slot: above classpath defaults, below environment variables.</p>
  *
  * <p><b>Failure semantics</b>: startup's validation rules run against the candidate;
  * a failing reload keeps serving the old config, warns naming the problem, and counts
@@ -113,7 +113,7 @@ public class ConfigFileReloader {
         }
         this.location = resolveLocation();
         if (this.location == null) {
-            log.warn("Config hot-reload requested but spring.config.additional-location is not a single file: location — disabled");
+            log.warn("Config hot-reload requested but spring.config.import is not a single file: location — disabled");
             return;
         }
         final long millis = this.properties.getReloadInterval().toMillis();
@@ -130,10 +130,12 @@ public class ConfigFileReloader {
         }
     }
 
-    /** The additional-location file, or {@code null} when there is none to watch. */
+    /** The imported config file, or {@code null} when there is none to watch. */
     private Path resolveLocation() {
-        final String raw = this.environment.getProperty("spring.config.additional-location", "");
-        // single location of the documented shape: optional:file:/etc/riptide/config.yaml
+        // spring.config.import (not additional-location, which Spring ignores when set
+        // inside the packaged application.properties) of the documented shape:
+        // optional:file:/etc/riptide/config.yaml
+        final String raw = this.environment.getProperty("spring.config.import", "");
         final String stripped = raw.replace("optional:", "").replace("file:", "").trim();
         if (stripped.isEmpty() || stripped.contains(",")) {
             return null;
@@ -254,7 +256,7 @@ public class ConfigFileReloader {
         return copy;
     }
 
-    /** Swaps the file layer in place, or inserts it at additional-location precedence. */
+    /** Swaps the file layer in place, or inserts it at the imported-file precedence. */
     private void substitute(final MutablePropertySources sources, final List<PropertySource<?>> fresh) {
         final String fileMarker = this.location.toString();
         String anchor = null;
@@ -275,7 +277,7 @@ public class ConfigFileReloader {
                 }
             }
         } else {
-            // file was absent at boot (optional:): insert where additional-location
+            // file was absent at boot (optional:): insert where the imported file
             // sits — above classpath defaults, below environment variables
             String classpathSource = null;
             for (final PropertySource<?> source : sources) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.main.banner-mode=off
 spring.main.web-application-type=none
 spring.main.keep-alive=true
 
-spring.config.additional-location=optional:file:/etc/riptide/config.yaml
+spring.config.import=optional:file:/etc/riptide/config.yaml
 
 # DAEMON
 # Receivers are empty by default: the daemon starts no listeners. Note that

--- a/src/test/java/org/riptide/config/ConfigFileReloaderTest.java
+++ b/src/test/java/org/riptide/config/ConfigFileReloaderTest.java
@@ -61,7 +61,7 @@ public class ConfigFileReloaderTest {
 
     @DynamicPropertySource
     static void reloadProperties(final DynamicPropertyRegistry registry) {
-        registry.add("spring.config.additional-location", () -> "optional:file:" + CONFIG);
+        registry.add("spring.config.import", () -> "optional:file:" + CONFIG);
         registry.add("riptide.config.reload-interval", () -> "1h");
         // stands in for the environment-variable layer: test properties outrank files
         registry.add("riptide.nodes.envnode.subnet-address", () -> "192.0.2.0/24");

--- a/src/test/java/org/riptide/config/ConfigFileReloaderTest.java
+++ b/src/test/java/org/riptide/config/ConfigFileReloaderTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Integration: the reloader's whole contract against a real Spring context. The
  * config file does not exist at boot (test property sources are applied after
  * ConfigData), so every test also exercises the file-created-after-boot insertion at
- * additional-location precedence. Polls are driven manually — the scheduled interval
+ * imported-file precedence. Polls are driven manually — the scheduled interval
  * is far in the future.
  */
 @SpringBootTest
@@ -269,7 +269,7 @@ public class ConfigFileReloaderTest {
     @Test
     public void fileInsertsAboveClasspathDefaults(@Autowired final org.springframework.core.env.ConfigurableEnvironment environment) throws Exception {
         // classpath application.properties sets riptide.snmp.cache.retentionMs=600000;
-        // the reloaded file must outrank it (additional-location precedence)
+        // the reloaded file must outrank it (imported-file precedence)
         write("""
                 riptide:
                   snmp:


### PR DESCRIPTION
Fixes #252.

## Problem

For every non-container deploy (DEB/RPM + systemd, NixOS module, plain `java -jar`), `/etc/riptide/config.yaml` was **silently ignored** — the app ran with packaged defaults and dialed ClickHouse at `localhost:8123` regardless of the file. Shipped in v0.4.1.

## Root cause

`application.properties` loaded the file with `spring.config.additional-location`, which Spring Boot does **not** honor when set inside a packaged config file (it only reads it from the environment/command line). So the location was never added.

## Fix

Switch to `spring.config.import=optional:file:/etc/riptide/config.yaml`, the mechanism designed to work from within a config file. `ConfigFileReloader` now resolves its watched file from `spring.config.import` too, so hot-reload keeps working. This fixes all launch paths at the jar level — no systemd-unit, Nix-module, or docs changes needed.

## Verification

Reproduced with the v0.4.1 release jar in a container (dialed `localhost:8123` despite a sentinel endpoint in `config.yaml`). After the fix:
- **with** `config.yaml` → dials the configured endpoint;
- **without** it → falls back to `localhost:8123` (the `optional:` prefix degrades gracefully);
- hot-reload logs `Config hot-reload enabled: watching /etc/riptide/config.yaml`.

Full suite green (656 tests, checkstyle/spotbugs clean). Medium code review run; one stale-comment finding applied.

## Workaround for existing v0.4.1 installs (no upgrade)

Add to `/etc/riptide/riptide.env` and `systemctl restart riptide` (the unit sources it; as an env var the location **is** honored):
```
SPRING_CONFIG_ADDITIONAL_LOCATION=optional:file:/etc/riptide/config.yaml
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)