### PR TITLE
fix: create the ClickHouse database in manage mode (closes #255)

### DIFF
--- a/docs/docs/configuration/clickhouse.md
+++ b/docs/docs/configuration/clickhouse.md
@@ -40,10 +40,12 @@ riptide.clickhouse.password=vault://secret/riptide/clickhouse/acme#password
 `riptide.clickhouse.manage-schema` (boolean, default `true`) selects who owns the schema:
 
 - **`true` (default, single-tenant)** — riptide ensures the schema idempotently at startup:
-  the `flows` table with `CREATE TABLE IF NOT EXISTS` (an existing table is not replaced, so
-  its data survives), and the `samples` view with `CREATE OR REPLACE VIEW` (a view holds no
-  data, so it is always refreshed and can never go stale). A fresh install is created; a
-  restart keeps the data — so **flow data now survives a Riptide restart**.
+  the database with `CREATE DATABASE IF NOT EXISTS` (so a fresh single-node install needs no
+  manual DDL — the configured user needs `CREATE` rights), the `flows` table with
+  `CREATE TABLE IF NOT EXISTS` (an existing table is not replaced, so its data survives), and
+  the `samples` view with `CREATE OR REPLACE VIEW` (a view holds no data, so it is always
+  refreshed and can never go stale). A fresh install is created; a restart keeps the data — so
+  **flow data now survives a Riptide restart**.
 - **`false` (provisioned / multi-tenant)** — riptide creates nothing. It validates that the
   `flows` table exists and carries every column it inserts and **fails startup with a clear,
   provisioning-pointing error** if it does not. Use this when an admin owns the schema and

--- a/docs/docs/deploy/linux-packages.md
+++ b/docs/docs/deploy/linux-packages.md
@@ -61,8 +61,8 @@ riptide:
     # password: left unset = the default user's empty password
 ```
 
-By default Riptide manages its own schema (`manage-schema: true`), creating the `flows` table on
-first start — no manual DDL needed.
+By default Riptide manages its own schema (`manage-schema: true`), creating the database and the
+`flows` table on first start — no manual DDL needed (the configured user needs `CREATE` rights).
 
 For a password-protected user, prefer a [secret reference](../configuration/secret-references.md)
 over an inline literal so no plaintext lives in the file:

--- a/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
+++ b/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
@@ -57,6 +57,10 @@ public class ClickhouseRepository implements FlowRepository {
 
     private final Client client;
 
+    // Retained so manage mode can open a second, unpinned client to create the database.
+    private final String username;
+    private final String password;
+
     @SneakyThrows
     public ClickhouseRepository(final FlowMapper flowMapper,
                                 final ClickhouseConfig config,
@@ -73,13 +77,13 @@ public class ClickhouseRepository implements FlowRepository {
         // fatal.
         final String resolvedUsername = secretResolvers.resolve(config.getUsername());
         final String resolvedPassword = secretResolvers.resolve(config.getPassword());
-        final String username = resolvedUsername != null ? resolvedUsername : "default";
-        final String password = resolvedPassword != null ? resolvedPassword : "";
+        this.username = resolvedUsername != null ? resolvedUsername : "default";
+        this.password = resolvedPassword != null ? resolvedPassword : "";
 
         this.client = new Client.Builder()
                 .addEndpoint(config.getEndpoint())
-                .setUsername(username)
-                .setPassword(password)
+                .setUsername(this.username)
+                .setPassword(this.password)
                 .setDefaultDatabase(config.getDatabase())
                 .compressClientRequest(true)
                 .compressServerResponse(true)
@@ -101,9 +105,12 @@ public class ClickhouseRepository implements FlowRepository {
     @SneakyThrows
     public void start() {
         if (this.config.isManageSchema()) {
-            // Manage mode: ensure the schema idempotently. IF NOT EXISTS means an existing flows
-            // table is not replaced, so previously persisted data survives a restart; the samples
-            // VIEW holds no data and is always refreshed (OR REPLACE) so it never goes stale.
+            // Manage mode: ensure the schema idempotently. The database comes first — the main
+            // client pins it via setDefaultDatabase, so DDL through it fails with UNKNOWN_DATABASE
+            // on a fresh server. Then IF NOT EXISTS means an existing flows table is not replaced,
+            // so previously persisted data survives a restart; the samples VIEW holds no data and is
+            // always refreshed (OR REPLACE) so it never goes stale.
+            ensureDatabase();
             this.client.execute(DDL_FLOWS).get();
             this.client.execute(DDL_SAMPLES).get();
         }
@@ -115,6 +122,27 @@ public class ClickhouseRepository implements FlowRepository {
         final TableSchema schema = checkSchema();
 
         this.client.register(ClickhouseFlow.class, schema);
+    }
+
+    /**
+     * Create the target database if it is absent. The main client is scoped to the configured
+     * database via {@code setDefaultDatabase}, so a {@code CREATE DATABASE} through it is rejected
+     * with {@code UNKNOWN_DATABASE} when the database does not exist yet. This opens a short-lived
+     * client that is not scoped to it (the always-present {@code default} database), so the
+     * statement runs. Manage mode owns the schema, so creating the database is part of that.
+     */
+    @SneakyThrows
+    private void ensureDatabase() {
+        try (Client bootstrap = new Client.Builder()
+                .addEndpoint(this.config.getEndpoint())
+                .setUsername(this.username)
+                .setPassword(this.password)
+                .setDefaultDatabase("default")
+                .compressClientRequest(true)
+                .compressServerResponse(true)
+                .build()) {
+            bootstrap.execute("CREATE DATABASE IF NOT EXISTS `" + this.config.getDatabase() + "`").get();
+        }
     }
 
     /**

--- a/src/test/java/org/riptide/repository/clickhouse/ClickhouseRepositoryIT.java
+++ b/src/test/java/org/riptide/repository/clickhouse/ClickhouseRepositoryIT.java
@@ -110,6 +110,22 @@ public class ClickhouseRepositoryIT {
     }
 
     @Test
+    void manageModeCreatesDatabaseOnFreshServer() throws Exception {
+        // A database the container did NOT pre-create and no test creates up front: manage mode
+        // must create the database itself, not just the flows table (regression for the
+        // UNKNOWN_DATABASE failure on a fresh single-node install).
+        final var config = configFor("fresh_managed", true);
+
+        final var repo = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), config, RESOLVERS);
+        Assertions.assertThatCode(repo::start).doesNotThrowAnyException();
+
+        repo.persist(List.of(testFlow(Instant.now().truncatedTo(ChronoUnit.MILLIS), 40001, 443, 99L)));
+        final var count = queryClient.queryAll("SELECT count() AS c FROM fresh_managed.flows")
+                .getFirst().getLong("c");
+        Assertions.assertThat(count).isEqualTo(1);
+    }
+
+    @Test
     void validateModeSucceedsWithProvisionedTable() {
         final var database = "validate_ok";
         queryClient.execute("CREATE DATABASE IF NOT EXISTS " + database).join();


### PR DESCRIPTION
Fixes #255.

## Problem

With `manage-schema=true` (default), a fresh single-node install failed at startup:

```
Code: 81. DB::Exception: Database riptide does not exist. (UNKNOWN_DATABASE)
```

manage mode created the `flows` table but not the **database**. The main client is pinned to the configured database (`setDefaultDatabase`), so its `CREATE TABLE` — and even a `CREATE DATABASE` — is rejected with `UNKNOWN_DATABASE` when the database is absent (verified against ClickHouse 26.x).

## Fix

In manage mode, run `CREATE DATABASE IF NOT EXISTS <database>` via a short-lived client scoped to the always-present `default` database, before the table DDL. Validate mode (admin owns the schema) is untouched.

## Test gap closed

`ClickhouseRepositoryIT` pre-created the database in every case (`CLICKHOUSE_DB=riptide`, plus explicit `CREATE DATABASE` per test), so the fresh-server manage path was never exercised. Added `manageModeCreatesDatabaseOnFreshServer`, which starts manage mode against a database the container did not pre-create.

## Verification

`ClickhouseRepositoryIT` 7/7 green (incl. the new regression); full unit suite 656 green, checkstyle/spotbugs clean; docs build clean.

Docs updated: manage mode now documented as creating the database and table (user needs `CREATE` rights).

## Workaround for existing installs

`CREATE DATABASE IF NOT EXISTS riptide;` then restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)