### PR TITLE
fix: tolerate trailing message padding in IPFIX/NetFlow-v9 parsing (closes #263)

### DIFF
--- a/src/main/java/org/riptide/flows/parser/ipfix/proto/Packet.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/proto/Packet.java
@@ -57,9 +57,16 @@ public final class Packet implements Iterable<FlowSet<?>> {
         final List<OptionsTemplateSet> parsedOptionTemplateSets = new ArrayList<>();
         final List<DataSet> parsedDataSets = new ArrayList<>();
 
-        while (buffer.isReadable()) {
+        // Stop once fewer than one Set header remains: a trailing remainder that small can only be
+        // message padding (some exporters pad to a 4-byte boundary), not a Set. Reading it as a Set
+        // would yield an invalid Set ID and drop the whole packet. (Matches goflow2 / NetGauze.)
+        while (buffer.readableBytes() >= FlowSetHeader.SIZE) {
             final ByteBuf headerBuffer = slice(buffer, FlowSetHeader.SIZE);
             final FlowSetHeader setHeader = new FlowSetHeader(headerBuffer);
+
+            if (setHeader.length < FlowSetHeader.SIZE) {
+                throw new InvalidPacketException(buffer, "Set length %d is smaller than the set header", setHeader.length);
+            }
 
             final ByteBuf payloadBuffer = slice(buffer, setHeader.length - FlowSetHeader.SIZE);
             switch (setHeader.getType()) {

--- a/src/main/java/org/riptide/flows/parser/netflow9/proto/Packet.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/proto/Packet.java
@@ -57,11 +57,18 @@ public final class Packet implements Iterable<FlowSet<?>> {
         final List<TemplateSet> parsedTemplateSets = new ArrayList<>();
         final List<OptionsTemplateSet> parsedOptionTemplateSets = new ArrayList<>();
         final List<DataSet> parsedDataSets = new ArrayList<>();
-        while (buffer.isReadable()) {
+        // Stop once fewer than one Set header remains: a trailing remainder that small can only be
+        // message padding (some exporters pad to a 4-byte boundary), not a Set. Reading it as a Set
+        // would yield an invalid Set ID and drop the whole packet. (Matches goflow2 / NetGauze.)
+        while (buffer.readableBytes() >= FlowSetHeader.SIZE) {
             // We ignore header.counter here, because different exporters interpret it as flowset count or record count
 
             final ByteBuf headerBuffer = slice(buffer, FlowSetHeader.SIZE);
             final FlowSetHeader setHeader = new FlowSetHeader(headerBuffer);
+
+            if (setHeader.length < FlowSetHeader.SIZE) {
+                throw new InvalidPacketException(buffer, "Set length %d is smaller than the set header", setHeader.length);
+            }
 
             final ByteBuf payloadBuffer = slice(buffer, setHeader.length - FlowSetHeader.SIZE);
             switch (setHeader.getType()) {

--- a/src/test/java/org/riptide/flows/ipfix/TrailingPaddingTest.java
+++ b/src/test/java/org/riptide/flows/ipfix/TrailingPaddingTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.ipfix;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.Test;
+import org.riptide.flows.parser.ipfix.proto.Header;
+import org.riptide.flows.parser.ipfix.proto.Packet;
+import org.riptide.flows.parser.session.SequenceNumberTracker;
+import org.riptide.flows.parser.session.Session;
+import org.riptide.flows.parser.session.TcpSession;
+
+import java.net.InetAddress;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.riptide.flows.utils.BufferUtils.slice;
+
+/**
+ * Some exporters pad the IPFIX message (e.g. to a 4-byte boundary), leaving a few trailing bytes
+ * after the last Set. The parser must ignore them instead of reading them as a Set (Set ID 0),
+ * which previously threw {@code Invalid set ID: 0} and dropped the whole packet.
+ */
+public class TrailingPaddingTest {
+
+    // Header(16) + Template Set(12) + Data Set(12) + 2 padding bytes = 42 bytes. The header length
+    // field (42) includes the padding, as a real exporter reports it.
+    private static final byte[] MESSAGE = {
+            // --- Message header ---
+            0x00, 0x0a,                                     // version 10 (IPFIX)
+            0x00, 0x2a,                                     // length 42 (incl. padding)
+            0x00, 0x00, 0x00, 0x01,                         // export time
+            0x00, 0x00, 0x00, 0x00,                         // sequence number
+            0x00, 0x00, 0x00, 0x00,                         // observation domain
+            // --- Template set (Set ID 2): template 256 = one octetDeltaCount (IE 1, 8 bytes) ---
+            0x00, 0x02, 0x00, 0x0c, 0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x08,
+            // --- Data set (Set ID 256): one record ---
+            0x01, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x2a,
+            // --- trailing message padding ---
+            0x00, 0x00,
+    };
+
+    @Test
+    void trailingPaddingDoesNotDropThePacket() throws Exception {
+        final Session session = new TcpSession(InetAddress.getLoopbackAddress(), () -> new SequenceNumberTracker(32));
+        final ByteBuf buf = Unpooled.wrappedBuffer(MESSAGE);
+        final var header = new Header(slice(buf, Header.SIZE));
+
+        assertThatCode(() -> {
+            final var packet = new Packet(session, header, slice(buf, header.length - Header.SIZE));
+            // The data set parsed — previously the whole packet was dropped with "Invalid set ID: 0".
+            assertThat(packet.dataRecordCount()).isEqualTo(1);
+        }).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
Fixes #263.

## Problem

Exporters that pad the IPFIX/NetFlow-v9 message (e.g. to a 4-byte boundary) left 1–3 trailing bytes after the last Set. The parse loop (`while (buffer.isReadable())`) read them as another Set header, got Set ID `0`, threw `InvalidPacketException`, and **dropped the whole packet** — silent flow loss (`WARN UdpListener : Invalid packet: Invalid set ID: 0, Offset: [len-2]`).

## Fix

Stop the set loop once fewer than one Set header (`FlowSetHeader.SIZE` = 4) remains, in both the IPFIX and NetFlow-v9 parsers. Verified against the reference implementations:
- **goflow2** (`decoders/netflow/netflow.go`): `for i := 0; payload.Len() >= headerSize && ...` (headerSize = 4) — ignores trailing 1–3 padding bytes.
- **NetGauze** (`crates/flow-pkt/.../netflow.rs`): `while i > 0 && buf.len() > 3`.

Message-length bounding is already in place — the parser is handed a buffer sliced to `header.payloadLength()`. Also added a defensive `Set length >= 4` check (clear error instead of an opaque negative slice), matching NetGauze.

## Verification

New `TrailingPaddingTest`: a hand-built IPFIX message (template + data set + 2 padding bytes, header length includes the padding) now parses and yields its data record, where it previously threw `Invalid set ID: 0`. Full suite 661 green; checkstyle/spotbugs clean. No behaviour change for conformant packets — a < 4-byte remainder was never a valid Set.

Rolling into the pending v0.4.5 alongside the sequence-number fix (#262).

🤖 Generated with [Claude Code](https://claude.com/claude-code)