### PR TITLE
feat: liveness/readiness health endpoints for Kubernetes probes (#242)

### DIFF
--- a/deployment/riptide/compose.yml
+++ b/deployment/riptide/compose.yml
@@ -17,4 +17,11 @@ services:
       RIPTIDE_CLICKHOUSE_DATABASE: riptide
     ports:
       - "9999:9999/udp"
+    healthcheck:
+      # BusyBox wget is present in the temurin-alpine image; /readyz is 200 once receivers are listening
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/readyz"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 20s
 

--- a/docs/docs/deploy/operations.md
+++ b/docs/docs/deploy/operations.md
@@ -71,9 +71,44 @@ restart. Configuration is backward-compatible within a minor line; breaking conf
 moves are logged loudly at startup (e.g. the pre-0.1.0 `riptide.snmp.config.definitions`
 tree logs an explicit error pointing at `riptide.nodes`).
 
+## Health endpoints & probes
+
+Riptide serves two plain-HTTP health endpoints on a management port (default `8080`) — no auth, no
+TLS, cluster-internal. They're built on the JDK HTTP server, so the collector stays headless (no
+application web server).
+
+| Endpoint | Meaning |
+|---|---|
+| `GET /livez` | **Liveness** — the receiver event loops are alive. Returns `200` while booting and once running; `503` only if a started receiver's socket has died. **Never** checks ClickHouse. |
+| `GET /readyz` | **Readiness** — all configured receivers are bound and listening (`200`), else `503`. |
+
+Configure via `riptide.management.*`:
+
+```properties
+riptide.management.enabled=true       # set false to disable the endpoints entirely
+riptide.management.port=8080
+riptide.management.bind-address=0.0.0.0
+```
+
+**Readiness deliberately excludes ClickHouse.** There is no write buffer and a single collector has
+no failover, so making the collector "not ready" during a ClickHouse blip would only drain the load
+balancer (with `externalTrafficPolicy: Local`) and lose *more* flows at the edges — for no benefit.
+Readiness reflects receiver health only; a ClickHouse outage keeps the collector receiving.
+
+Kubernetes probe mapping:
+
+```yaml
+startupProbe:   { httpGet: { path: /readyz, port: 8080 }, failureThreshold: 30, periodSeconds: 2 }
+livenessProbe:  { httpGet: { path: /livez,  port: 8080 } }
+readinessProbe: { httpGet: { path: /readyz, port: 8080 } }
+```
+
+The Compose stack uses `/readyz` as the service `healthcheck` (via the image's BusyBox `wget`).
+
 ## Ports
 
 | Port | Protocol | What |
 |---|---|---|
 | `9999/udp` | NetFlow/IPFIX | default flow ingest (container `EXPOSE`; receivers are configurable) |
+| `8080` | HTTP | management / health endpoints (`/livez`, `/readyz`) |
 | `8123` | HTTP | ClickHouse (stack-internal unless you expose it) |

--- a/src/main/java/org/riptide/flows/Daemon.java
+++ b/src/main/java/org/riptide/flows/Daemon.java
@@ -44,6 +44,10 @@ public class Daemon implements ApplicationRunner {
     private final List<Listener> listeners;
     private final Pipeline pipeline;
 
+    // Set once the receivers have been started, so health checks can tell "still booting" (live but
+    // not ready) apart from "a started receiver has died" (not live).
+    private volatile boolean started;
+
     public Daemon(final Pipeline pipeline,
                   final MetricRegistry metricRegistry,
                   @Qualifier("ipfixValueConversionService") final ValueConversionService ipfixValueConversionService,
@@ -170,11 +174,23 @@ public class Daemon implements ApplicationRunner {
     public void run(final ApplicationArguments args) throws Exception {
         this.pipeline.start();
         this.listeners.forEach(Listener::start);
+        this.started = true;
     }
 
     @PreDestroy
     public void stop() throws Exception {
+        this.started = false;
         this.pipeline.stop();
         this.listeners.forEach(Listener::stop);
+    }
+
+    /** The configured receivers, for health reporting. */
+    public List<Listener> getListeners() {
+        return this.listeners;
+    }
+
+    /** Whether the receivers have been started (i.e. {@link #run} has completed). */
+    public boolean isStarted() {
+        return this.started;
     }
 }

--- a/src/main/java/org/riptide/flows/listeners/Listener.java
+++ b/src/main/java/org/riptide/flows/listeners/Listener.java
@@ -19,4 +19,11 @@ public interface Listener {
     String getDescription();
     void start();
     void stop();
+
+    /**
+     * Whether this receiver is currently bound and its socket active — i.e. its event loop is alive
+     * and serving the channel. Used by the management health endpoints. Returns {@code false} before
+     * {@link #start()} and after {@link #stop()}, or if the channel has died.
+     */
+    boolean isListening();
 }

--- a/src/main/java/org/riptide/flows/listeners/TcpListener.java
+++ b/src/main/java/org/riptide/flows/listeners/TcpListener.java
@@ -179,6 +179,11 @@ public class TcpListener implements Listener {
         return String.format("TCP %s:%s",  this.host != null ? this.host : "*", this.port);
     }
 
+    @Override
+    public boolean isListening() {
+        return this.socketFuture != null && this.socketFuture.channel().isActive();
+    }
+
     public TcpListener withHost(final String host) {
         this.host = host;
         return this;

--- a/src/main/java/org/riptide/flows/listeners/UdpListener.java
+++ b/src/main/java/org/riptide/flows/listeners/UdpListener.java
@@ -97,6 +97,11 @@ public class UdpListener implements Listener {
         }
     }
 
+    @Override
+    public boolean isListening() {
+        return this.socketFuture != null && this.socketFuture.channel().isActive();
+    }
+
     public UdpListener withHost(String host) {
         this.host = host;
         return this;

--- a/src/main/java/org/riptide/management/Health.java
+++ b/src/main/java/org/riptide/management/Health.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.management;
+
+/** Result of a health check: whether the aspect is up, plus a terse human-readable detail. */
+public record Health(boolean up, String detail) {
+    public static Health up(final String detail) {
+        return new Health(true, detail);
+    }
+
+    public static Health down(final String detail) {
+        return new Health(false, detail);
+    }
+}

--- a/src/main/java/org/riptide/management/HealthService.java
+++ b/src/main/java/org/riptide/management/HealthService.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.management;
+
+import org.riptide.flows.Daemon;
+import org.riptide.flows.listeners.Listener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Evaluates collector health for the management endpoints. Deliberately never references ClickHouse:
+ * there is no write buffer and a single collector has no failover, so gating readiness on ClickHouse
+ * would only add load-balancer convergence loss for no benefit (see the add-health-endpoints design).
+ */
+@Component
+public class HealthService {
+
+    private final Daemon daemon;
+
+    public HealthService(final Daemon daemon) {
+        this.daemon = daemon;
+    }
+
+    /**
+     * Process-level liveness: booting is not a fatal state, so it stays up until the receivers have
+     * been started; after that, a receiver whose socket has died is a fatal state warranting a restart.
+     */
+    public Health liveness() {
+        if (!this.daemon.isStarted()) {
+            return Health.up("starting");
+        }
+        return receivers();
+    }
+
+    /** Readiness: the collector can do useful work — it has started and every receiver is listening. */
+    public Health readiness() {
+        if (!this.daemon.isStarted()) {
+            return Health.down("starting");
+        }
+        return receivers();
+    }
+
+    private Health receivers() {
+        final var down = this.daemon.getListeners().stream()
+                .filter(listener -> !listener.isListening())
+                .map(Listener::getName)
+                .toList();
+        return down.isEmpty()
+                ? Health.up("receivers listening")
+                : Health.down("receivers not listening: " + String.join(",", down));
+    }
+}

--- a/src/main/java/org/riptide/management/ManagementServer.java
+++ b/src/main/java/org/riptide/management/ManagementServer.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.management;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * A minimal HTTP server (JDK {@link HttpServer}, no web application server) exposing {@code /livez}
+ * and {@code /readyz} on the management port for Kubernetes probes and Docker Compose health checks.
+ */
+@Slf4j
+@Component
+public class ManagementServer {
+
+    private final RiptideManagementProperties properties;
+    private final HealthService health;
+
+    private HttpServer server;
+    private ExecutorService executor;
+
+    public ManagementServer(final RiptideManagementProperties properties, final HealthService health) {
+        this.properties = properties;
+        this.health = health;
+    }
+
+    @PostConstruct
+    void start() throws IOException {
+        if (!this.properties.isEnabled()) {
+            log.info("Management server disabled (riptide.management.enabled=false)");
+            return;
+        }
+
+        this.server = HttpServer.create(
+                new InetSocketAddress(this.properties.getBindAddress(), this.properties.getPort()), 0);
+        this.executor = Executors.newFixedThreadPool(2, new ThreadFactoryBuilder()
+                .setNameFormat("management-http-%d")
+                .setDaemon(true)
+                .build());
+        this.server.setExecutor(this.executor);
+        this.server.createContext("/livez", exchange -> respond(exchange, this.health.liveness()));
+        this.server.createContext("/readyz", exchange -> respond(exchange, this.health.readiness()));
+        this.server.start();
+
+        log.info("Management server listening on {}:{} (/livez, /readyz)",
+                this.properties.getBindAddress(), this.properties.getPort());
+    }
+
+    @PreDestroy
+    void stop() {
+        if (this.server != null) {
+            this.server.stop(0);
+        }
+        if (this.executor != null) {
+            // stop() does not shut down a user-set executor
+            this.executor.shutdownNow();
+        }
+    }
+
+    private static void respond(final HttpExchange exchange, final Health health) throws IOException {
+        final byte[] body = ((health.up() ? "ok" : "unavailable") + ": " + health.detail() + "\n")
+                .getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "text/plain; charset=utf-8");
+        exchange.sendResponseHeaders(health.up() ? 200 : 503, body.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(body);
+        }
+    }
+}

--- a/src/main/java/org/riptide/management/RiptideManagementProperties.java
+++ b/src/main/java/org/riptide/management/RiptideManagementProperties.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.management;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** Management HTTP server (health endpoints) configuration. */
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "riptide.management")
+public class RiptideManagementProperties {
+
+    /** Serve the management HTTP endpoints ({@code /livez}, {@code /readyz}). */
+    private boolean enabled = true;
+
+    /** Management HTTP port. */
+    private int port = 8080;
+
+    /** Bind address; defaults to all interfaces so a kubelet can probe the pod IP. */
+    private String bindAddress = "0.0.0.0";
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -54,3 +54,11 @@ riptide.snmp.cache.retentionMs=600000
 
 # ENRICHER: HOSTNAMES
 riptide.enricher.hostnames.enabled=false
+
+# MANAGEMENT
+# Plain-HTTP health endpoints for Kubernetes probes / Docker Compose healthchecks:
+#   GET /livez  — process liveness (receiver event loops alive); never touches ClickHouse
+#   GET /readyz — readiness (all receivers bound and listening); excludes ClickHouse by design
+riptide.management.enabled=true
+riptide.management.port=8080
+riptide.management.bind-address=0.0.0.0

--- a/src/test/java/org/riptide/management/ManagementServerTest.java
+++ b/src/test/java/org/riptide/management/ManagementServerTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.management;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.riptide.flows.Daemon;
+import org.riptide.flows.listeners.Listener;
+
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Exercises the real management HTTP server end to end. There is no ClickHouse anywhere in the setup,
+ * which demonstrates the endpoints are ClickHouse-independent by construction.
+ */
+class ManagementServerTest {
+
+    private ManagementServer server;
+
+    @AfterEach
+    void tearDown() {
+        if (this.server != null) {
+            this.server.stop();
+        }
+    }
+
+    private int start(final Daemon daemon) throws Exception {
+        final int port;
+        try (ServerSocket probe = new ServerSocket(0)) {
+            port = probe.getLocalPort();
+        }
+        final var properties = new RiptideManagementProperties();
+        properties.setPort(port);
+        properties.setBindAddress("127.0.0.1");
+
+        this.server = new ManagementServer(properties, new HealthService(daemon));
+        this.server.start();
+        return port;
+    }
+
+    private int status(final int port, final String path) throws Exception {
+        final HttpResponse<String> response = HttpClient.newHttpClient().send(
+                HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + path)).GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+        return response.statusCode();
+    }
+
+    @Test
+    void liveAndReadyWhenReceiversListening() throws Exception {
+        final Listener listener = mock(Listener.class);
+        when(listener.isListening()).thenReturn(true);
+        final Daemon daemon = mock(Daemon.class);
+        when(daemon.isStarted()).thenReturn(true);
+        when(daemon.getListeners()).thenReturn(List.of(listener));
+
+        final int port = start(daemon);
+        assertThat(status(port, "/livez")).isEqualTo(200);
+        assertThat(status(port, "/readyz")).isEqualTo(200);
+    }
+
+    @Test
+    void unavailableWhenAReceiverDied() throws Exception {
+        final Listener listener = mock(Listener.class);
+        lenient().when(listener.getName()).thenReturn("ipfix");
+        when(listener.isListening()).thenReturn(false);
+        final Daemon daemon = mock(Daemon.class);
+        when(daemon.isStarted()).thenReturn(true);
+        when(daemon.getListeners()).thenReturn(List.of(listener));
+
+        final int port = start(daemon);
+        // a started receiver whose socket died is both not-live (restart) and not-ready
+        assertThat(status(port, "/livez")).isEqualTo(503);
+        assertThat(status(port, "/readyz")).isEqualTo(503);
+    }
+
+    @Test
+    void liveButNotReadyWhileStarting() throws Exception {
+        final Daemon daemon = mock(Daemon.class);
+        when(daemon.isStarted()).thenReturn(false);
+
+        final int port = start(daemon);
+        assertThat(status(port, "/livez")).isEqualTo(200);   // booting is not a fatal state
+        assertThat(status(port, "/readyz")).isEqualTo(503);  // not ready until receivers are up
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,13 @@
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Test defaults. ClickHouse/receiver knobs fall back to their @ConfigurationProperties field
+# defaults (NoopRepository stands in for persistence under the non-e2e profile).
+
+# The management HTTP server binds a fixed port; disable it so cached @SpringBootTest contexts
+# don't collide on it. ManagementServerTest exercises the real server directly on an ephemeral port.
+riptide.management.enabled=false
+
+# Keep runtime behaviour identical to production for tests that boot the context.
+spring.main.web-application-type=none
+riptide.enricher.hostnames.enabled=false


### PR DESCRIPTION
Resolves #242.

## What

A tiny management HTTP server on a dedicated port so Kubernetes (and Docker Compose) can probe the otherwise-headless UDP collector — built on the JDK `com.sun.net.httpserver` (**no new dependency**, stays `web-application-type=none`, consistent with the app's Dropwizard metrics rather than pulling in actuator/Micrometer).

- `GET /livez` — process liveness: receiver event loops alive. `200` while booting and once running; `503` only if a *started* receiver's socket has died. **Never** touches ClickHouse (a ClickHouse outage must not cause kubelet restart storms).
- `GET /readyz` — readiness: all configured receivers bound and listening (`200`/`503`).
- Config `riptide.management.*` (`enabled`/`port`/`bind-address`), a `/readyz` Compose `healthcheck` (BusyBox `wget`), and operations docs with the k8s probe mapping.

## The design decision (readiness excludes ClickHouse)

The issue left this open. Grounding it in the code settles it: `Pipeline.process` has **no write buffer** (persist failure logs and drops), and backpressure blocks the Netty event loop so a ClickHouse slowdown already drops UDP at the kernel. With no buffer and no failover (single collector), gating readiness on ClickHouse yields identical data loss **plus** load-balancer convergence flap (`externalTrafficPolicy: Local`) — strictly worse. So readiness is receiver/process health only; a spool that would make readiness dynamically meaningful is filed as a follow-up (non-goal here).

Probe mapping (in the docs): `startupProbe`+`readinessProbe` → `/readyz`, `livenessProbe` → `/livez`.

## Verification

Full suite **664 green**, checkstyle/spotbugs clean, docs build clean. `ManagementServerTest` (3 cases on an ephemeral port) covers live+ready, 503 when a receiver died, and live-but-not-ready while starting — all with **no ClickHouse**, proving independence. Confirmed empirically that BusyBox `wget` exits `1` on `503`/`0` on `200`, so the Compose healthcheck actually gates.

## Reviewer note

`src/test/resources/application.properties` is **new** and shadows the main one to set `riptide.management.enabled=false` — every `@SpringBootTest` otherwise binds the fixed management port and cached contexts collide (`ManagementServerTest` uses the real server on an ephemeral port instead). `ClickhouseConfig`/receiver knobs have field defaults so nothing else breaks, but it's a drift trap: a future main-only default won't reach tests. A `@Primary`-bean override was tried first and didn't take; this is the reliable path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)