### PR TITLE
feat: onboard provisions the flows schema (#246)

### DIFF
--- a/docs/docs/configuration/clickhouse.md
+++ b/docs/docs/configuration/clickhouse.md
@@ -46,10 +46,12 @@ riptide.clickhouse.password=vault://secret/riptide/clickhouse/acme#password
   the `samples` view with `CREATE OR REPLACE VIEW` (a view holds no data, so it is always
   refreshed and can never go stale). A fresh install is created; a restart keeps the data — so
   **flow data now survives a Riptide restart**.
-- **`false` (provisioned / multi-tenant)** — riptide creates nothing. It validates that the
+- **`false` (provisioned / multi-tenant)** — the collector creates nothing. It validates that the
   `flows` table exists and carries every column it inserts and **fails startup with a clear,
   provisioning-pointing error** if it does not. Use this when an admin owns the schema and
-  RBAC and each riptide process is a narrowly-scoped writer that only uses the table.
+  RBAC and each riptide process is a narrowly-scoped writer that only uses the table. The admin-side
+  [`onboard` subcommand](../deploy/multi-tenancy.md#what-it-provisions) creates the database and
+  `flows` table as part of provisioning, so this mode needs no separate manual schema step.
 
 In both modes, startup verifies the `flows` table is present and carries every column riptide
 inserts (including the `tenant`/`organisation`/`zone`/`system` identity columns) by reading the

--- a/docs/docs/deploy/multi-tenancy.md
+++ b/docs/docs/deploy/multi-tenancy.md
@@ -59,8 +59,10 @@ for filtering. All four are riptide-populated columns.
 
 - The `SQL_` custom-settings prefix enabled (write-barrier requirement) — see the
   [server requirement](../configuration/clickhouse.md#server-requirement).
-- The `flows` table provisioned by an admin, with riptide running in
-  [validate mode](../configuration/clickhouse.md#schema-ownership) (`manage-schema=false`).
+- Riptide running in [validate mode](../configuration/clickhouse.md#schema-ownership)
+  (`manage-schema=false`). The `flows` schema itself needs no manual step — `onboard` creates the
+  database and `flows` table (see [What it provisions](#what-it-provisions)) before it grants and
+  constrains them.
 
 ## Onboard a tenant
 
@@ -96,12 +98,16 @@ row policy; the shared roles/constraints/quota stay).
 
 ### What it provisions
 
-The recipe is **role-based**: the grants, the reader hardening, the CHECK barrier, and the quota are
-one-time objects, so per-tenant reduces to the scoped users + role grants + one literal row policy.
-`onboard` ensures the one-time objects on first run and adds the per-tenant part:
+The recipe is **role-based**: the schema, the grants, the reader hardening, the CHECK barrier, and
+the quota are one-time objects, so per-tenant reduces to the scoped users + role grants + one literal
+row policy. `onboard` ensures the one-time objects on first run and adds the per-tenant part:
 
 ```sql
--- Once per cluster (idempotent): roles carry every per-tenant grant and the reader hardening.
+-- Once per cluster (idempotent): onboard first creates the schema it depends on, so a fresh
+-- provisioned database needs no manual step. IF NOT EXISTS leaves an existing table untouched.
+CREATE DATABASE IF NOT EXISTS riptide;
+CREATE TABLE IF NOT EXISTS riptide.flows (…);  -- full column definition — see the ClickHouse deployment docs
+-- Roles carry every per-tenant grant and the reader hardening.
 CREATE ROLE IF NOT EXISTS flow_writer;
 GRANT INSERT ON riptide.flows TO flow_writer;
 CREATE ROLE IF NOT EXISTS flow_reader;

--- a/src/main/java/org/riptide/provisioning/ProvisioningDdl.java
+++ b/src/main/java/org/riptide/provisioning/ProvisioningDdl.java
@@ -5,6 +5,8 @@
 
 package org.riptide.provisioning;
 
+import org.riptide.schema.FlowsSchema;
+
 import java.util.List;
 
 /**
@@ -12,9 +14,9 @@ import java.util.List;
  * whole recipe is one auditable place and lifts cleanly into a future {@code riptide-admin} module.
  *
  * <p>The model puts every identical-per-tenant part into one-time objects ({@link #ensureShared})
- * — the {@code flow_writer}/{@code flow_reader} roles carry the grants and the reader hardening,
- * and a single quota is keyed by user — so {@link #onboardTenant} reduces to the scoped users, two
- * role grants, and one literal row policy. All statements are idempotent
+ * — the {@code flows} schema, the {@code flow_writer}/{@code flow_reader} roles carrying the grants
+ * and the reader hardening, and a single quota keyed by user — so {@link #onboardTenant} reduces to
+ * the scoped users, two role grants, and one literal row policy. All statements are idempotent
  * ({@code IF NOT EXISTS} / {@code ALTER ROLE SETTINGS}), verified on ClickHouse 25.3.
  *
  * <p>Tenant/org names are validated ({@link TenantSpec}) to a safe charset; generated identifiers
@@ -25,10 +27,18 @@ public final class ProvisioningDdl {
     private ProvisioningDdl() {
     }
 
-    /** One-time shared objects: the two roles, the reader hardening, the CHECK barrier, the quota. */
+    /**
+     * One-time shared objects: the database and {@code flows} table (so onboarding a fresh
+     * provisioned deployment is self-sufficient — the collector only validates in
+     * {@code manage-schema=false} mode), then the two roles, the reader hardening, the CHECK
+     * barrier, and the quota. The schema DDL comes first because the {@code GRANT INSERT} and
+     * {@code ALTER TABLE … ADD CONSTRAINT} below require the table to exist.
+     */
     public static List<String> ensureShared(final String database, final long quotaBytes) {
         final String flows = ident(database) + ".flows";
         return List.of(
+                FlowsSchema.createDatabase(database),
+                FlowsSchema.createFlowsTable(database),
                 "CREATE ROLE IF NOT EXISTS flow_writer",
                 "GRANT INSERT ON " + flows + " TO flow_writer",
                 "CREATE ROLE IF NOT EXISTS flow_reader",

--- a/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
+++ b/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
@@ -9,7 +9,6 @@ package org.riptide.repository.clickhouse;
 import com.clickhouse.client.api.Client;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.intellij.lang.annotations.Language;
 import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.NullValueCheckStrategy;
@@ -20,6 +19,7 @@ import org.riptide.pipeline.FlowException;
 import com.clickhouse.client.api.metadata.TableSchema;
 import com.clickhouse.data.ClickHouseColumn;
 import org.riptide.repository.FlowRepository;
+import org.riptide.schema.FlowsSchema;
 import org.riptide.secrets.SecretResolvers;
 
 import java.io.IOException;
@@ -111,8 +111,8 @@ public class ClickhouseRepository implements FlowRepository {
             // so previously persisted data survives a restart; the samples VIEW holds no data and is
             // always refreshed (OR REPLACE) so it never goes stale.
             ensureDatabase();
-            this.client.execute(DDL_FLOWS).get();
-            this.client.execute(DDL_SAMPLES).get();
+            this.client.execute(FlowsSchema.createFlowsTable(this.config.getDatabase())).get();
+            this.client.execute(FlowsSchema.createSamplesView(this.config.getDatabase())).get();
         }
 
         // Both modes: the flows table must exist and carry every column riptide inserts. Fail-fast
@@ -141,7 +141,7 @@ public class ClickhouseRepository implements FlowRepository {
                 .compressClientRequest(true)
                 .compressServerResponse(true)
                 .build()) {
-            bootstrap.execute("CREATE DATABASE IF NOT EXISTS `" + this.config.getDatabase() + "`").get();
+            bootstrap.execute(FlowsSchema.createDatabase(this.config.getDatabase())).get();
         }
     }
 
@@ -188,152 +188,6 @@ public class ClickhouseRepository implements FlowRepository {
         }
         return schema;
     }
-
-    @Language("ClickHouse")
-    private static final String DDL_FLOWS = """
-        CREATE TABLE IF NOT EXISTS flows (
-            timestamp DateTime64(3),
-    
-            flowProtocol Enum8(
-                'NetflowV5' = 1,
-                'NetflowV9' = 2,
-                'IPFIX' = 3,
-                'SFLOW' = 4
-            ),
-    
-            tenant String,
-            organisation String,
-            zone String,
-            system String,
-            exporterAddr String,
-    
-            receivedAt DateTime64(9),
-    
-            firstSwitched DateTime64(9),
-            deltaSwitched DateTime64(9),
-            lastSwitched DateTime64(9),
-    
-            inputSnmp UInt32,
-            inputSnmpIfName Nullable(String),
-            inputSnmpIfAlias Nullable(String),
-            inputSnmpIfSpeed Nullable(UInt32),
-    
-            outputSnmp UInt32,
-            outputSnmpIfName Nullable(String),
-            outputSnmpIfAlias Nullable(String),
-            outputSnmpIfSpeed Nullable(UInt32),
-    
-            srcAs UInt64,
-            srcAsOrg Nullable(String),
-            srcAddr IPv6,
-            srcMaskLen UInt8,
-            srcAddrHostname Nullable(String),
-            srcPort UInt16,
-    
-            dstAs UInt64,
-            dstAsOrg Nullable(String),
-            dstAddr IPv6,
-            dstMaskLen UInt8,
-            dstAddrHostname Nullable(String),
-            dstPort UInt16,
-    
-            nextHop Nullable(IPv6),
-            nextHopHostname Nullable(String),
-    
-            bytes UInt64,
-            packets UInt64,
-    
-            direction Enum8('INGRESS' = 1, 'EGRESS' = 2, 'UNKNOWN' = 3),
-    
-            engineId UInt32,
-            engineType UInt16,
-    
-            vlan UInt16,
-            ipProtocolVersion UInt8,
-            protocol UInt8,
-            tcpFlags UInt8,
-            tos UInt8,
-    
-            samplingAlgorithm Enum8(
-                'Unassigned' = 1,
-                'SystematicCountBasedSampling' = 2,
-                'SystematicTimeBasedSampling' = 3,
-                'RandomNOutOfNSampling' = 4,
-                'UniformProbabilisticSampling' = 5,
-                'PropertyMatchFiltering' = 6,
-                'HashBasedFiltering' = 7,
-                'FlowStateDependentIntermediateFlowSelectionProcess' = 8
-            ),\s
-            samplingInterval Float64,
-    
-            application Nullable(String),
-    
-            srcLocality Enum8('PUBLIC' = 1, 'PRIVATE' = 2),
-            dstLocality Enum8('PUBLIC' = 1, 'PRIVATE' = 2),
-            flowLocality Enum8('PUBLIC' = 1, 'PRIVATE' = 2),
-    
-            clockCorrection Nullable(Int64)
-        ) ENGINE = MergeTree()
-        ORDER BY (
-            tenant, organisation,
-            toStartOfHour(timestamp),
-            srcAs, dstAs,
-            srcAddr, dstAddr,
-            srcPort, dstPort
-        )
-        PARTITION BY toYYYYMMDD(timestamp)
-        TTL toDateTime(timestamp) + INTERVAL 30 DAY
-        SETTINGS index_granularity = 8192;
-    """;
-
-    @Language("ClickHouse")
-    private static final String DDL_SAMPLES = """
-        CREATE OR REPLACE VIEW samples AS
-        WITH
-            toInt64({ival:Int64} * 1e9) AS interval_ns,
-    
-            -- Find first and last absolute bucket numbers
-            toUInt64(toUnixTimestamp64Nano(deltaSwitched) / interval_ns) as first_bucket,
-            toUInt64(toUnixTimestamp64Nano(lastSwitched) / interval_ns) as last_bucket,
-    
-            last_bucket - first_bucket + 1 as bucket_count,
-    
-            -- Calculate total duration in nanoseconds
-            age('ns', deltaSwitched, lastSwitched) as flow_duration,
-    
-            -- Generate buckets from the first bucket onward
-            range(toUInt32(bucket_count)) AS buckets,
-    
-            -- Determine the fraction of the interval used in each case
-            CASE
-                -- Only one bucket
-                WHEN bucket_count = 1
-                    THEN 1.0
-    
-                -- First bucket: Portion from start time to the next bucket boundary
-                WHEN bucket = 0
-                    THEN ((interval_ns * (first_bucket + 1)) - toUnixTimestamp64Nano(deltaSwitched)) / interval_ns
-    
-                -- Last bucket: Portion from the start of the last bucket to end time
-                WHEN bucket = bucket_count - 1
-                    THEN (toUnixTimestamp64Nano(lastSwitched) - (interval_ns * last_bucket)) / interval_ns
-    
-                -- Full buckets in between
-                ELSE 1.0
-                END AS bucket_fraction
-    
-        SELECT
-            flow.*,
-    
-            fromUnixTimestamp64Nano((first_bucket + bucket) * interval_ns) AS timestamp,
-    
-            bytes * bucket_fraction / toFloat64(bucket_count) as bytes,
-            packets * bucket_fraction / toFloat64(bucket_count) as packets
-    
-        FROM flows AS flow
-        ARRAY JOIN buckets AS bucket
-        ORDER BY timestamp;
-    """;
 
     @Mapper(nullValueCheckStrategy = NullValueCheckStrategy.ALWAYS,
             componentModel = "spring")

--- a/src/main/java/org/riptide/schema/FlowsSchema.java
+++ b/src/main/java/org/riptide/schema/FlowsSchema.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.schema;
+
+import org.intellij.lang.annotations.Language;
+
+/**
+ * The one definition of riptide's ClickHouse flow schema — the {@code flows} table and the
+ * {@code samples} view — as database-qualified, idempotent DDL. Pure string builders (no I/O), so
+ * both consumers share one source and cannot drift:
+ *
+ * <ul>
+ *   <li>the collector's manage-schema path ({@code ClickhouseRepository}) creates the database,
+ *       table, and view;</li>
+ *   <li>{@code onboard} ({@code ProvisioningDdl.ensureShared}) creates the database and table so a
+ *       provisioned deployment can be onboarded before any {@code GRANT}/{@code ALTER} that needs
+ *       the table to exist.</li>
+ * </ul>
+ *
+ * <p>Every statement names {@code `<db>`.flows} / {@code `<db>`.samples} explicitly rather than
+ * relying on a client's default-database pinning, so the same DDL runs correctly on the collector's
+ * pinned client and on an unpinned admin client. The database name is backtick-quoted; callers pass
+ * a validated name.
+ *
+ * <p>The {@code samples} view carries no data and is created with {@code CREATE OR REPLACE}, so it
+ * always tracks the running version. It is used only by the collector's manage path — {@code
+ * onboard} does not create it (in provisioned mode the reader role is not granted {@code SELECT} on
+ * it, so it would be inert).
+ */
+public final class FlowsSchema {
+
+    private FlowsSchema() {
+    }
+
+    /** {@code CREATE DATABASE IF NOT EXISTS `<db>`} — safe on an unpinned connection. */
+    public static String createDatabase(final String database) {
+        return "CREATE DATABASE IF NOT EXISTS " + ident(database);
+    }
+
+    /** {@code CREATE TABLE IF NOT EXISTS `<db>`.flows (…)} — a pre-existing table is left intact. */
+    public static String createFlowsTable(final String database) {
+        return FLOWS_TABLE.replace(FLOWS_TOKEN, ident(database) + ".flows");
+    }
+
+    /** {@code CREATE OR REPLACE VIEW `<db>`.samples AS … FROM `<db>`.flows} — collector-only. */
+    public static String createSamplesView(final String database) {
+        return SAMPLES_VIEW
+                .replace(SAMPLES_TOKEN, ident(database) + ".samples")
+                .replace(FLOWS_TOKEN, ident(database) + ".flows");
+    }
+
+    /** Backtick-quote an identifier. The value is pre-validated to exclude backticks. */
+    private static String ident(final String name) {
+        return "`" + name + "`";
+    }
+
+    // Placeholder tokens substituted with the qualified names. Plain replace() (not String.format)
+    // avoids treating the multi-line DDL as a format string.
+    private static final String FLOWS_TOKEN = "@@flows@@";
+    private static final String SAMPLES_TOKEN = "@@samples@@";
+
+    @Language("ClickHouse")
+    private static final String FLOWS_TABLE = """
+        CREATE TABLE IF NOT EXISTS @@flows@@ (
+            timestamp DateTime64(3),
+
+            flowProtocol Enum8(
+                'NetflowV5' = 1,
+                'NetflowV9' = 2,
+                'IPFIX' = 3,
+                'SFLOW' = 4
+            ),
+
+            tenant String,
+            organisation String,
+            zone String,
+            system String,
+            exporterAddr String,
+
+            receivedAt DateTime64(9),
+
+            firstSwitched DateTime64(9),
+            deltaSwitched DateTime64(9),
+            lastSwitched DateTime64(9),
+
+            inputSnmp UInt32,
+            inputSnmpIfName Nullable(String),
+            inputSnmpIfAlias Nullable(String),
+            inputSnmpIfSpeed Nullable(UInt32),
+
+            outputSnmp UInt32,
+            outputSnmpIfName Nullable(String),
+            outputSnmpIfAlias Nullable(String),
+            outputSnmpIfSpeed Nullable(UInt32),
+
+            srcAs UInt64,
+            srcAsOrg Nullable(String),
+            srcAddr IPv6,
+            srcMaskLen UInt8,
+            srcAddrHostname Nullable(String),
+            srcPort UInt16,
+
+            dstAs UInt64,
+            dstAsOrg Nullable(String),
+            dstAddr IPv6,
+            dstMaskLen UInt8,
+            dstAddrHostname Nullable(String),
+            dstPort UInt16,
+
+            nextHop Nullable(IPv6),
+            nextHopHostname Nullable(String),
+
+            bytes UInt64,
+            packets UInt64,
+
+            direction Enum8('INGRESS' = 1, 'EGRESS' = 2, 'UNKNOWN' = 3),
+
+            engineId UInt32,
+            engineType UInt16,
+
+            vlan UInt16,
+            ipProtocolVersion UInt8,
+            protocol UInt8,
+            tcpFlags UInt8,
+            tos UInt8,
+
+            samplingAlgorithm Enum8(
+                'Unassigned' = 1,
+                'SystematicCountBasedSampling' = 2,
+                'SystematicTimeBasedSampling' = 3,
+                'RandomNOutOfNSampling' = 4,
+                'UniformProbabilisticSampling' = 5,
+                'PropertyMatchFiltering' = 6,
+                'HashBasedFiltering' = 7,
+                'FlowStateDependentIntermediateFlowSelectionProcess' = 8
+            ),\s
+            samplingInterval Float64,
+
+            application Nullable(String),
+
+            srcLocality Enum8('PUBLIC' = 1, 'PRIVATE' = 2),
+            dstLocality Enum8('PUBLIC' = 1, 'PRIVATE' = 2),
+            flowLocality Enum8('PUBLIC' = 1, 'PRIVATE' = 2),
+
+            clockCorrection Nullable(Int64)
+        ) ENGINE = MergeTree()
+        ORDER BY (
+            tenant, organisation,
+            toStartOfHour(timestamp),
+            srcAs, dstAs,
+            srcAddr, dstAddr,
+            srcPort, dstPort
+        )
+        PARTITION BY toYYYYMMDD(timestamp)
+        TTL toDateTime(timestamp) + INTERVAL 30 DAY
+        SETTINGS index_granularity = 8192;
+    """;
+
+    @Language("ClickHouse")
+    private static final String SAMPLES_VIEW = """
+        CREATE OR REPLACE VIEW @@samples@@ AS
+        WITH
+            toInt64({ival:Int64} * 1e9) AS interval_ns,
+
+            -- Find first and last absolute bucket numbers
+            toUInt64(toUnixTimestamp64Nano(deltaSwitched) / interval_ns) as first_bucket,
+            toUInt64(toUnixTimestamp64Nano(lastSwitched) / interval_ns) as last_bucket,
+
+            last_bucket - first_bucket + 1 as bucket_count,
+
+            -- Calculate total duration in nanoseconds
+            age('ns', deltaSwitched, lastSwitched) as flow_duration,
+
+            -- Generate buckets from the first bucket onward
+            range(toUInt32(bucket_count)) AS buckets,
+
+            -- Determine the fraction of the interval used in each case
+            CASE
+                -- Only one bucket
+                WHEN bucket_count = 1
+                    THEN 1.0
+
+                -- First bucket: Portion from start time to the next bucket boundary
+                WHEN bucket = 0
+                    THEN ((interval_ns * (first_bucket + 1)) - toUnixTimestamp64Nano(deltaSwitched)) / interval_ns
+
+                -- Last bucket: Portion from the start of the last bucket to end time
+                WHEN bucket = bucket_count - 1
+                    THEN (toUnixTimestamp64Nano(lastSwitched) - (interval_ns * last_bucket)) / interval_ns
+
+                -- Full buckets in between
+                ELSE 1.0
+                END AS bucket_fraction
+
+        SELECT
+            flow.*,
+
+            fromUnixTimestamp64Nano((first_bucket + bucket) * interval_ns) AS timestamp,
+
+            bytes * bucket_fraction / toFloat64(bucket_count) as bytes,
+            packets * bucket_fraction / toFloat64(bucket_count) as packets
+
+        FROM @@flows@@ AS flow
+        ARRAY JOIN buckets AS bucket
+        ORDER BY timestamp;
+    """;
+}

--- a/src/test/java/org/riptide/provisioning/ProvisioningDdlTest.java
+++ b/src/test/java/org/riptide/provisioning/ProvisioningDdlTest.java
@@ -41,6 +41,37 @@ class ProvisioningDdlTest {
     }
 
     @Test
+    void ensureSharedCreatesSchemaBeforeGrantingOrConstrainingIt() {
+        final List<String> sql = ProvisioningDdl.ensureShared("riptide", 50_000_000_000L);
+        // The database and flows table are created first — the GRANT INSERT and ALTER … ADD
+        // CONSTRAINT below require the table to exist, so a fresh provisioned database is onboardable.
+        assertThat(sql.get(0)).isEqualTo("CREATE DATABASE IF NOT EXISTS `riptide`");
+        assertThat(sql.get(1).strip()).startsWith("CREATE TABLE IF NOT EXISTS `riptide`.flows (");
+
+        final int createTable = 1;
+        final int firstGrantOnFlows = indexOfFirst(sql, s -> s.startsWith("GRANT INSERT ON `riptide`.flows"));
+        final int firstAlterTable = indexOfFirst(sql, s -> s.startsWith("ALTER TABLE `riptide`.flows"));
+        assertThat(createTable).isLessThan(firstGrantOnFlows).isLessThan(firstAlterTable);
+    }
+
+    @Test
+    void ensureSharedDoesNotCreateTheSamplesView() {
+        // In provisioned mode flow_reader is not granted SELECT on samples, so onboard must not
+        // create the (inert, unqueryable) view — it stays a manage-mode-only convenience.
+        assertThat(ProvisioningDdl.ensureShared("riptide", 50_000_000_000L))
+                .noneMatch(s -> s.contains("samples"));
+    }
+
+    private static int indexOfFirst(final List<String> statements, final java.util.function.Predicate<String> match) {
+        for (int i = 0; i < statements.size(); i++) {
+            if (match.test(statements.get(i))) {
+                return i;
+            }
+        }
+        throw new AssertionError("no statement matched");
+    }
+
+    @Test
     void onboardTenantScopesUsersPolicyWithEscapedPassword() {
         final List<String> sql = ProvisioningDdl.onboardTenant("riptide", "acme", "acme-eu", "p'w", "r'w");
         assertThat(sql).hasSize(7);

--- a/src/test/java/org/riptide/repository/clickhouse/TenantOnboardingIT.java
+++ b/src/test/java/org/riptide/repository/clickhouse/TenantOnboardingIT.java
@@ -27,8 +27,10 @@ import java.util.List;
 import static org.riptide.repository.clickhouse.ClickhouseItFlows.flow;
 
 /**
- * The {@code onboard}/{@code offboard} subcommands, proven end to end against a real ClickHouse. The
- * admin provisions the base {@code flows} table (as in production), then the CLI is driven exactly
+ * The {@code onboard}/{@code offboard} subcommands, proven end to end against a real ClickHouse.
+ * Onboarding runs against a fresh, empty database — {@code onboard} provisions the {@code flows}
+ * table itself (issue #246; the collector only validates in {@code manage-schema=false} mode) before
+ * it can grant and constrain it. Then the CLI is driven exactly
  * as an operator would: {@code onboard} a tenant, and the resulting scoped credentials must satisfy
  * the full isolation matrix — honest write persists, cross-tenant write is rejected (469), the
  * reader sees only its tenant and cannot write/DDL — and {@code offboard} must revoke access.
@@ -54,11 +56,11 @@ public class TenantOnboardingIT {
     private static Client admin;
 
     @BeforeAll
-    static void createBaseTable() throws Exception {
+    static void createDatabase() throws Exception {
         admin = new Client.Builder().addEndpoint(endpoint()).setUsername("default").setPassword("").build();
+        // Only the empty database exists up front — no flows table. onboard must create the table
+        // itself before it can grant/constrain it, which is exactly the bootstrap #246 adds.
         admin.execute("CREATE DATABASE IF NOT EXISTS " + DATABASE).get();
-        // The flows table is admin-owned (manage mode), as it would be before any tenant onboards.
-        new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), adminConfig(), RESOLVERS).start();
     }
 
     @Test
@@ -182,15 +184,6 @@ public class TenantOnboardingIT {
                 .setPassword(password)
                 .setDefaultDatabase(DATABASE)
                 .build();
-    }
-
-    private static ClickhouseConfig adminConfig() {
-        final var config = new ClickhouseConfig();
-        config.setEndpoint(endpoint());
-        config.setUsername(SecretRef.of("default"));
-        config.setDatabase(DATABASE);
-        config.setManageSchema(true);
-        return config;
     }
 
     private static PrintStream discard() {

--- a/src/test/java/org/riptide/schema/FlowsSchemaTest.java
+++ b/src/test/java/org/riptide/schema/FlowsSchemaTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.schema;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The flow schema DDL is the single source shared by the collector's manage path and {@code
+ * onboard}, so the load-bearing properties are that it is database-qualified (works on an unpinned
+ * client), idempotent, and that the {@code samples} view still references the same qualified table.
+ */
+class FlowsSchemaTest {
+
+    @Test
+    void createDatabaseIsIdempotentAndQuoted() {
+        assertThat(FlowsSchema.createDatabase("riptide"))
+                .isEqualTo("CREATE DATABASE IF NOT EXISTS `riptide`");
+    }
+
+    @Test
+    void createFlowsTableIsQualifiedAndIdempotent() {
+        final String ddl = FlowsSchema.createFlowsTable("riptide");
+        assertThat(ddl.strip()).startsWith("CREATE TABLE IF NOT EXISTS `riptide`.flows (");
+        // A representative column and the engine/partitioning survive the extraction unchanged.
+        assertThat(ddl)
+                .contains("tenant String,")
+                .contains("clockCorrection Nullable(Int64)")
+                .contains("ENGINE = MergeTree()")
+                .contains("PARTITION BY toYYYYMMDD(timestamp)");
+    }
+
+    @Test
+    void createSamplesViewQualifiesBothViewAndSourceTable() {
+        final String ddl = FlowsSchema.createSamplesView("riptide");
+        assertThat(ddl.strip()).startsWith("CREATE OR REPLACE VIEW `riptide`.samples AS");
+        assertThat(ddl).contains("FROM `riptide`.flows AS flow");
+        // The view parameter is a literal placeholder bound at SELECT time, not at CREATE time.
+        assertThat(ddl).contains("{ival:Int64}");
+    }
+
+    @Test
+    void qualifiesToTheGivenDatabase() {
+        assertThat(FlowsSchema.createFlowsTable("acme_prod"))
+                .contains("CREATE TABLE IF NOT EXISTS `acme_prod`.flows (");
+        assertThat(FlowsSchema.createSamplesView("acme_prod"))
+                .contains("VIEW `acme_prod`.samples AS")
+                .contains("FROM `acme_prod`.flows AS flow");
+    }
+}


### PR DESCRIPTION
Closes #246.

## The problem

In provisioned mode (`manage-schema=false`) the collector only **validates** the schema at startup — it never creates the `flows` table. But `onboard`'s `ProvisioningDdl.ensureShared` opened with `GRANT INSERT ON <db>.flows` and `ALTER TABLE <db>.flows ADD CONSTRAINT`, both of which require the table to exist. Nobody created it, so a fresh provisioned deployment couldn't be onboarded without an operator hand-creating the schema out-of-band.

## The fix

- **One shared definition.** The `flows` table + `samples` view DDL move to a neutral, database-qualified `org.riptide.schema.FlowsSchema`, called by both the collector's manage path and `onboard` — so the two can't drift.
- **`onboard` bootstraps the schema.** `ensureShared` now prepends `CREATE DATABASE IF NOT EXISTS` + `CREATE TABLE IF NOT EXISTS <db>.flows` **before** the first `GRANT`/`ALTER`. onboard's admin client is unpinned, so `CREATE DATABASE` just works.
- **Collector unchanged in behavior.** Its DDL switches from unqualified (relying on `setDefaultDatabase`) to the shared qualified form — equivalent on its pinned client. Manage mode still creates database + table + view exactly as before.
- **Tenant CHECK constraints stay in `ProvisioningDdl`** (provisioned-mode-specific).

## Deliberately out of scope

`onboard` does **not** create the `samples` view: in provisioned mode `flow_reader` is granted `SELECT` on `flows` and `system.*` only, so a `samples` view would be inert (unqueryable by readers). Exposing it to provisioned readers is a separate follow-up — a spike confirmed it's safe (a row policy on `flows` propagates through the parameterized `samples` view under ClickHouse's default **INVOKER** view security; `SQL SECURITY DEFINER` would leak across tenants), so the follow-up is `GRANT SELECT ON samples TO flow_reader` + a guardrail that the view stays INVOKER.

## Testing

- **670 unit tests** green, incl. new `FlowsSchemaTest` (qualified/idempotent DDL, `{ival:Int64}` view param survives) and `ProvisioningDdlTest` (schema created before the first grant/alter; no `samples` in onboard).
- **20 ClickHouse integration tests** green against a real server. `TenantOnboardingIT` now onboards into an **empty database** — proving the table bootstrap end to end (previously it pre-created the table via manage mode, masking the new path).

## Review

`/code-review` high: 2 findings — the test-coverage gap (fixed: `TenantOnboardingIT` now bootstraps from empty) and a trivial cross-package `ident()` duplication (accepted; deduping a one-line pure function isn't worth coupling the `schema` and `provisioning` packages).