### PR TITLE
feat: guard onboard schema bootstrap with opt-in --create-schema (#267)

### DIFF
--- a/docs/docs/configuration/clickhouse.md
+++ b/docs/docs/configuration/clickhouse.md
@@ -39,6 +39,10 @@ riptide.clickhouse.password=vault://secret/riptide/clickhouse/acme#password
 
 `riptide.clickhouse.manage-schema` (boolean, default `true`) selects who owns the schema:
 
+The database name (`riptide.clickhouse.database`) must match `[A-Za-z0-9_-]+` — names with other
+characters (dots, spaces, unicode) are rejected at startup in manage mode. This is stricter than
+what ClickHouse accepts under backtick quoting; rename such a database or use validate mode.
+
 - **`true` (default, single-tenant)** — riptide ensures the schema idempotently at startup:
   the database with `CREATE DATABASE IF NOT EXISTS` (so a fresh single-node install needs no
   manual DDL — the configured user needs `CREATE` rights), the `flows` table with
@@ -49,9 +53,11 @@ riptide.clickhouse.password=vault://secret/riptide/clickhouse/acme#password
 - **`false` (provisioned / multi-tenant)** — the collector creates nothing. It validates that the
   `flows` table exists and carries every column it inserts and **fails startup with a clear,
   provisioning-pointing error** if it does not. Use this when an admin owns the schema and
-  RBAC and each riptide process is a narrowly-scoped writer that only uses the table. The admin-side
-  [`onboard` subcommand](../deploy/multi-tenancy.md#what-it-provisions) creates the database and
-  `flows` table as part of provisioning, so this mode needs no separate manual schema step.
+  RBAC and each riptide process is a narrowly-scoped writer that only uses the table. On a fresh
+  single-node server the admin-side
+  [`onboard --create-schema`](../deploy/multi-tenancy.md#what-it-provisions) bootstraps the database
+  and `flows` table as part of provisioning; without the flag, `onboard` requires the schema to
+  exist and fails loudly if it does not (replicated clusters pre-create the table admin-side).
 
 In both modes, startup verifies the `flows` table is present and carries every column riptide
 inserts (including the `tenant`/`organisation`/`zone`/`system` identity columns) by reading the

--- a/docs/docs/deploy/multi-tenancy.md
+++ b/docs/docs/deploy/multi-tenancy.md
@@ -60,9 +60,12 @@ for filtering. All four are riptide-populated columns.
 - The `SQL_` custom-settings prefix enabled (write-barrier requirement) — see the
   [server requirement](../configuration/clickhouse.md#server-requirement).
 - Riptide running in [validate mode](../configuration/clickhouse.md#schema-ownership)
-  (`manage-schema=false`). The `flows` schema itself needs no manual step — `onboard` creates the
-  database and `flows` table (see [What it provisions](#what-it-provisions)) before it grants and
-  constrains them.
+  (`manage-schema=false`). On a fresh **single-node** server, `onboard --create-schema` bootstraps
+  the database and `flows` table itself (see [What it provisions](#what-it-provisions)) — no manual
+  DDL. On a **replicated cluster**, pre-create the `flows` table admin-side (e.g.
+  `ReplicatedMergeTree`, `ON CLUSTER`) and run `onboard` *without* `--create-schema`: the bootstrap
+  DDL is single-node (`MergeTree()`, no `ON CLUSTER`) and would create a node-local table on
+  whichever replica the admin client hits, while the roles and grants replicate.
 
 ## Onboard a tenant
 
@@ -91,6 +94,22 @@ Secret references resolve through the built-in resolvers (`plain`, `env://`, `fi
 `riptide.clickhouse.manage-schema=false` and `riptide.identity.zone` to the collector config as
 needed.
 
+On a fresh single-node server, add **`--create-schema`** to the first onboard: it creates the
+database and `flows` table (with `--ttl-days N` retention, default 30, max 10950 — ClickHouse's
+`DateTime` ends in 2106) before the grants and constraints that need them. `--ttl-days` applies
+only to a table this run creates: it requires `--create-schema`, and a re-run against an existing
+table warns that retention is unchanged. Without the flag, a missing database or table **fails before any
+statement runs** — so a typo'd `--database` can never silently provision a phantom database — and
+the run sends no `CREATE` statement at all, which keeps a least-privilege admin working (ClickHouse
+checks `CREATE` privileges even when `IF NOT EXISTS` would no-op).
+
+### Admin privileges
+
+| mode | minimum privileges for the admin credential |
+|---|---|
+| default (schema exists) | `CREATE USER`/`CREATE ROLE`/`CREATE QUOTA`/`CREATE ROW POLICY`, `ALTER USER`/`ALTER ROLE`, `DROP USER`/`DROP ROW POLICY` (offboard), `ALTER TABLE` on `<db>.flows`, and `INSERT`, `SELECT` on `<db>.flows` plus `SELECT` on `system.databases/tables/columns` **with grant option** (they are granted onward to the roles) |
+| `--create-schema` | the above, plus `CREATE DATABASE ON <db>.*` and `CREATE TABLE ON <db>.flows` |
+
 `onboard` is safe to re-run: it reconciles the writer/reader **passwords** to the current secret, so
 rotating a secret and re-running updates ClickHouse (the users' `CONST` settings and row policy are
 preserved). To remove a tenant: `offboard --admin-url … --tenant acme --yes` (drops its users and
@@ -103,11 +122,11 @@ the quota are one-time objects, so per-tenant reduces to the scoped users + role
 row policy. `onboard` ensures the one-time objects on first run and adds the per-tenant part:
 
 ```sql
--- Once per cluster (idempotent): onboard first creates the schema it depends on, so a fresh
--- provisioned database needs no manual step. IF NOT EXISTS leaves an existing table untouched.
+-- Only with --create-schema, and only when the schema is actually missing (a default run emits
+-- no CREATE statement, so it needs no CREATE privileges). IF NOT EXISTS never replaces a table.
 CREATE DATABASE IF NOT EXISTS riptide;
-CREATE TABLE IF NOT EXISTS riptide.flows (…);  -- full column definition — see the ClickHouse deployment docs
--- Roles carry every per-tenant grant and the reader hardening.
+CREATE TABLE IF NOT EXISTS riptide.flows (…);  -- single-node MergeTree, TTL from --ttl-days (default 30)
+-- Once per cluster (idempotent): roles carry every per-tenant grant and the reader hardening.
 CREATE ROLE IF NOT EXISTS flow_writer;
 GRANT INSERT ON riptide.flows TO flow_writer;
 CREATE ROLE IF NOT EXISTS flow_reader;

--- a/src/main/java/org/riptide/provisioning/ProvisioningCommand.java
+++ b/src/main/java/org/riptide/provisioning/ProvisioningCommand.java
@@ -6,6 +6,7 @@
 package org.riptide.provisioning;
 
 import com.clickhouse.client.api.Client;
+import org.riptide.schema.FlowsSchema;
 import org.riptide.secrets.SecretRef;
 import org.riptide.secrets.SecretResolvers;
 
@@ -25,6 +26,9 @@ import java.util.Set;
 public final class ProvisioningCommand {
 
     private static final long DEFAULT_QUOTA_BYTES = 50_000_000_000L;
+
+    /** 30 years — far beyond any NetFlow retention, comfortably below the 2106 DateTime wrap. */
+    private static final int MAX_TTL_DAYS = 10_950;
 
     private ProvisioningCommand() {
     }
@@ -87,6 +91,14 @@ public final class ProvisioningCommand {
     private static int onboard(final Args parsed, final String database, final TenantProvisioner provisioner,
                                final PrintStream out, final PrintStream err) {
         final long quotaBytes = parseQuotaBytes(parsed.get("quota-bytes"));
+        final boolean createSchema = parsed.flags.contains("create-schema");
+        final boolean ttlRequested = parsed.get("ttl-days") != null;
+        if (ttlRequested && !createSchema) {
+            // Enforce the nesting the usage text promises: the TTL only applies to a table this
+            // run creates — accepting it standalone would silently do nothing.
+            throw new IllegalArgumentException("--ttl-days requires --create-schema");
+        }
+        final int ttlDays = parseTtlDays(parsed.get("ttl-days"));
         final var spec = new TenantSpec(
                 parsed.require("tenant"),
                 parsed.require("org"),
@@ -95,10 +107,14 @@ public final class ProvisioningCommand {
                 parsed.require("reader-secret"),
                 quotaBytes);
 
-        final String stanza = provisioner.onboard(spec);
+        final var result = provisioner.onboard(spec, createSchema, ttlDays);
+        if (ttlRequested && !result.schemaBootstrapped()) {
+            err.println("warning: --ttl-days ignored — the flows table already exists, its retention"
+                    + " is unchanged (use ALTER TABLE ... MODIFY TTL to change it)");
+        }
         err.println("Onboarded tenant '" + spec.tenant() + "' (org '" + spec.organisation()
                 + "'). Add this to the tenant's riptide config:");
-        out.println(stanza);
+        out.println(result.configStanza());
         return 0;
     }
 
@@ -126,21 +142,48 @@ public final class ProvisioningCommand {
         }
     }
 
+    /**
+     * Retention for a {@code --create-schema}-created table; defaults to the collector's 30 days.
+     * Capped at 30 years: ClickHouse {@code DateTime} ends 2106-02-07 and TTL arithmetic wraps
+     * modulo 2^32 seconds — an oversized interval (verified: {@code INTERVAL 49710 DAY}) wraps to a
+     * TTL in the past and silently discards every inserted row.
+     */
+    static int parseTtlDays(final String value) {
+        if (value == null) {
+            return FlowsSchema.DEFAULT_TTL_DAYS;
+        }
+        final int days;
+        try {
+            days = Integer.parseInt(value);
+        } catch (final NumberFormatException e) {
+            throw new IllegalArgumentException("--ttl-days must be a number of days, was: " + value);
+        }
+        if (days <= 0 || days > MAX_TTL_DAYS) {
+            throw new IllegalArgumentException("--ttl-days must be between 1 and " + MAX_TTL_DAYS
+                    + " (ClickHouse DateTime ends 2106; larger intervals wrap and expire data immediately),"
+                    + " was: " + value);
+        }
+        return days;
+    }
+
     private static void usage(final PrintStream err) {
         err.println("""
                 usage:
                   riptide onboard  --admin-url URL [--admin-user U] [--admin-password REF] \\
                                    --tenant T --org O --writer-secret REF --reader-secret REF \\
-                                   [--database DB] [--quota-bytes N]
+                                   [--database DB] [--quota-bytes N] \\
+                                   [--create-schema [--ttl-days N]]
                   riptide offboard --admin-url URL [--admin-user U] [--admin-password REF] \\
                                    --tenant T [--database DB] --yes
-                secret REF: plain literal, env://VAR, or file:///path[#key]""");
+                secret REF: plain literal, env://VAR, or file:///path[#key]
+                --create-schema: bootstrap the database and flows table if absent (needs CREATE
+                                 privileges); without it, a missing schema fails before provisioning""");
     }
 
     /** Minimal {@code --key value} / {@code --flag} parser. {@code args[0]} is the subcommand. */
     private record Args(String subcommand, Map<String, String> options, Set<String> flags) {
 
-        private static final Set<String> KNOWN_FLAGS = Set.of("yes");
+        private static final Set<String> KNOWN_FLAGS = Set.of("yes", "create-schema");
 
         static Args parse(final String[] args) {
             if (args.length == 0 || !matches(args[0])) {

--- a/src/main/java/org/riptide/provisioning/ProvisioningDdl.java
+++ b/src/main/java/org/riptide/provisioning/ProvisioningDdl.java
@@ -14,9 +14,10 @@ import java.util.List;
  * whole recipe is one auditable place and lifts cleanly into a future {@code riptide-admin} module.
  *
  * <p>The model puts every identical-per-tenant part into one-time objects ({@link #ensureShared})
- * — the {@code flows} schema, the {@code flow_writer}/{@code flow_reader} roles carrying the grants
- * and the reader hardening, and a single quota keyed by user — so {@link #onboardTenant} reduces to
- * the scoped users, two role grants, and one literal row policy. All statements are idempotent
+ * — the {@code flow_writer}/{@code flow_reader} roles carrying the grants and the reader hardening,
+ * and a single quota keyed by user — so {@link #onboardTenant} reduces to the scoped users, two
+ * role grants, and one literal row policy. The {@code flows} schema itself is a separate, opt-in
+ * recipe ({@link #bootstrapSchema}, {@code onboard --create-schema}). All statements are idempotent
  * ({@code IF NOT EXISTS} / {@code ALTER ROLE SETTINGS}), verified on ClickHouse 25.3.
  *
  * <p>Tenant/org names are validated ({@link TenantSpec}) to a safe charset; generated identifiers
@@ -28,17 +29,23 @@ public final class ProvisioningDdl {
     }
 
     /**
-     * One-time shared objects: the database and {@code flows} table (so onboarding a fresh
-     * provisioned deployment is self-sufficient — the collector only validates in
-     * {@code manage-schema=false} mode), then the two roles, the reader hardening, the CHECK
-     * barrier, and the quota. The schema DDL comes first because the {@code GRANT INSERT} and
-     * {@code ALTER TABLE … ADD CONSTRAINT} below require the table to exist.
+     * The opt-in schema bootstrap ({@code onboard --create-schema}): the database and {@code flows}
+     * table, ordered before {@link #ensureShared} because its {@code GRANT INSERT} and
+     * {@code ALTER TABLE … ADD CONSTRAINT} require the table to exist. Kept separate from
+     * {@link #ensureShared} so a default run sends no CREATE statement at all — ClickHouse checks
+     * the {@code CREATE DATABASE}/{@code CREATE TABLE} privilege even when {@code IF NOT EXISTS}
+     * would no-op, so emitting them unconditionally would break least-privilege admins.
      */
-    public static List<String> ensureShared(final String database, final long quotaBytes) {
-        final String flows = ident(database) + ".flows";
+    public static List<String> bootstrapSchema(final String database, final int ttlDays) {
         return List.of(
                 FlowsSchema.createDatabase(database),
-                FlowsSchema.createFlowsTable(database),
+                FlowsSchema.createFlowsTable(database, ttlDays));
+    }
+
+    /** One-time shared objects: the two roles, the reader hardening, the CHECK barrier, the quota. */
+    public static List<String> ensureShared(final String database, final long quotaBytes) {
+        final String flows = FlowsSchema.qualifiedFlows(database);
+        return List.of(
                 "CREATE ROLE IF NOT EXISTS flow_writer",
                 "GRANT INSERT ON " + flows + " TO flow_writer",
                 "CREATE ROLE IF NOT EXISTS flow_reader",
@@ -66,7 +73,7 @@ public final class ProvisioningDdl {
      */
     public static List<String> onboardTenant(final String database, final String tenant, final String organisation,
                                              final String writerPassword, final String readerPassword) {
-        final String flows = ident(database) + ".flows";
+        final String flows = FlowsSchema.qualifiedFlows(database);
         final String writer = ident("writer_" + tenant);
         final String reader = ident("bi_" + tenant);
         final String policy = ident(tenant + "_iso");
@@ -87,15 +94,16 @@ public final class ProvisioningDdl {
 
     /** Per-tenant teardown: drop the row policy and the two users; shared objects stay. */
     public static List<String> offboardTenant(final String database, final String tenant) {
-        final String flows = ident(database) + ".flows";
+        final String flows = FlowsSchema.qualifiedFlows(database);
         return List.of(
                 "DROP ROW POLICY IF EXISTS " + ident(tenant + "_iso") + " ON " + flows,
                 "DROP USER IF EXISTS " + ident("bi_" + tenant),
                 "DROP USER IF EXISTS " + ident("writer_" + tenant));
     }
 
-    /** Backtick-quote an identifier. The value is pre-validated to exclude backticks. */
+    /** Validate (safe charset, via the package's single check) and backtick-quote an identifier. */
     static String ident(final String name) {
+        TenantSpec.requireSafe("identifier", name);
         return "`" + name + "`";
     }
 

--- a/src/main/java/org/riptide/provisioning/TenantProvisioner.java
+++ b/src/main/java/org/riptide/provisioning/TenantProvisioner.java
@@ -6,6 +6,7 @@
 package org.riptide.provisioning;
 
 import com.clickhouse.client.api.Client;
+import org.riptide.schema.FlowsSchema;
 import org.riptide.secrets.SecretRef;
 import org.riptide.secrets.SecretResolvers;
 
@@ -37,18 +38,60 @@ public final class TenantProvisioner {
     /**
      * Ensure the shared objects and this tenant's users/policy exist (idempotent). Returns the
      * riptide configuration stanza for the tenant's collector, referencing the same writer secret.
+     *
+     * <p>A pre-flight check verifies the database and {@code flows} table exist <em>before any
+     * statement runs</em>. If they are missing, the run fails unless {@code createSchema} is set —
+     * a typo'd database name must fail loudly, not silently provision a phantom database with the
+     * shared roles granted on it. The bootstrap statements are only <em>emitted</em> when actually
+     * creating: ClickHouse checks the {@code CREATE} privileges even when {@code IF NOT EXISTS}
+     * would no-op, and a least-privilege admin re-run (e.g. password rotation) must keep working.
      */
-    public String onboard(final TenantSpec spec) {
+    public OnboardResult onboard(final TenantSpec spec, final boolean createSchema, final int ttlDays) {
         final String writerPassword = resolve(spec.writerSecret());
         final String readerPassword = resolve(spec.readerSecret());
 
         final var statements = new ArrayList<String>();
+        final boolean bootstrap = !flowsTableExists(spec.database());
+        if (bootstrap) {
+            if (!createSchema) {
+                throw new ProvisioningException(
+                        "database '" + spec.database() + "' has no flows table — re-run with"
+                                + " --create-schema to bootstrap it, or check the --database value"
+                                + " for typos (an admin-provisioned table is also accepted)", null);
+            }
+            statements.addAll(ProvisioningDdl.bootstrapSchema(spec.database(), ttlDays));
+        }
         statements.addAll(ProvisioningDdl.ensureShared(spec.database(), spec.quotaBytes()));
         statements.addAll(ProvisioningDdl.onboardTenant(
                 spec.database(), spec.tenant(), spec.organisation(), writerPassword, readerPassword));
         execute(statements);
 
-        return configStanza(spec);
+        return new OnboardResult(configStanza(spec), bootstrap);
+    }
+
+    /**
+     * The config stanza plus whether this run created the schema — the caller needs the latter to
+     * warn when an explicitly requested {@code --ttl-days} was not applied (table pre-existed).
+     */
+    public record OnboardResult(String configStanza, boolean schemaBootstrapped) {
+    }
+
+    /**
+     * Pre-flight existence check. {@code EXISTS DATABASE} is queried first — {@code EXISTS TABLE}
+     * against a nonexistent database can raise {@code UNKNOWN_DATABASE} rather than returning 0.
+     */
+    private boolean flowsTableExists(final String database) {
+        return exists("EXISTS DATABASE " + ProvisioningDdl.ident(database))
+                && exists("EXISTS TABLE " + FlowsSchema.qualifiedFlows(database));
+    }
+
+    private boolean exists(final String sql) {
+        try {
+            // EXISTS returns a single UInt8 column named "result".
+            return this.admin.queryAll(sql).getFirst().getLong("result") == 1;
+        } catch (final Exception e) {
+            throw new ProvisioningException("Pre-flight schema check failed: " + sql, e);
+        }
     }
 
     /** Drop the tenant's users and row policy; the shared roles/constraints/quota are left intact. */

--- a/src/main/java/org/riptide/schema/FlowsSchema.java
+++ b/src/main/java/org/riptide/schema/FlowsSchema.java
@@ -7,6 +7,8 @@ package org.riptide.schema;
 
 import org.intellij.lang.annotations.Language;
 
+import java.util.regex.Pattern;
+
 /**
  * The one definition of riptide's ClickHouse flow schema — the {@code flows} table and the
  * {@code samples} view — as database-qualified, idempotent DDL. Pure string builders (no I/O), so
@@ -22,8 +24,9 @@ import org.intellij.lang.annotations.Language;
  *
  * <p>Every statement names {@code `<db>`.flows} / {@code `<db>`.samples} explicitly rather than
  * relying on a client's default-database pinning, so the same DDL runs correctly on the collector's
- * pinned client and on an unpinned admin client. The database name is backtick-quoted; callers pass
- * a validated name.
+ * pinned client and on an unpinned admin client. The database name is charset-checked and
+ * backtick-quoted here — the collector's {@code riptide.clickhouse.database} property binds without
+ * validation, so the quoting site is the enforcement point.
  *
  * <p>The {@code samples} view carries no data and is created with {@code CREATE OR REPLACE}, so it
  * always tracks the running version. It is used only by the collector's manage path — {@code
@@ -31,6 +34,12 @@ import org.intellij.lang.annotations.Language;
  * it, so it would be inert).
  */
 public final class FlowsSchema {
+
+    /** The collector's manage-mode retention; also the {@code onboard --ttl-days} default. */
+    public static final int DEFAULT_TTL_DAYS = 30;
+
+    /** Same charset as the provisioning boundary ({@code TenantSpec}): no quotes, backticks, spaces. */
+    private static final Pattern SAFE_NAME = Pattern.compile("[A-Za-z0-9_-]+");
 
     private FlowsSchema() {
     }
@@ -40,27 +49,50 @@ public final class FlowsSchema {
         return "CREATE DATABASE IF NOT EXISTS " + ident(database);
     }
 
-    /** {@code CREATE TABLE IF NOT EXISTS `<db>`.flows (…)} — a pre-existing table is left intact. */
+    /** As {@link #createFlowsTable(String, int)} with the collector's default retention. */
     public static String createFlowsTable(final String database) {
-        return FLOWS_TABLE.replace(FLOWS_TOKEN, ident(database) + ".flows");
+        return createFlowsTable(database, DEFAULT_TTL_DAYS);
+    }
+
+    /** {@code CREATE TABLE IF NOT EXISTS `<db>`.flows (…)} — a pre-existing table is left intact. */
+    public static String createFlowsTable(final String database, final int ttlDays) {
+        return FLOWS_TABLE
+                .replace(FLOWS_TOKEN, qualifiedFlows(database))
+                .replace(TTL_DAYS_TOKEN, Integer.toString(ttlDays));
     }
 
     /** {@code CREATE OR REPLACE VIEW `<db>`.samples AS … FROM `<db>`.flows} — collector-only. */
     public static String createSamplesView(final String database) {
         return SAMPLES_VIEW
                 .replace(SAMPLES_TOKEN, ident(database) + ".samples")
-                .replace(FLOWS_TOKEN, ident(database) + ".flows");
+                .replace(FLOWS_TOKEN, qualifiedFlows(database));
     }
 
-    /** Backtick-quote an identifier. The value is pre-validated to exclude backticks. */
+    /** The qualified {@code `<db>`.flows} name — the one home for its construction. */
+    public static String qualifiedFlows(final String database) {
+        return ident(database) + ".flows";
+    }
+
+    /**
+     * Charset-check and backtick-quote an identifier. Enforced here (not just documented) because
+     * the collector's database name arrives from unvalidated configuration; a bad value fails with
+     * a clear message instead of producing malformed DDL.
+     */
     private static String ident(final String name) {
+        if (name == null || !SAFE_NAME.matcher(name).matches()) {
+            throw new IllegalArgumentException(
+                    "invalid ClickHouse database name '" + name + "' — riptide.clickhouse.database"
+                            + " (or onboard --database) must match [A-Za-z0-9_-]+"
+                            + " (letters, digits, underscore, hyphen)");
+        }
         return "`" + name + "`";
     }
 
-    // Placeholder tokens substituted with the qualified names. Plain replace() (not String.format)
-    // avoids treating the multi-line DDL as a format string.
+    // Placeholder tokens substituted with the qualified names / TTL. Plain replace() (not
+    // String.format) avoids treating the multi-line DDL as a format string.
     private static final String FLOWS_TOKEN = "@@flows@@";
     private static final String SAMPLES_TOKEN = "@@samples@@";
+    private static final String TTL_DAYS_TOKEN = "@@ttlDays@@";
 
     @Language("ClickHouse")
     private static final String FLOWS_TABLE = """
@@ -155,7 +187,7 @@ public final class FlowsSchema {
             srcPort, dstPort
         )
         PARTITION BY toYYYYMMDD(timestamp)
-        TTL toDateTime(timestamp) + INTERVAL 30 DAY
+        TTL toDateTime(timestamp) + INTERVAL @@ttlDays@@ DAY
         SETTINGS index_granularity = 8192;
     """;
 

--- a/src/test/java/org/riptide/provisioning/ProvisioningCommandTest.java
+++ b/src/test/java/org/riptide/provisioning/ProvisioningCommandTest.java
@@ -54,6 +54,34 @@ class ProvisioningCommandTest {
                 .hasMessageContaining("--quota-bytes must be a number");
     }
 
+    @Test
+    void parseTtlDaysDefaultsAndRejectsOutOfRange() {
+        assertThat(ProvisioningCommand.parseTtlDays(null)).isEqualTo(30);
+        assertThat(ProvisioningCommand.parseTtlDays("400")).isEqualTo(400);
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> ProvisioningCommand.parseTtlDays("0"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("--ttl-days must be between 1 and 10950");
+        // Oversized intervals wrap ClickHouse's UInt32 DateTime arithmetic (verified: INTERVAL
+        // 49710 DAY wraps to a TTL in the past and every insert is silently discarded).
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> ProvisioningCommand.parseTtlDays("49710"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("2106");
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> ProvisioningCommand.parseTtlDays("month"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("--ttl-days must be a number");
+    }
+
+    @Test
+    void ttlDaysWithoutCreateSchemaExitsTwo() {
+        final var err = new ByteArrayOutputStream();
+        final int code = ProvisioningCommand.run(
+                new String[] {"onboard", "--admin-url", "http://localhost:1", "--ttl-days", "90",
+                        "--tenant", "t", "--org", "o", "--writer-secret", "w", "--reader-secret", "r"},
+                discard(), new PrintStream(err, true, StandardCharsets.UTF_8));
+        assertThat(code).isEqualTo(2);
+        assertThat(err.toString(StandardCharsets.UTF_8)).contains("--ttl-days requires --create-schema");
+    }
+
     private static PrintStream discard() {
         return new PrintStream(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8);
     }

--- a/src/test/java/org/riptide/provisioning/ProvisioningDdlTest.java
+++ b/src/test/java/org/riptide/provisioning/ProvisioningDdlTest.java
@@ -41,34 +41,32 @@ class ProvisioningDdlTest {
     }
 
     @Test
-    void ensureSharedCreatesSchemaBeforeGrantingOrConstrainingIt() {
-        final List<String> sql = ProvisioningDdl.ensureShared("riptide", 50_000_000_000L);
-        // The database and flows table are created first — the GRANT INSERT and ALTER … ADD
-        // CONSTRAINT below require the table to exist, so a fresh provisioned database is onboardable.
+    void bootstrapSchemaCreatesDatabaseThenTableWithTtl() {
+        final List<String> sql = ProvisioningDdl.bootstrapSchema("riptide", 400);
+        // Database before table. The composed onboard ordering (bootstrap before the GRANT/ALTER
+        // that need the table) is pinned end-to-end by TenantOnboardingIT against a fresh server.
         assertThat(sql.get(0)).isEqualTo("CREATE DATABASE IF NOT EXISTS `riptide`");
         assertThat(sql.get(1).strip()).startsWith("CREATE TABLE IF NOT EXISTS `riptide`.flows (");
-
-        final int createTable = 1;
-        final int firstGrantOnFlows = indexOfFirst(sql, s -> s.startsWith("GRANT INSERT ON `riptide`.flows"));
-        final int firstAlterTable = indexOfFirst(sql, s -> s.startsWith("ALTER TABLE `riptide`.flows"));
-        assertThat(createTable).isLessThan(firstGrantOnFlows).isLessThan(firstAlterTable);
+        assertThat(sql.get(1)).contains("TTL toDateTime(timestamp) + INTERVAL 400 DAY");
+        assertThat(sql).hasSize(2);
     }
 
     @Test
-    void ensureSharedDoesNotCreateTheSamplesView() {
-        // In provisioned mode flow_reader is not granted SELECT on samples, so onboard must not
-        // create the (inert, unqueryable) view — it stays a manage-mode-only convenience.
+    void ensureSharedEmitsNoCreateStatement() {
+        // ClickHouse checks CREATE privileges even when IF NOT EXISTS would no-op, so a default
+        // (least-privilege) onboard run must never send CREATE DATABASE/CREATE TABLE — the schema
+        // bootstrap is a separate, opt-in recipe.
         assertThat(ProvisioningDdl.ensureShared("riptide", 50_000_000_000L))
-                .noneMatch(s -> s.contains("samples"));
+                .noneMatch(s -> s.startsWith("CREATE DATABASE") || s.startsWith("CREATE TABLE"));
     }
 
-    private static int indexOfFirst(final List<String> statements, final java.util.function.Predicate<String> match) {
-        for (int i = 0; i < statements.size(); i++) {
-            if (match.test(statements.get(i))) {
-                return i;
-            }
-        }
-        throw new AssertionError("no statement matched");
+    @Test
+    void neitherRecipeCreatesTheSamplesView() {
+        // In provisioned mode flow_reader is not granted SELECT on samples, so onboard must not
+        // create the (inert, unqueryable) view — it stays a manage-mode-only convenience.
+        assertThat(ProvisioningDdl.bootstrapSchema("riptide", 30)).noneMatch(s -> s.contains("samples"));
+        assertThat(ProvisioningDdl.ensureShared("riptide", 50_000_000_000L))
+                .noneMatch(s -> s.contains("samples"));
     }
 
     @Test

--- a/src/test/java/org/riptide/repository/clickhouse/TenantOnboardingIT.java
+++ b/src/test/java/org/riptide/repository/clickhouse/TenantOnboardingIT.java
@@ -7,7 +7,6 @@ package org.riptide.repository.clickhouse;
 
 import com.clickhouse.client.api.Client;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.riptide.config.ClickhouseConfig;
 import org.riptide.provisioning.ProvisioningCommand;
@@ -28,9 +27,10 @@ import static org.riptide.repository.clickhouse.ClickhouseItFlows.flow;
 
 /**
  * The {@code onboard}/{@code offboard} subcommands, proven end to end against a real ClickHouse.
- * Onboarding runs against a fresh, empty database — {@code onboard} provisions the {@code flows}
- * table itself (issue #246; the collector only validates in {@code manage-schema=false} mode) before
- * it can grant and constrain it. Then the CLI is driven exactly
+ * Onboarding runs against a genuinely fresh server — nothing is pre-created, so
+ * {@code onboard --create-schema} must bootstrap the database and {@code flows} table itself
+ * (issues #246/#267; the collector only validates in {@code manage-schema=false} mode) before it
+ * can grant and constrain them. Then the CLI is driven exactly
  * as an operator would: {@code onboard} a tenant, and the resulting scoped credentials must satisfy
  * the full isolation matrix — honest write persists, cross-tenant write is rejected (469), the
  * reader sees only its tenant and cannot write/DDL — and {@code offboard} must revoke access.
@@ -52,16 +52,6 @@ public class TenantOnboardingIT {
                     "/etc/clickhouse-server/config.d/custom-settings.xml")
             .withExposedPorts(8123)
             .waitingFor(Wait.forHttp("/ping").forPort(8123).forStatusCode(200));
-
-    private static Client admin;
-
-    @BeforeAll
-    static void createDatabase() throws Exception {
-        admin = new Client.Builder().addEndpoint(endpoint()).setUsername("default").setPassword("").build();
-        // Only the empty database exists up front — no flows table. onboard must create the table
-        // itself before it can grant/constrain it, which is exactly the bootstrap #246 adds.
-        admin.execute("CREATE DATABASE IF NOT EXISTS " + DATABASE).get();
-    }
 
     @Test
     void onboardedTenantWritesHonestlyAndIsIsolated() throws Exception {
@@ -131,6 +121,49 @@ public class TenantOnboardingIT {
     }
 
     @Test
+    void onboardWithoutCreateSchemaFailsLoudlyBeforeProvisioning() throws Exception {
+        // A typo'd --database must fail before any statement runs — not silently provision a
+        // phantom database with the shared roles granted on it (issue #267).
+        final var err = new ByteArrayOutputStream();
+        final int code = ProvisioningCommand.run(
+                new String[] {"onboard", "--admin-url", endpoint(), "--database", "ript1de",
+                        "--tenant", "phantom", "--org", "phantom-eu",
+                        "--writer-secret", "wP", "--reader-secret", "rP"},
+                discard(), new PrintStream(err, true, StandardCharsets.UTF_8));
+
+        Assertions.assertThat(code).isEqualTo(1);
+        Assertions.assertThat(err.toString(StandardCharsets.UTF_8)).contains("--create-schema");
+        try (var admin = new Client.Builder()
+                .addEndpoint(endpoint()).setUsername("default").setPassword("").build()) {
+            Assertions.assertThat(admin.queryAll("EXISTS DATABASE `ript1de`")
+                    .getFirst().getLong("result")).isZero();
+            Assertions.assertThat(admin.queryAll(
+                            "SELECT count() AS c FROM system.users WHERE name = 'writer_phantom'")
+                    .getFirst().getLong("c")).isZero();
+        }
+    }
+
+    @Test
+    void onboardAcceptsAnAdminProvisionedSchemaWithoutTheFlag() throws Exception {
+        // Brownfield/upgrade path: a manage-mode collector owns the schema first; a plain onboard
+        // (no --create-schema) must accept it — this is also the documented clustered-deployment
+        // shape, where the table is pre-created admin-side.
+        final var config = new ClickhouseConfig();
+        config.setEndpoint(endpoint());
+        config.setUsername(SecretRef.of("default"));
+        config.setDatabase("brown");
+        config.setManageSchema(true);
+        new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), config, RESOLVERS).start();
+
+        final int code = ProvisioningCommand.run(
+                new String[] {"onboard", "--admin-url", endpoint(), "--database", "brown",
+                        "--tenant", "browny", "--org", "brown-eu",
+                        "--writer-secret", "wB", "--reader-secret", "rB"},
+                discard(), discard());
+        Assertions.assertThat(code).isZero();
+    }
+
+    @Test
     void offboardRevokesAccessOnlyWithYes() throws Exception {
         Assertions.assertThat(onboard("temp", "temp-eu", "wT", "rT")).isZero();
         try (var reader = rawClient("bi_temp", "rT")) {
@@ -160,8 +193,9 @@ public class TenantOnboardingIT {
     }
 
     private static String[] onboardArgs(final String tenant, final String org, final String writerPw, final String readerPw) {
+        // --create-schema: nothing is pre-created, so the first onboard bootstraps database + table.
         return new String[] {
-                "onboard", "--admin-url", endpoint(), "--database", DATABASE,
+                "onboard", "--admin-url", endpoint(), "--database", DATABASE, "--create-schema",
                 "--tenant", tenant, "--org", org, "--writer-secret", writerPw, "--reader-secret", readerPw};
     }
 

--- a/src/test/java/org/riptide/schema/FlowsSchemaTest.java
+++ b/src/test/java/org/riptide/schema/FlowsSchemaTest.java
@@ -8,6 +8,7 @@ package org.riptide.schema;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * The flow schema DDL is the single source shared by the collector's manage path and {@code
@@ -50,5 +51,28 @@ class FlowsSchemaTest {
         assertThat(FlowsSchema.createSamplesView("acme_prod"))
                 .contains("VIEW `acme_prod`.samples AS")
                 .contains("FROM `acme_prod`.flows AS flow");
+        assertThat(FlowsSchema.qualifiedFlows("acme_prod")).isEqualTo("`acme_prod`.flows");
+    }
+
+    @Test
+    void ttlIsParameterizedAndDefaultsToTheCollectorRetention() {
+        assertThat(FlowsSchema.createFlowsTable("riptide", 400))
+                .contains("TTL toDateTime(timestamp) + INTERVAL 400 DAY");
+        // The single-arg overload (the collector's manage path) keeps the historical 30 days.
+        assertThat(FlowsSchema.createFlowsTable("riptide"))
+                .contains("TTL toDateTime(timestamp) + INTERVAL 30 DAY");
+    }
+
+    @Test
+    void identRejectsUnsafeDatabaseNames() {
+        // The collector's riptide.clickhouse.database binds without validation, so the quoting
+        // site enforces the charset — a backtick must fail clearly, not emit malformed DDL.
+        assertThatThrownBy(() -> FlowsSchema.createDatabase("ript`ide"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("ript`ide");
+        assertThatThrownBy(() -> FlowsSchema.createFlowsTable("a;b"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> FlowsSchema.createSamplesView(""))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }


### PR DESCRIPTION
Closes #267. Follow-up hardening for the #246/#266 schema bootstrap (all three problems land unreleased, so nothing here is a breaking change for released deployments).

## One mechanism: schema creation is opt-in

- **`onboard --create-schema`** bootstraps database + `flows` table; greenfield stays one command. **`--ttl-days N`** sets the created table's retention (default 30, **max 10950** — see below).
- **Default (no flag):** a pre-flight `EXISTS` check fails loudly **before any statement** when the schema is missing (naming the flag — a typo'd `--database` can no longer silently provision a phantom database), and the statement list contains **no CREATE at all** — ClickHouse checks CREATE privileges even when `IF NOT EXISTS` would no-op (verified on 25.3/26.6), so least-privilege re-runs (password rotation) keep working.
- **Clustered deployments:** documented path is admin-created `ReplicatedMergeTree` (accepted by the pre-flight without the flag); the runbook now carries the **minimum admin privilege set** for both modes.

## Review findings fixed pre-merge (`/code-review` medium, 8 finder angles + 6 verifiers, 2 empirical)

- **TTL wrap = silent data destruction** *(verified on a real server)*: `INTERVAL 49710 DAY` wraps ClickHouse's UInt32 DateTime to a TTL in the past — `CREATE` succeeds and **every inserted row is silently discarded**. `parseTtlDays` now caps at 10950 days with a message naming the 2106 limit.
- **`--ttl-days` was silently ignored** when the table pre-existed (or without the flag): now a usage error without `--create-schema`, and a warning (`TenantProvisioner` returns `OnboardResult(configStanza, schemaBootstrapped)`) when the table pre-existed.
- **`ident()` charset error** now names `riptide.clickhouse.database`/`--database`; the charset restriction is documented in clickhouse.md.
- **Single enforcement point:** `ProvisioningDdl.ident` delegates to `TenantSpec.requireSafe`, so both quoting sites enforce the same rule; `FlowsSchema.qualifiedFlows()` is the one home for the qualified name.
- Two candidates refuted by verification: the pre-flight TOCTOU (self-healing, and emit-always would break privilege-tightened re-runs) and the composed-order unit-test gap (pinned deterministically by `TenantOnboardingIT` in the CI e2e job).

## Testing

- **675 unit tests** green (`mvn verify` incl. SpotBugs/checkstyle/Error Prone).
- **22 ClickHouse ITs** green. `TenantOnboardingIT` now runs against a **genuinely fresh server** (nothing pre-created — the `CREATE DATABASE` half finally exercised end-to-end), plus new cases: missing-database run exits 1 and provisions nothing; brownfield (collector-created schema) onboard succeeds without the flag.