### PR TITLE
feat: bundled Grafana dashboards (Top 10 + Sankey); conserve samples view (#270)

### DIFF
--- a/deployment/clickhouse/compose.yml
+++ b/deployment/clickhouse/compose.yml
@@ -1,3 +1,5 @@
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
 ---
 volumes:
   clickhouse-data:
@@ -46,7 +48,7 @@ services:
     environment:
       TZ: UTC
       GF_SECURITY_ADMIN_PASSWORD: admin
-      GF_INSTALL_PLUGINS: grafana-clickhouse-datasource
+      GF_INSTALL_PLUGINS: grafana-clickhouse-datasource,netsage-sankey-panel
       GF_FEATURE_TOGGLES_ENABLE: nestedFolders
     volumes:
       - gf-data:/var/lib/grafana

--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/.gitkeep
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/.gitkeep
@@ -1,1 +1,0 @@
-# Add directory as a placeholder for dashboards

--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/dashboards.yml
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,15 @@
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+---
+apiVersion: 1
+
+providers:
+  - name: riptide
+    type: file
+    updateIntervalSeconds: 30
+    # UI edits are allowed but live only until the provisioned JSON changes (e.g. an image
+    # update) — the file version then wins. Use "Save as" to keep a customized copy.
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: false

--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-sankey.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-sankey.json
@@ -1,0 +1,228 @@
+{
+  "uid": "riptide-sankey",
+  "title": "Riptide - Traffic Paths (Sankey)",
+  "tags": [
+    "riptide",
+    "netflow"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "5m",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "editable": true,
+  "graphTooltip": 0,
+  "templating": {
+    "list": [
+      {
+        "name": "limit",
+        "label": "Paths",
+        "type": "custom",
+        "query": "10,25,50,100",
+        "options": [],
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "selected": true,
+          "text": "25",
+          "value": "25"
+        }
+      },
+      {
+        "name": "tenant",
+        "label": "Tenant",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "riptide-clickhouse"
+        },
+        "query": {
+          "editorType": "sql",
+          "format": 1,
+          "rawSql": "SELECT DISTINCT tenant FROM flows ORDER BY tenant",
+          "queryType": "table"
+        },
+        "refresh": 1,
+        "includeAll": true,
+        "multi": true,
+        "sort": 1,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "definition": "SELECT DISTINCT tenant FROM flows ORDER BY tenant"
+      },
+      {
+        "name": "zone",
+        "label": "Zone",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "riptide-clickhouse"
+        },
+        "query": {
+          "editorType": "sql",
+          "format": 1,
+          "rawSql": "SELECT DISTINCT zone FROM flows ORDER BY zone",
+          "queryType": "table"
+        },
+        "refresh": 1,
+        "includeAll": true,
+        "multi": true,
+        "sort": 1,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "definition": "SELECT DISTINCT zone FROM flows ORDER BY zone"
+      },
+      {
+        "name": "locality",
+        "label": "Flow locality",
+        "type": "custom",
+        "query": "PUBLIC,PRIVATE",
+        "options": [],
+        "includeAll": true,
+        "multi": false,
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "netsage-sankey-panel",
+      "title": "Traffic paths: Source AS - Ingress interface - Application - Destination AS",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "riptide-clickhouse"
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "riptide-clickhouse"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "queryType": "table",
+          "rawSql": "SELECT concat(toString(srcAs), ': ', ifNull(srcAsOrg, 'unknown')) AS \"Source AS\",\n       concat(exporterAddr, ' - ', ifNull(inputSnmpIfName, concat('if', toString(inputSnmp))), if(inputSnmpIfAlias IS NULL, '', concat(' (', inputSnmpIfAlias, ')'))) AS \"Ingress\",\n       ifNull(application, 'unclassified') AS \"Application\",\n       concat(toString(dstAs), ': ', ifNull(dstAsOrg, 'unknown')) AS \"Destination AS\",\n       sum(bytes) AS \"Bytes\"\nFROM flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Source AS\", \"Ingress\", \"Application\", \"Destination AS\"\nORDER BY \"Bytes\" DESC\nLIMIT $limit",
+          "refId": "A",
+          "meta": {
+            "timezone": "UTC"
+          }
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "netsage-sankey-panel",
+      "title": "Conversations: Source host - Service - Destination host",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "riptide-clickhouse"
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "riptide-clickhouse"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "queryType": "table",
+          "rawSql": "SELECT ifNull(srcAddrHostname, replaceOne(toString(srcAddr), '::ffff:', '')) AS \"Source\",\n       concat(transform(protocol, [1, 2, 6, 17, 41, 47, 50, 51, 58, 89, 132], ['ICMP', 'IGMP', 'TCP', 'UDP', 'IPv6', 'GRE', 'ESP', 'AH', 'IPv6-ICMP', 'OSPFIGP', 'SCTP'], concat('proto-', toString(protocol))), '/', toString(dstPort)) AS \"Service\",\n       ifNull(dstAddrHostname, replaceOne(toString(dstAddr), '::ffff:', '')) AS \"Destination\",\n       sum(bytes) AS \"Bytes\"\nFROM flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Source\", \"Service\", \"Destination\"\nORDER BY \"Bytes\" DESC\nLIMIT $limit",
+          "refId": "A",
+          "meta": {
+            "timezone": "UTC"
+          }
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "netsage-sankey-panel",
+      "title": "Tenancy: Tenant - Zone - Application",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "riptide-clickhouse"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "riptide-clickhouse"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "queryType": "table",
+          "rawSql": "SELECT tenant AS \"Tenant\",\n       zone AS \"Zone\",\n       ifNull(application, 'unclassified') AS \"Application\",\n       sum(bytes) AS \"Bytes\"\nFROM flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Tenant\", \"Zone\", \"Application\"\nORDER BY \"Bytes\" DESC\nLIMIT $limit",
+          "refId": "A",
+          "meta": {
+            "timezone": "UTC"
+          }
+        }
+      ]
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "links": []
+}

--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-sankey.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-sankey.json
@@ -18,6 +18,18 @@
   "templating": {
     "list": [
       {
+        "name": "datasource",
+        "label": "Datasource",
+        "type": "datasource",
+        "query": "grafana-clickhouse-datasource",
+        "refresh": 1,
+        "hide": 0,
+        "current": {},
+        "options": [],
+        "includeAll": false,
+        "multi": false
+      },
+      {
         "name": "limit",
         "label": "Paths",
         "type": "custom",
@@ -37,7 +49,7 @@
         "type": "query",
         "datasource": {
           "type": "grafana-clickhouse-datasource",
-          "uid": "riptide-clickhouse"
+          "uid": "${datasource}"
         },
         "query": {
           "editorType": "sql",
@@ -66,7 +78,7 @@
         "type": "query",
         "datasource": {
           "type": "grafana-clickhouse-datasource",
-          "uid": "riptide-clickhouse"
+          "uid": "${datasource}"
         },
         "query": {
           "editorType": "sql",
@@ -112,7 +124,7 @@
       "title": "Traffic paths: Source AS - Ingress interface - Application - Destination AS",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
-        "uid": "riptide-clickhouse"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 13,
@@ -131,7 +143,7 @@
         {
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "riptide-clickhouse"
+            "uid": "${datasource}"
           },
           "editorType": "sql",
           "format": 1,
@@ -150,7 +162,7 @@
       "title": "Conversations: Source host - Service - Destination host",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
-        "uid": "riptide-clickhouse"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 13,
@@ -169,7 +181,7 @@
         {
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "riptide-clickhouse"
+            "uid": "${datasource}"
           },
           "editorType": "sql",
           "format": 1,
@@ -188,7 +200,7 @@
       "title": "Tenancy: Tenant - Zone - Application",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
-        "uid": "riptide-clickhouse"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 10,
@@ -207,7 +219,7 @@
         {
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "riptide-clickhouse"
+            "uid": "${datasource}"
           },
           "editorType": "sql",
           "format": 1,

--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-sankey.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-sankey.json
@@ -30,6 +30,31 @@
         "multi": false
       },
       {
+        "name": "database",
+        "label": "Database",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${datasource}"
+        },
+        "query": {
+          "editorType": "sql",
+          "format": 1,
+          "queryType": "table",
+          "rawSql": "SELECT DISTINCT database FROM system.tables WHERE name = 'flows'"
+        },
+        "refresh": 1,
+        "includeAll": false,
+        "multi": false,
+        "sort": 1,
+        "current": {
+          "selected": true,
+          "text": "riptide",
+          "value": "riptide"
+        },
+        "definition": "SELECT DISTINCT database FROM system.tables WHERE name = 'flows'"
+      },
+      {
         "name": "limit",
         "label": "Paths",
         "type": "custom",
@@ -54,7 +79,7 @@
         "query": {
           "editorType": "sql",
           "format": 1,
-          "rawSql": "SELECT DISTINCT tenant FROM flows ORDER BY tenant",
+          "rawSql": "SELECT DISTINCT tenant FROM ${database}.flows ORDER BY tenant",
           "queryType": "table"
         },
         "refresh": 1,
@@ -70,7 +95,7 @@
             "$__all"
           ]
         },
-        "definition": "SELECT DISTINCT tenant FROM flows ORDER BY tenant"
+        "definition": "SELECT DISTINCT tenant FROM ${database}.flows ORDER BY tenant"
       },
       {
         "name": "zone",
@@ -83,7 +108,7 @@
         "query": {
           "editorType": "sql",
           "format": 1,
-          "rawSql": "SELECT DISTINCT zone FROM flows ORDER BY zone",
+          "rawSql": "SELECT DISTINCT zone FROM ${database}.flows ORDER BY zone",
           "queryType": "table"
         },
         "refresh": 1,
@@ -99,7 +124,7 @@
             "$__all"
           ]
         },
-        "definition": "SELECT DISTINCT zone FROM flows ORDER BY zone"
+        "definition": "SELECT DISTINCT zone FROM ${database}.flows ORDER BY zone"
       },
       {
         "name": "locality",
@@ -148,7 +173,7 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "SELECT concat(toString(srcAs), ': ', ifNull(srcAsOrg, 'unknown')) AS \"Source AS\",\n       concat(exporterAddr, ' - ', ifNull(inputSnmpIfName, concat('if', toString(inputSnmp))), if(inputSnmpIfAlias IS NULL, '', concat(' (', inputSnmpIfAlias, ')'))) AS \"Ingress\",\n       ifNull(application, 'unclassified') AS \"Application\",\n       concat(toString(dstAs), ': ', ifNull(dstAsOrg, 'unknown')) AS \"Destination AS\",\n       sum(bytes) AS \"Bytes\"\nFROM flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Source AS\", \"Ingress\", \"Application\", \"Destination AS\"\nORDER BY \"Bytes\" DESC\nLIMIT $limit",
+          "rawSql": "SELECT concat(toString(srcAs), ': ', ifNull(srcAsOrg, 'unknown')) AS \"Source AS\",\n       concat(exporterAddr, ' - ', ifNull(inputSnmpIfName, concat('if', toString(inputSnmp))), if(inputSnmpIfAlias IS NULL, '', concat(' (', inputSnmpIfAlias, ')'))) AS \"Ingress\",\n       ifNull(application, 'unclassified') AS \"Application\",\n       concat(toString(dstAs), ': ', ifNull(dstAsOrg, 'unknown')) AS \"Destination AS\",\n       sum(bytes) AS \"Bytes\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Source AS\", \"Ingress\", \"Application\", \"Destination AS\"\nORDER BY \"Bytes\" DESC\nLIMIT $limit",
           "refId": "A",
           "meta": {
             "timezone": "UTC"
@@ -186,7 +211,7 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "SELECT ifNull(srcAddrHostname, replaceOne(toString(srcAddr), '::ffff:', '')) AS \"Source\",\n       concat(transform(protocol, [1, 2, 6, 17, 41, 47, 50, 51, 58, 89, 132], ['ICMP', 'IGMP', 'TCP', 'UDP', 'IPv6', 'GRE', 'ESP', 'AH', 'IPv6-ICMP', 'OSPFIGP', 'SCTP'], concat('proto-', toString(protocol))), '/', toString(dstPort)) AS \"Service\",\n       ifNull(dstAddrHostname, replaceOne(toString(dstAddr), '::ffff:', '')) AS \"Destination\",\n       sum(bytes) AS \"Bytes\"\nFROM flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Source\", \"Service\", \"Destination\"\nORDER BY \"Bytes\" DESC\nLIMIT $limit",
+          "rawSql": "SELECT ifNull(srcAddrHostname, replaceOne(toString(srcAddr), '::ffff:', '')) AS \"Source\",\n       concat(transform(protocol, [1, 2, 6, 17, 41, 47, 50, 51, 58, 89, 132], ['ICMP', 'IGMP', 'TCP', 'UDP', 'IPv6', 'GRE', 'ESP', 'AH', 'IPv6-ICMP', 'OSPFIGP', 'SCTP'], concat('proto-', toString(protocol))), '/', toString(dstPort)) AS \"Service\",\n       ifNull(dstAddrHostname, replaceOne(toString(dstAddr), '::ffff:', '')) AS \"Destination\",\n       sum(bytes) AS \"Bytes\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Source\", \"Service\", \"Destination\"\nORDER BY \"Bytes\" DESC\nLIMIT $limit",
           "refId": "A",
           "meta": {
             "timezone": "UTC"
@@ -224,7 +249,7 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "SELECT tenant AS \"Tenant\",\n       zone AS \"Zone\",\n       ifNull(application, 'unclassified') AS \"Application\",\n       sum(bytes) AS \"Bytes\"\nFROM flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Tenant\", \"Zone\", \"Application\"\nORDER BY \"Bytes\" DESC\nLIMIT $limit",
+          "rawSql": "SELECT tenant AS \"Tenant\",\n       zone AS \"Zone\",\n       ifNull(application, 'unclassified') AS \"Application\",\n       sum(bytes) AS \"Bytes\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Tenant\", \"Zone\", \"Application\"\nORDER BY \"Bytes\" DESC\nLIMIT $limit",
           "refId": "A",
           "meta": {
             "timezone": "UTC"

--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-top-10.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-top-10.json
@@ -1,0 +1,1098 @@
+{
+  "uid": "riptide-top10",
+  "title": "Riptide - Top 10",
+  "tags": [
+    "riptide",
+    "netflow"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "5m",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "editable": true,
+  "graphTooltip": 1,
+  "templating": {
+    "list": [
+      {
+        "name": "bucket",
+        "label": "Bucket size (s)",
+        "type": "custom",
+        "query": "10,30,60,300,900,3600",
+        "options": [],
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "selected": true,
+          "text": "60",
+          "value": "60"
+        }
+      },
+      {
+        "name": "tenant",
+        "label": "Tenant",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "riptide-clickhouse"
+        },
+        "query": {
+          "editorType": "sql",
+          "format": 1,
+          "rawSql": "SELECT DISTINCT tenant FROM flows ORDER BY tenant",
+          "queryType": "table"
+        },
+        "refresh": 1,
+        "includeAll": true,
+        "multi": true,
+        "sort": 1,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "definition": "SELECT DISTINCT tenant FROM flows ORDER BY tenant"
+      },
+      {
+        "name": "zone",
+        "label": "Zone",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "riptide-clickhouse"
+        },
+        "query": {
+          "editorType": "sql",
+          "format": 1,
+          "rawSql": "SELECT DISTINCT zone FROM flows ORDER BY zone",
+          "queryType": "table"
+        },
+        "refresh": 1,
+        "includeAll": true,
+        "multi": true,
+        "sort": 1,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "definition": "SELECT DISTINCT zone FROM flows ORDER BY zone"
+      },
+      {
+        "name": "locality",
+        "label": "Flow locality",
+        "type": "custom",
+        "query": "PUBLIC,PRIVATE",
+        "options": [],
+        "includeAll": true,
+        "multi": false,
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Throughput",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "riptide-clickhouse"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "graphMode": "area",
+        "colorMode": "value",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "riptide-clickhouse"
+          },
+          "editorType": "sql",
+          "format": 0,
+          "queryType": "table",
+          "rawSql": "SELECT timestamp AS time, sum(bytes) * 8 / $bucket AS bps\nFROM samples(ival = $bucket) WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\n  AND timestamp < toStartOfInterval(now(), toIntervalSecond($bucket))\nGROUP BY time ORDER BY time",
+          "refId": "A",
+          "meta": {
+            "timezone": "UTC"
+          }
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Volume (time range)",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "riptide-clickhouse"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "graphMode": "area",
+        "colorMode": "value",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "riptide-clickhouse"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "queryType": "table",
+          "rawSql": "SELECT sum(bytes) AS total FROM flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality)",
+          "refId": "A",
+          "meta": {
+            "timezone": "UTC"
+          }
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Flow records (time range)",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "riptide-clickhouse"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "graphMode": "area",
+        "colorMode": "value",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "riptide-clickhouse"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "queryType": "table",
+          "rawSql": "SELECT count() AS flows FROM flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality)",
+          "refId": "A",
+          "meta": {
+            "timezone": "UTC"
+          }
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Top 10 Source AS",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "riptide-clickhouse"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 30,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            },
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Other"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#7f7f7f"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "riptide-clickhouse"
+          },
+          "editorType": "sql",
+          "format": 0,
+          "queryType": "table",
+          "rawSql": "WITH top AS (SELECT srcAs AS dim FROM flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10)\nSELECT timestamp AS time,\n       if(srcAs IN (SELECT dim FROM top), concat(toString(srcAs), ': ', ifNull(srcAsOrg, 'unknown')), 'Other') AS series,\n       sum(bytes) * 8 / $bucket AS bps\nFROM samples(ival = $bucket)\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\nGROUP BY time, series\nORDER BY time",
+          "refId": "A",
+          "meta": {
+            "timezone": "UTC"
+          }
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Top 10 Destination AS",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "riptide-clickhouse"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 30,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            },
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Other"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#7f7f7f"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "riptide-clickhouse"
+          },
+          "editorType": "sql",
+          "format": 0,
+          "queryType": "table",
+          "rawSql": "WITH top AS (SELECT dstAs AS dim FROM flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10)\nSELECT timestamp AS time,\n       if(dstAs IN (SELECT dim FROM top), concat(toString(dstAs), ': ', ifNull(dstAsOrg, 'unknown')), 'Other') AS series,\n       sum(bytes) * 8 / $bucket AS bps\nFROM samples(ival = $bucket)\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\nGROUP BY time, series\nORDER BY time",
+          "refId": "A",
+          "meta": {
+            "timezone": "UTC"
+          }
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Top 10 Talkers (source hosts)",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "riptide-clickhouse"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 13
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 30,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            },
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Other"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#7f7f7f"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "riptide-clickhouse"
+          },
+          "editorType": "sql",
+          "format": 0,
+          "queryType": "table",
+          "rawSql": "WITH top AS (SELECT srcAddr AS dim FROM flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10)\nSELECT timestamp AS time,\n       if(srcAddr IN (SELECT dim FROM top), ifNull(srcAddrHostname, replaceOne(toString(srcAddr), '::ffff:', '')), 'Other') AS series,\n       sum(bytes) * 8 / $bucket AS bps\nFROM samples(ival = $bucket)\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\nGROUP BY time, series\nORDER BY time",
+          "refId": "A",
+          "meta": {
+            "timezone": "UTC"
+          }
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Top 10 Destinations (destination hosts)",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "riptide-clickhouse"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 13
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 30,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            },
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Other"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#7f7f7f"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "riptide-clickhouse"
+          },
+          "editorType": "sql",
+          "format": 0,
+          "queryType": "table",
+          "rawSql": "WITH top AS (SELECT dstAddr AS dim FROM flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10)\nSELECT timestamp AS time,\n       if(dstAddr IN (SELECT dim FROM top), ifNull(dstAddrHostname, replaceOne(toString(dstAddr), '::ffff:', '')), 'Other') AS series,\n       sum(bytes) * 8 / $bucket AS bps\nFROM samples(ival = $bucket)\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\nGROUP BY time, series\nORDER BY time",
+          "refId": "A",
+          "meta": {
+            "timezone": "UTC"
+          }
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Top 10 Applications",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "riptide-clickhouse"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 30,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            },
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Other"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#7f7f7f"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "riptide-clickhouse"
+          },
+          "editorType": "sql",
+          "format": 0,
+          "queryType": "table",
+          "rawSql": "WITH top AS (SELECT ifNull(application, 'unclassified') AS dim FROM flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10)\nSELECT timestamp AS time,\n       if(ifNull(application, 'unclassified') IN (SELECT dim FROM top), ifNull(application, 'unclassified'), 'Other') AS series,\n       sum(bytes) * 8 / $bucket AS bps\nFROM samples(ival = $bucket)\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\nGROUP BY time, series\nORDER BY time",
+          "refId": "A",
+          "meta": {
+            "timezone": "UTC"
+          }
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Top 10 Services (protocol/destination port)",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "riptide-clickhouse"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 30,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            },
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Other"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#7f7f7f"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "riptide-clickhouse"
+          },
+          "editorType": "sql",
+          "format": 0,
+          "queryType": "table",
+          "rawSql": "WITH top AS (SELECT concat(transform(protocol, [1, 2, 6, 17, 41, 47, 50, 51, 58, 89, 132], ['ICMP', 'IGMP', 'TCP', 'UDP', 'IPv6', 'GRE', 'ESP', 'AH', 'IPv6-ICMP', 'OSPFIGP', 'SCTP'], concat('proto-', toString(protocol))), '/', toString(dstPort)) AS dim FROM flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10)\nSELECT timestamp AS time,\n       if(concat(transform(protocol, [1, 2, 6, 17, 41, 47, 50, 51, 58, 89, 132], ['ICMP', 'IGMP', 'TCP', 'UDP', 'IPv6', 'GRE', 'ESP', 'AH', 'IPv6-ICMP', 'OSPFIGP', 'SCTP'], concat('proto-', toString(protocol))), '/', toString(dstPort)) IN (SELECT dim FROM top), concat(transform(protocol, [1, 2, 6, 17, 41, 47, 50, 51, 58, 89, 132], ['ICMP', 'IGMP', 'TCP', 'UDP', 'IPv6', 'GRE', 'ESP', 'AH', 'IPv6-ICMP', 'OSPFIGP', 'SCTP'], concat('proto-', toString(protocol))), '/', toString(dstPort)), 'Other') AS series,\n       sum(bytes) * 8 / $bucket AS bps\nFROM samples(ival = $bucket)\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\nGROUP BY time, series\nORDER BY time",
+          "refId": "A",
+          "meta": {
+            "timezone": "UTC"
+          }
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Top 10 Protocols",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "riptide-clickhouse"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 31
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 30,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            },
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Other"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#7f7f7f"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "riptide-clickhouse"
+          },
+          "editorType": "sql",
+          "format": 0,
+          "queryType": "table",
+          "rawSql": "WITH top AS (SELECT transform(protocol, [1, 2, 6, 17, 41, 47, 50, 51, 58, 89, 132], ['ICMP', 'IGMP', 'TCP', 'UDP', 'IPv6', 'GRE', 'ESP', 'AH', 'IPv6-ICMP', 'OSPFIGP', 'SCTP'], concat('proto-', toString(protocol))) AS dim FROM flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10)\nSELECT timestamp AS time,\n       if(transform(protocol, [1, 2, 6, 17, 41, 47, 50, 51, 58, 89, 132], ['ICMP', 'IGMP', 'TCP', 'UDP', 'IPv6', 'GRE', 'ESP', 'AH', 'IPv6-ICMP', 'OSPFIGP', 'SCTP'], concat('proto-', toString(protocol))) IN (SELECT dim FROM top), transform(protocol, [1, 2, 6, 17, 41, 47, 50, 51, 58, 89, 132], ['ICMP', 'IGMP', 'TCP', 'UDP', 'IPv6', 'GRE', 'ESP', 'AH', 'IPv6-ICMP', 'OSPFIGP', 'SCTP'], concat('proto-', toString(protocol))), 'Other') AS series,\n       sum(bytes) * 8 / $bucket AS bps\nFROM samples(ival = $bucket)\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\nGROUP BY time, series\nORDER BY time",
+          "refId": "A",
+          "meta": {
+            "timezone": "UTC"
+          }
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Top 10 Exporters",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "riptide-clickhouse"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 31
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 30,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            },
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Other"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#7f7f7f"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "riptide-clickhouse"
+          },
+          "editorType": "sql",
+          "format": 0,
+          "queryType": "table",
+          "rawSql": "WITH top AS (SELECT exporterAddr AS dim FROM flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10)\nSELECT timestamp AS time,\n       if(exporterAddr IN (SELECT dim FROM top), exporterAddr, 'Other') AS series,\n       sum(bytes) * 8 / $bucket AS bps\nFROM samples(ival = $bucket)\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\nGROUP BY time, series\nORDER BY time",
+          "refId": "A",
+          "meta": {
+            "timezone": "UTC"
+          }
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Top 10 Ingress Interfaces",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "riptide-clickhouse"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 30,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            },
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Other"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#7f7f7f"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "riptide-clickhouse"
+          },
+          "editorType": "sql",
+          "format": 0,
+          "queryType": "table",
+          "rawSql": "WITH top AS (SELECT concat(exporterAddr, ' - ', ifNull(inputSnmpIfName, concat('if', toString(inputSnmp))), if(inputSnmpIfAlias IS NULL, '', concat(' (', inputSnmpIfAlias, ')'))) AS dim FROM flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10)\nSELECT timestamp AS time,\n       if(concat(exporterAddr, ' - ', ifNull(inputSnmpIfName, concat('if', toString(inputSnmp))), if(inputSnmpIfAlias IS NULL, '', concat(' (', inputSnmpIfAlias, ')'))) IN (SELECT dim FROM top), concat(exporterAddr, ' - ', ifNull(inputSnmpIfName, concat('if', toString(inputSnmp))), if(inputSnmpIfAlias IS NULL, '', concat(' (', inputSnmpIfAlias, ')'))), 'Other') AS series,\n       sum(bytes) * 8 / $bucket AS bps\nFROM samples(ival = $bucket)\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\nGROUP BY time, series\nORDER BY time",
+          "refId": "A",
+          "meta": {
+            "timezone": "UTC"
+          }
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "table",
+      "title": "Top 10 Source AS - statistics",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "riptide-clickhouse"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 49
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            }
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "decbytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Src AS"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "string"
+              },
+              {
+                "id": "custom.width",
+                "value": 320
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "Average",
+            "desc": true
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "riptide-clickhouse"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "queryType": "table",
+          "rawSql": "WITH top AS (SELECT srcAs AS dim FROM flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10),\n     intDiv(toUnixTimestamp($__toTime), $bucket)\n       - intDiv(toUnixTimestamp($__fromTime) + $bucket - 1, $bucket) + 1 AS nBuckets,\n     arrayResize(groupArray(bps), greatest(nBuckets, length(groupArray(bps))), 0.) AS padded\nSELECT series AS \"Src AS\",\n       arrayMin(padded) AS \"Min\", arrayMax(padded) AS \"Max\", argMax(bps, time) AS \"Last\",\n       arrayAvg(padded) AS \"Average\", arrayReduce('quantile(0.95)', padded) AS \"95th\",\n       sum(bucket_bytes) AS \"Total\"\nFROM (\n    SELECT timestamp AS time, concat(toString(srcAs), ': ', ifNull(srcAsOrg, 'unknown')) AS series,\n           sum(bytes) * 8 / $bucket AS bps, sum(bytes) AS bucket_bytes\n    FROM samples(ival = $bucket)\n    WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND AND srcAs IN (SELECT dim FROM top)\n      AND timestamp < toStartOfInterval(now(), toIntervalSecond($bucket))\n    GROUP BY time, series\n)\nGROUP BY series\nORDER BY \"Average\" DESC",
+          "refId": "A",
+          "meta": {
+            "timezone": "UTC"
+          }
+        }
+      ]
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "links": []
+}

--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-top-10.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-top-10.json
@@ -30,6 +30,31 @@
         "multi": false
       },
       {
+        "name": "database",
+        "label": "Database",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${datasource}"
+        },
+        "query": {
+          "editorType": "sql",
+          "format": 1,
+          "queryType": "table",
+          "rawSql": "SELECT DISTINCT database FROM system.tables WHERE name = 'flows'"
+        },
+        "refresh": 1,
+        "includeAll": false,
+        "multi": false,
+        "sort": 1,
+        "current": {
+          "selected": true,
+          "text": "riptide",
+          "value": "riptide"
+        },
+        "definition": "SELECT DISTINCT database FROM system.tables WHERE name = 'flows'"
+      },
+      {
         "name": "bucket",
         "label": "Bucket size (s)",
         "type": "custom",
@@ -54,7 +79,7 @@
         "query": {
           "editorType": "sql",
           "format": 1,
-          "rawSql": "SELECT DISTINCT tenant FROM flows ORDER BY tenant",
+          "rawSql": "SELECT DISTINCT tenant FROM ${database}.flows ORDER BY tenant",
           "queryType": "table"
         },
         "refresh": 1,
@@ -70,7 +95,7 @@
             "$__all"
           ]
         },
-        "definition": "SELECT DISTINCT tenant FROM flows ORDER BY tenant"
+        "definition": "SELECT DISTINCT tenant FROM ${database}.flows ORDER BY tenant"
       },
       {
         "name": "zone",
@@ -83,7 +108,7 @@
         "query": {
           "editorType": "sql",
           "format": 1,
-          "rawSql": "SELECT DISTINCT zone FROM flows ORDER BY zone",
+          "rawSql": "SELECT DISTINCT zone FROM ${database}.flows ORDER BY zone",
           "queryType": "table"
         },
         "refresh": 1,
@@ -99,7 +124,7 @@
             "$__all"
           ]
         },
-        "definition": "SELECT DISTINCT zone FROM flows ORDER BY zone"
+        "definition": "SELECT DISTINCT zone FROM ${database}.flows ORDER BY zone"
       },
       {
         "name": "locality",
@@ -162,7 +187,7 @@
           "editorType": "sql",
           "format": 0,
           "queryType": "table",
-          "rawSql": "SELECT timestamp AS time, sum(bytes) * 8 / $bucket AS bps\nFROM samples(ival = $bucket) WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\n  AND timestamp < toStartOfInterval(now(), toIntervalSecond($bucket))\nGROUP BY time ORDER BY time",
+          "rawSql": "SELECT timestamp AS time, sum(bytes) * 8 / $bucket AS bps\nFROM ${database}.samples(ival = $bucket) WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\n  AND timestamp < toStartOfInterval(now(), toIntervalSecond($bucket))\nGROUP BY time ORDER BY time",
           "refId": "A",
           "meta": {
             "timezone": "UTC"
@@ -214,7 +239,7 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "SELECT sum(bytes) AS total FROM flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality)",
+          "rawSql": "SELECT sum(bytes) AS total FROM ${database}.flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality)",
           "refId": "A",
           "meta": {
             "timezone": "UTC"
@@ -266,7 +291,7 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "SELECT count() AS flows FROM flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality)",
+          "rawSql": "SELECT count() AS flows FROM ${database}.flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality)",
           "refId": "A",
           "meta": {
             "timezone": "UTC"
@@ -349,7 +374,7 @@
           "editorType": "sql",
           "format": 0,
           "queryType": "table",
-          "rawSql": "WITH top AS (SELECT srcAs AS dim FROM flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10)\nSELECT timestamp AS time,\n       if(srcAs IN (SELECT dim FROM top), concat(toString(srcAs), ': ', ifNull(srcAsOrg, 'unknown')), 'Other') AS series,\n       sum(bytes) * 8 / $bucket AS bps\nFROM samples(ival = $bucket)\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\nGROUP BY time, series\nORDER BY time",
+          "rawSql": "WITH top AS (SELECT srcAs AS dim FROM ${database}.flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10)\nSELECT timestamp AS time,\n       if(srcAs IN (SELECT dim FROM top), concat(toString(srcAs), ': ', ifNull(srcAsOrg, 'unknown')), 'Other') AS series,\n       sum(bytes) * 8 / $bucket AS bps\nFROM ${database}.samples(ival = $bucket)\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\nGROUP BY time, series\nORDER BY time",
           "refId": "A",
           "meta": {
             "timezone": "UTC"
@@ -432,7 +457,7 @@
           "editorType": "sql",
           "format": 0,
           "queryType": "table",
-          "rawSql": "WITH top AS (SELECT dstAs AS dim FROM flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10)\nSELECT timestamp AS time,\n       if(dstAs IN (SELECT dim FROM top), concat(toString(dstAs), ': ', ifNull(dstAsOrg, 'unknown')), 'Other') AS series,\n       sum(bytes) * 8 / $bucket AS bps\nFROM samples(ival = $bucket)\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\nGROUP BY time, series\nORDER BY time",
+          "rawSql": "WITH top AS (SELECT dstAs AS dim FROM ${database}.flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10)\nSELECT timestamp AS time,\n       if(dstAs IN (SELECT dim FROM top), concat(toString(dstAs), ': ', ifNull(dstAsOrg, 'unknown')), 'Other') AS series,\n       sum(bytes) * 8 / $bucket AS bps\nFROM ${database}.samples(ival = $bucket)\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\nGROUP BY time, series\nORDER BY time",
           "refId": "A",
           "meta": {
             "timezone": "UTC"
@@ -515,7 +540,7 @@
           "editorType": "sql",
           "format": 0,
           "queryType": "table",
-          "rawSql": "WITH top AS (SELECT srcAddr AS dim FROM flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10)\nSELECT timestamp AS time,\n       if(srcAddr IN (SELECT dim FROM top), ifNull(srcAddrHostname, replaceOne(toString(srcAddr), '::ffff:', '')), 'Other') AS series,\n       sum(bytes) * 8 / $bucket AS bps\nFROM samples(ival = $bucket)\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\nGROUP BY time, series\nORDER BY time",
+          "rawSql": "WITH top AS (SELECT srcAddr AS dim FROM ${database}.flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10)\nSELECT timestamp AS time,\n       if(srcAddr IN (SELECT dim FROM top), ifNull(srcAddrHostname, replaceOne(toString(srcAddr), '::ffff:', '')), 'Other') AS series,\n       sum(bytes) * 8 / $bucket AS bps\nFROM ${database}.samples(ival = $bucket)\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\nGROUP BY time, series\nORDER BY time",
           "refId": "A",
           "meta": {
             "timezone": "UTC"
@@ -598,7 +623,7 @@
           "editorType": "sql",
           "format": 0,
           "queryType": "table",
-          "rawSql": "WITH top AS (SELECT dstAddr AS dim FROM flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10)\nSELECT timestamp AS time,\n       if(dstAddr IN (SELECT dim FROM top), ifNull(dstAddrHostname, replaceOne(toString(dstAddr), '::ffff:', '')), 'Other') AS series,\n       sum(bytes) * 8 / $bucket AS bps\nFROM samples(ival = $bucket)\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\nGROUP BY time, series\nORDER BY time",
+          "rawSql": "WITH top AS (SELECT dstAddr AS dim FROM ${database}.flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10)\nSELECT timestamp AS time,\n       if(dstAddr IN (SELECT dim FROM top), ifNull(dstAddrHostname, replaceOne(toString(dstAddr), '::ffff:', '')), 'Other') AS series,\n       sum(bytes) * 8 / $bucket AS bps\nFROM ${database}.samples(ival = $bucket)\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\nGROUP BY time, series\nORDER BY time",
           "refId": "A",
           "meta": {
             "timezone": "UTC"
@@ -681,7 +706,7 @@
           "editorType": "sql",
           "format": 0,
           "queryType": "table",
-          "rawSql": "WITH top AS (SELECT ifNull(application, 'unclassified') AS dim FROM flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10)\nSELECT timestamp AS time,\n       if(ifNull(application, 'unclassified') IN (SELECT dim FROM top), ifNull(application, 'unclassified'), 'Other') AS series,\n       sum(bytes) * 8 / $bucket AS bps\nFROM samples(ival = $bucket)\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\nGROUP BY time, series\nORDER BY time",
+          "rawSql": "WITH top AS (SELECT ifNull(application, 'unclassified') AS dim FROM ${database}.flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10)\nSELECT timestamp AS time,\n       if(ifNull(application, 'unclassified') IN (SELECT dim FROM top), ifNull(application, 'unclassified'), 'Other') AS series,\n       sum(bytes) * 8 / $bucket AS bps\nFROM ${database}.samples(ival = $bucket)\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\nGROUP BY time, series\nORDER BY time",
           "refId": "A",
           "meta": {
             "timezone": "UTC"
@@ -764,7 +789,7 @@
           "editorType": "sql",
           "format": 0,
           "queryType": "table",
-          "rawSql": "WITH top AS (SELECT concat(transform(protocol, [1, 2, 6, 17, 41, 47, 50, 51, 58, 89, 132], ['ICMP', 'IGMP', 'TCP', 'UDP', 'IPv6', 'GRE', 'ESP', 'AH', 'IPv6-ICMP', 'OSPFIGP', 'SCTP'], concat('proto-', toString(protocol))), '/', toString(dstPort)) AS dim FROM flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10)\nSELECT timestamp AS time,\n       if(concat(transform(protocol, [1, 2, 6, 17, 41, 47, 50, 51, 58, 89, 132], ['ICMP', 'IGMP', 'TCP', 'UDP', 'IPv6', 'GRE', 'ESP', 'AH', 'IPv6-ICMP', 'OSPFIGP', 'SCTP'], concat('proto-', toString(protocol))), '/', toString(dstPort)) IN (SELECT dim FROM top), concat(transform(protocol, [1, 2, 6, 17, 41, 47, 50, 51, 58, 89, 132], ['ICMP', 'IGMP', 'TCP', 'UDP', 'IPv6', 'GRE', 'ESP', 'AH', 'IPv6-ICMP', 'OSPFIGP', 'SCTP'], concat('proto-', toString(protocol))), '/', toString(dstPort)), 'Other') AS series,\n       sum(bytes) * 8 / $bucket AS bps\nFROM samples(ival = $bucket)\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\nGROUP BY time, series\nORDER BY time",
+          "rawSql": "WITH top AS (SELECT concat(transform(protocol, [1, 2, 6, 17, 41, 47, 50, 51, 58, 89, 132], ['ICMP', 'IGMP', 'TCP', 'UDP', 'IPv6', 'GRE', 'ESP', 'AH', 'IPv6-ICMP', 'OSPFIGP', 'SCTP'], concat('proto-', toString(protocol))), '/', toString(dstPort)) AS dim FROM ${database}.flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10)\nSELECT timestamp AS time,\n       if(concat(transform(protocol, [1, 2, 6, 17, 41, 47, 50, 51, 58, 89, 132], ['ICMP', 'IGMP', 'TCP', 'UDP', 'IPv6', 'GRE', 'ESP', 'AH', 'IPv6-ICMP', 'OSPFIGP', 'SCTP'], concat('proto-', toString(protocol))), '/', toString(dstPort)) IN (SELECT dim FROM top), concat(transform(protocol, [1, 2, 6, 17, 41, 47, 50, 51, 58, 89, 132], ['ICMP', 'IGMP', 'TCP', 'UDP', 'IPv6', 'GRE', 'ESP', 'AH', 'IPv6-ICMP', 'OSPFIGP', 'SCTP'], concat('proto-', toString(protocol))), '/', toString(dstPort)), 'Other') AS series,\n       sum(bytes) * 8 / $bucket AS bps\nFROM ${database}.samples(ival = $bucket)\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\nGROUP BY time, series\nORDER BY time",
           "refId": "A",
           "meta": {
             "timezone": "UTC"
@@ -847,7 +872,7 @@
           "editorType": "sql",
           "format": 0,
           "queryType": "table",
-          "rawSql": "WITH top AS (SELECT transform(protocol, [1, 2, 6, 17, 41, 47, 50, 51, 58, 89, 132], ['ICMP', 'IGMP', 'TCP', 'UDP', 'IPv6', 'GRE', 'ESP', 'AH', 'IPv6-ICMP', 'OSPFIGP', 'SCTP'], concat('proto-', toString(protocol))) AS dim FROM flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10)\nSELECT timestamp AS time,\n       if(transform(protocol, [1, 2, 6, 17, 41, 47, 50, 51, 58, 89, 132], ['ICMP', 'IGMP', 'TCP', 'UDP', 'IPv6', 'GRE', 'ESP', 'AH', 'IPv6-ICMP', 'OSPFIGP', 'SCTP'], concat('proto-', toString(protocol))) IN (SELECT dim FROM top), transform(protocol, [1, 2, 6, 17, 41, 47, 50, 51, 58, 89, 132], ['ICMP', 'IGMP', 'TCP', 'UDP', 'IPv6', 'GRE', 'ESP', 'AH', 'IPv6-ICMP', 'OSPFIGP', 'SCTP'], concat('proto-', toString(protocol))), 'Other') AS series,\n       sum(bytes) * 8 / $bucket AS bps\nFROM samples(ival = $bucket)\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\nGROUP BY time, series\nORDER BY time",
+          "rawSql": "WITH top AS (SELECT transform(protocol, [1, 2, 6, 17, 41, 47, 50, 51, 58, 89, 132], ['ICMP', 'IGMP', 'TCP', 'UDP', 'IPv6', 'GRE', 'ESP', 'AH', 'IPv6-ICMP', 'OSPFIGP', 'SCTP'], concat('proto-', toString(protocol))) AS dim FROM ${database}.flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10)\nSELECT timestamp AS time,\n       if(transform(protocol, [1, 2, 6, 17, 41, 47, 50, 51, 58, 89, 132], ['ICMP', 'IGMP', 'TCP', 'UDP', 'IPv6', 'GRE', 'ESP', 'AH', 'IPv6-ICMP', 'OSPFIGP', 'SCTP'], concat('proto-', toString(protocol))) IN (SELECT dim FROM top), transform(protocol, [1, 2, 6, 17, 41, 47, 50, 51, 58, 89, 132], ['ICMP', 'IGMP', 'TCP', 'UDP', 'IPv6', 'GRE', 'ESP', 'AH', 'IPv6-ICMP', 'OSPFIGP', 'SCTP'], concat('proto-', toString(protocol))), 'Other') AS series,\n       sum(bytes) * 8 / $bucket AS bps\nFROM ${database}.samples(ival = $bucket)\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\nGROUP BY time, series\nORDER BY time",
           "refId": "A",
           "meta": {
             "timezone": "UTC"
@@ -930,7 +955,7 @@
           "editorType": "sql",
           "format": 0,
           "queryType": "table",
-          "rawSql": "WITH top AS (SELECT exporterAddr AS dim FROM flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10)\nSELECT timestamp AS time,\n       if(exporterAddr IN (SELECT dim FROM top), exporterAddr, 'Other') AS series,\n       sum(bytes) * 8 / $bucket AS bps\nFROM samples(ival = $bucket)\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\nGROUP BY time, series\nORDER BY time",
+          "rawSql": "WITH top AS (SELECT exporterAddr AS dim FROM ${database}.flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10)\nSELECT timestamp AS time,\n       if(exporterAddr IN (SELECT dim FROM top), exporterAddr, 'Other') AS series,\n       sum(bytes) * 8 / $bucket AS bps\nFROM ${database}.samples(ival = $bucket)\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\nGROUP BY time, series\nORDER BY time",
           "refId": "A",
           "meta": {
             "timezone": "UTC"
@@ -1013,7 +1038,7 @@
           "editorType": "sql",
           "format": 0,
           "queryType": "table",
-          "rawSql": "WITH top AS (SELECT concat(exporterAddr, ' - ', ifNull(inputSnmpIfName, concat('if', toString(inputSnmp))), if(inputSnmpIfAlias IS NULL, '', concat(' (', inputSnmpIfAlias, ')'))) AS dim FROM flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10)\nSELECT timestamp AS time,\n       if(concat(exporterAddr, ' - ', ifNull(inputSnmpIfName, concat('if', toString(inputSnmp))), if(inputSnmpIfAlias IS NULL, '', concat(' (', inputSnmpIfAlias, ')'))) IN (SELECT dim FROM top), concat(exporterAddr, ' - ', ifNull(inputSnmpIfName, concat('if', toString(inputSnmp))), if(inputSnmpIfAlias IS NULL, '', concat(' (', inputSnmpIfAlias, ')'))), 'Other') AS series,\n       sum(bytes) * 8 / $bucket AS bps\nFROM samples(ival = $bucket)\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\nGROUP BY time, series\nORDER BY time",
+          "rawSql": "WITH top AS (SELECT concat(exporterAddr, ' - ', ifNull(inputSnmpIfName, concat('if', toString(inputSnmp))), if(inputSnmpIfAlias IS NULL, '', concat(' (', inputSnmpIfAlias, ')'))) AS dim FROM ${database}.flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10)\nSELECT timestamp AS time,\n       if(concat(exporterAddr, ' - ', ifNull(inputSnmpIfName, concat('if', toString(inputSnmp))), if(inputSnmpIfAlias IS NULL, '', concat(' (', inputSnmpIfAlias, ')'))) IN (SELECT dim FROM top), concat(exporterAddr, ' - ', ifNull(inputSnmpIfName, concat('if', toString(inputSnmp))), if(inputSnmpIfAlias IS NULL, '', concat(' (', inputSnmpIfAlias, ')'))), 'Other') AS series,\n       sum(bytes) * 8 / $bucket AS bps\nFROM ${database}.samples(ival = $bucket)\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND\nGROUP BY time, series\nORDER BY time",
           "refId": "A",
           "meta": {
             "timezone": "UTC"
@@ -1094,7 +1119,7 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "WITH top AS (SELECT srcAs AS dim FROM flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10),\n     intDiv(toUnixTimestamp($__toTime), $bucket)\n       - intDiv(toUnixTimestamp($__fromTime) + $bucket - 1, $bucket) + 1 AS nBuckets,\n     arrayResize(groupArray(bps), greatest(nBuckets, length(groupArray(bps))), 0.) AS padded\nSELECT series AS \"Src AS\",\n       arrayMin(padded) AS \"Min\", arrayMax(padded) AS \"Max\", argMax(bps, time) AS \"Last\",\n       arrayAvg(padded) AS \"Average\", arrayReduce('quantile(0.95)', padded) AS \"95th\",\n       sum(bucket_bytes) AS \"Total\"\nFROM (\n    SELECT timestamp AS time, concat(toString(srcAs), ': ', ifNull(srcAsOrg, 'unknown')) AS series,\n           sum(bytes) * 8 / $bucket AS bps, sum(bytes) AS bucket_bytes\n    FROM samples(ival = $bucket)\n    WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND AND srcAs IN (SELECT dim FROM top)\n      AND timestamp < toStartOfInterval(now(), toIntervalSecond($bucket))\n    GROUP BY time, series\n)\nGROUP BY series\nORDER BY \"Average\" DESC",
+          "rawSql": "WITH top AS (SELECT srcAs AS dim FROM ${database}.flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10),\n     intDiv(toUnixTimestamp($__toTime), $bucket)\n       - intDiv(toUnixTimestamp($__fromTime) + $bucket - 1, $bucket) + 1 AS nBuckets,\n     arrayResize(groupArray(bps), greatest(nBuckets, length(groupArray(bps))), 0.) AS padded\nSELECT series AS \"Src AS\",\n       arrayMin(padded) AS \"Min\", arrayMax(padded) AS \"Max\", argMax(bps, time) AS \"Last\",\n       arrayAvg(padded) AS \"Average\", arrayReduce('quantile(0.95)', padded) AS \"95th\",\n       sum(bucket_bytes) AS \"Total\"\nFROM (\n    SELECT timestamp AS time, concat(toString(srcAs), ': ', ifNull(srcAsOrg, 'unknown')) AS series,\n           sum(bytes) * 8 / $bucket AS bps, sum(bytes) AS bucket_bytes\n    FROM ${database}.samples(ival = $bucket)\n    WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND AND srcAs IN (SELECT dim FROM top)\n      AND timestamp < toStartOfInterval(now(), toIntervalSecond($bucket))\n    GROUP BY time, series\n)\nGROUP BY series\nORDER BY \"Average\" DESC",
           "refId": "A",
           "meta": {
             "timezone": "UTC"

--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-top-10.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-top-10.json
@@ -18,6 +18,18 @@
   "templating": {
     "list": [
       {
+        "name": "datasource",
+        "label": "Datasource",
+        "type": "datasource",
+        "query": "grafana-clickhouse-datasource",
+        "refresh": 1,
+        "hide": 0,
+        "current": {},
+        "options": [],
+        "includeAll": false,
+        "multi": false
+      },
+      {
         "name": "bucket",
         "label": "Bucket size (s)",
         "type": "custom",
@@ -37,7 +49,7 @@
         "type": "query",
         "datasource": {
           "type": "grafana-clickhouse-datasource",
-          "uid": "riptide-clickhouse"
+          "uid": "${datasource}"
         },
         "query": {
           "editorType": "sql",
@@ -66,7 +78,7 @@
         "type": "query",
         "datasource": {
           "type": "grafana-clickhouse-datasource",
-          "uid": "riptide-clickhouse"
+          "uid": "${datasource}"
         },
         "query": {
           "editorType": "sql",
@@ -112,7 +124,7 @@
       "title": "Throughput",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
-        "uid": "riptide-clickhouse"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 4,
@@ -145,7 +157,7 @@
         {
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "riptide-clickhouse"
+            "uid": "${datasource}"
           },
           "editorType": "sql",
           "format": 0,
@@ -164,7 +176,7 @@
       "title": "Volume (time range)",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
-        "uid": "riptide-clickhouse"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 4,
@@ -197,7 +209,7 @@
         {
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "riptide-clickhouse"
+            "uid": "${datasource}"
           },
           "editorType": "sql",
           "format": 1,
@@ -216,7 +228,7 @@
       "title": "Flow records (time range)",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
-        "uid": "riptide-clickhouse"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 4,
@@ -249,7 +261,7 @@
         {
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "riptide-clickhouse"
+            "uid": "${datasource}"
           },
           "editorType": "sql",
           "format": 1,
@@ -268,7 +280,7 @@
       "title": "Top 10 Source AS",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
-        "uid": "riptide-clickhouse"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 9,
@@ -332,7 +344,7 @@
         {
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "riptide-clickhouse"
+            "uid": "${datasource}"
           },
           "editorType": "sql",
           "format": 0,
@@ -351,7 +363,7 @@
       "title": "Top 10 Destination AS",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
-        "uid": "riptide-clickhouse"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 9,
@@ -415,7 +427,7 @@
         {
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "riptide-clickhouse"
+            "uid": "${datasource}"
           },
           "editorType": "sql",
           "format": 0,
@@ -434,7 +446,7 @@
       "title": "Top 10 Talkers (source hosts)",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
-        "uid": "riptide-clickhouse"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 9,
@@ -498,7 +510,7 @@
         {
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "riptide-clickhouse"
+            "uid": "${datasource}"
           },
           "editorType": "sql",
           "format": 0,
@@ -517,7 +529,7 @@
       "title": "Top 10 Destinations (destination hosts)",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
-        "uid": "riptide-clickhouse"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 9,
@@ -581,7 +593,7 @@
         {
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "riptide-clickhouse"
+            "uid": "${datasource}"
           },
           "editorType": "sql",
           "format": 0,
@@ -600,7 +612,7 @@
       "title": "Top 10 Applications",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
-        "uid": "riptide-clickhouse"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 9,
@@ -664,7 +676,7 @@
         {
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "riptide-clickhouse"
+            "uid": "${datasource}"
           },
           "editorType": "sql",
           "format": 0,
@@ -683,7 +695,7 @@
       "title": "Top 10 Services (protocol/destination port)",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
-        "uid": "riptide-clickhouse"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 9,
@@ -747,7 +759,7 @@
         {
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "riptide-clickhouse"
+            "uid": "${datasource}"
           },
           "editorType": "sql",
           "format": 0,
@@ -766,7 +778,7 @@
       "title": "Top 10 Protocols",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
-        "uid": "riptide-clickhouse"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 9,
@@ -830,7 +842,7 @@
         {
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "riptide-clickhouse"
+            "uid": "${datasource}"
           },
           "editorType": "sql",
           "format": 0,
@@ -849,7 +861,7 @@
       "title": "Top 10 Exporters",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
-        "uid": "riptide-clickhouse"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 9,
@@ -913,7 +925,7 @@
         {
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "riptide-clickhouse"
+            "uid": "${datasource}"
           },
           "editorType": "sql",
           "format": 0,
@@ -932,7 +944,7 @@
       "title": "Top 10 Ingress Interfaces",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
-        "uid": "riptide-clickhouse"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 9,
@@ -996,7 +1008,7 @@
         {
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "riptide-clickhouse"
+            "uid": "${datasource}"
           },
           "editorType": "sql",
           "format": 0,
@@ -1015,7 +1027,7 @@
       "title": "Top 10 Source AS - statistics",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
-        "uid": "riptide-clickhouse"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 10,
@@ -1077,7 +1089,7 @@
         {
           "datasource": {
             "type": "grafana-clickhouse-datasource",
-            "uid": "riptide-clickhouse"
+            "uid": "${datasource}"
           },
           "editorType": "sql",
           "format": 1,

--- a/deployment/clickhouse/container-fs/grafana/provisioning/datasources/datasource.yml
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/datasources/datasource.yml
@@ -1,8 +1,12 @@
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
 ---
 apiVersion: 1
 
 datasources:
   - name: ClickHouse
+    # Stable uid so provisioned dashboards can reference this datasource.
+    uid: riptide-clickhouse
     type: grafana-clickhouse-datasource
     jsonData:
       defaultDatabase: riptide

--- a/docs/docs/configuration/clickhouse.md
+++ b/docs/docs/configuration/clickhouse.md
@@ -50,6 +50,15 @@ what ClickHouse accepts under backtick quoting; rename such a database or use va
   the `samples` view with `CREATE OR REPLACE VIEW` (a view holds no data, so it is always
   refreshed and can never go stale). A fresh install is created; a restart keeps the data — so
   **flow data now survives a Riptide restart**.
+
+  :::warning[Hand-created `samples` views need re-creating]
+
+  The `samples` bucket split was corrected in #270 (older definitions under-report traffic by up
+  to the flow's bucket count). Manage-mode collectors heal on restart, but a `samples` view an
+  admin created by hand — e.g. in a provisioned deployment — keeps the old formula until it is
+  re-created from the current definition.
+
+  :::
 - **`false` (provisioned / multi-tenant)** — the collector creates nothing. It validates that the
   `flows` table exists and carries every column it inserts and **fails startup with a clear,
   provisioning-pointing error** if it does not. Use this when an admin owns the schema and

--- a/docs/docs/deploy/docker-compose.md
+++ b/docs/docs/deploy/docker-compose.md
@@ -33,8 +33,10 @@ Grafana (admin/admin) ships two provisioned dashboards backed by the `flows` tab
 
 The JSON sources live in `deployment/clickhouse/container-fs/grafana/provisioning/dashboards/`.
 UI edits last only until the provisioned JSON changes — use *Save as* to keep a customized copy.
-The dashboards query the `riptide` database (the datasource's `defaultDatabase`); if you change
-`riptide.clickhouse.database`, adjust the provisioned datasource to match.
+Both dashboards select their ClickHouse connection through a **Datasource** variable, so they can
+also be imported into an external Grafana — any `grafana-clickhouse-datasource` whose
+`defaultDatabase` points at the riptide database works (if you change
+`riptide.clickhouse.database`, adjust the datasource to match).
 
 Point a NetFlow v5/v9 or IPFIX exporter at UDP `9999` and watch rows arrive in
 `riptide.flows` via ch-ui. Configure [receivers](../configuration/receivers.md) and

--- a/docs/docs/deploy/docker-compose.md
+++ b/docs/docs/deploy/docker-compose.md
@@ -23,6 +23,19 @@ This starts, from `ghcr.io/riptide-labs/riptide:latest`:
 | ch-ui | [`:5521`](http://localhost:5521) | browse the `riptide.flows` table |
 | grafana | [`:3000`](http://localhost:3000) | dashboards (ClickHouse datasource provisioned) |
 
+Grafana (admin/admin) ships two provisioned dashboards backed by the `flows` table and the
+`samples` bucket-expansion view:
+
+- **Riptide - Top 10**: stacked top-10 rate panels (AS, hosts, applications, services, protocols,
+  exporters, interfaces) plus a source-AS statistics table with a 95th-percentile column.
+- **Riptide - Traffic Paths (Sankey)**: Kentik-style path diagrams (source AS → ingress
+  interface → application → destination AS, and more), weighted by bytes over the selected range.
+
+The JSON sources live in `deployment/clickhouse/container-fs/grafana/provisioning/dashboards/`.
+UI edits last only until the provisioned JSON changes — use *Save as* to keep a customized copy.
+The dashboards query the `riptide` database (the datasource's `defaultDatabase`); if you change
+`riptide.clickhouse.database`, adjust the provisioned datasource to match.
+
 Point a NetFlow v5/v9 or IPFIX exporter at UDP `9999` and watch rows arrive in
 `riptide.flows` via ch-ui. Configure [receivers](../configuration/receivers.md) and
 [nodes](../configuration/nodes-and-snmp.md) through environment variables in the compose

--- a/docs/docs/deploy/docker-compose.md
+++ b/docs/docs/deploy/docker-compose.md
@@ -33,10 +33,10 @@ Grafana (admin/admin) ships two provisioned dashboards backed by the `flows` tab
 
 The JSON sources live in `deployment/clickhouse/container-fs/grafana/provisioning/dashboards/`.
 UI edits last only until the provisioned JSON changes — use *Save as* to keep a customized copy.
-Both dashboards select their ClickHouse connection through a **Datasource** variable, so they can
-also be imported into an external Grafana — any `grafana-clickhouse-datasource` whose
-`defaultDatabase` points at the riptide database works (if you change
-`riptide.clickhouse.database`, adjust the datasource to match).
+Both dashboards are deployment-neutral: a **Datasource** variable selects the ClickHouse
+connection and a **Database** variable (auto-populated from databases containing a `flows` table)
+selects the riptide database, so they import into any external Grafana without a specifically
+named or `defaultDatabase`-pinned datasource.
 
 Point a NetFlow v5/v9 or IPFIX exporter at UDP `9999` and watch rows arrive in
 `riptide.flows` via ch-ui. Configure [receivers](../configuration/receivers.md) and

--- a/src/main/java/org/riptide/schema/FlowsSchema.java
+++ b/src/main/java/org/riptide/schema/FlowsSchema.java
@@ -197,9 +197,17 @@ public final class FlowsSchema {
         WITH
             toInt64({ival:Int64} * 1e9) AS interval_ns,
 
-            -- Find first and last absolute bucket numbers
-            toUInt64(toUnixTimestamp64Nano(deltaSwitched) / interval_ns) as first_bucket,
-            toUInt64(toUnixTimestamp64Nano(lastSwitched) / interval_ns) as last_bucket,
+            -- Find first and last absolute bucket numbers. Integer division is load-bearing:
+            -- Float64 '/' cannot represent nanosecond epochs exactly (ULP ~256ns), which would
+            -- absorb the boundary shift below. greatest() clamps corrupt flows with
+            -- lastSwitched < deltaSwitched to one bucket — unclamped, bucket_count wraps and
+            -- range() throws, poisoning every query over the view. The 1ns shift moves a flow
+            -- ending exactly on a bucket boundary into the preceding bucket instead of emitting
+            -- a spurious zero-contribution bucket.
+            toUInt64(intDiv(toUnixTimestamp64Nano(deltaSwitched), interval_ns)) as first_bucket,
+            toUInt64(intDiv(toUnixTimestamp64Nano(greatest(lastSwitched, deltaSwitched))
+                            - if(age('ns', deltaSwitched, lastSwitched) > 0, 1, 0),
+                            interval_ns)) as last_bucket,
 
             last_bucket - first_bucket + 1 as bucket_count,
 
@@ -225,15 +233,23 @@ public final class FlowsSchema {
 
                 -- Full buckets in between
                 ELSE 1.0
-                END AS bucket_fraction
+                END AS bucket_fraction,
+
+            -- Each bucket receives the flow's share proportional to the TIME spent in that bucket
+            -- (fraction of the interval, normalized by the flow duration), so bytes/packets are
+            -- conserved: summing over all buckets returns the flow's exact totals. Dividing by
+            -- bucket_count instead would under-report by duration/(ival * buckets) (issue #270).
+            -- The bucket_count = 1 branch is the division guard for zero-duration flows — do not
+            -- fold it into bucket_fraction.
+            if(bucket_count = 1, 1., bucket_fraction * interval_ns / flow_duration) AS bucket_share
 
         SELECT
             flow.*,
 
             fromUnixTimestamp64Nano((first_bucket + bucket) * interval_ns) AS timestamp,
 
-            bytes * bucket_fraction / toFloat64(bucket_count) as bytes,
-            packets * bucket_fraction / toFloat64(bucket_count) as packets
+            bytes * bucket_share as bytes,
+            packets * bucket_share as packets
 
         FROM @@flows@@ AS flow
         ARRAY JOIN buckets AS bucket

--- a/src/test/java/org/riptide/repository/clickhouse/ClickhouseRepositoryIT.java
+++ b/src/test/java/org/riptide/repository/clickhouse/ClickhouseRepositoryIT.java
@@ -166,6 +166,39 @@ public class ClickhouseRepositoryIT {
                 .hasMessageContaining("tenant");
     }
 
+    @Test
+    void samplesViewConservesBytesAcrossBucketExpansion() throws Exception {
+        final var database = "samples_cons";
+        final var repo = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), configFor(database, true), RESOLVERS);
+        repo.start();
+
+        // The #270 repro: a 90s, 6000-byte, 90-packet flow starting 30s before a bucket boundary.
+        // With ival=60 it spans 30s of its first bucket and 60s of its second, so a time-
+        // proportional split gives exactly 2000/4000 bytes — and the totals must be conserved
+        // (the pre-#270 division by bucket_count returned 1000/2000, half the traffic).
+        final var bucketStart = Instant.now().truncatedTo(ChronoUnit.MINUTES).minus(10, ChronoUnit.MINUTES);
+        final var start = bucketStart.plusSeconds(30);
+        final var end = bucketStart.plusSeconds(120);
+        repo.persist(List.of(testFlow(start, end, 50001, 443, 6000L, 90L)));
+
+        // Exactly two buckets — a flow ending on a bucket boundary must NOT emit a spurious
+        // zero-contribution third bucket (boundary shift in the view's last_bucket).
+        final var buckets = queryClient.queryAll(
+                "SELECT round(bytes, 3) AS b, round(packets, 3) AS p FROM " + database
+                        + ".samples(ival = 60) ORDER BY timestamp");
+        Assertions.assertThat(buckets).hasSize(2);
+        Assertions.assertThat(buckets.get(0).getDouble("b")).isCloseTo(2000.0, Assertions.within(0.01));
+        Assertions.assertThat(buckets.get(0).getDouble("p")).isCloseTo(30.0, Assertions.within(0.01));
+        Assertions.assertThat(buckets.get(1).getDouble("b")).isCloseTo(4000.0, Assertions.within(0.01));
+        Assertions.assertThat(buckets.get(1).getDouble("p")).isCloseTo(60.0, Assertions.within(0.01));
+
+        // Conservation: summing the expansion returns the flow's exact totals.
+        final var totals = queryClient.queryAll(
+                "SELECT sum(bytes) AS b, sum(packets) AS p FROM " + database + ".samples(ival = 60)");
+        Assertions.assertThat(totals.getFirst().getDouble("b")).isCloseTo(6000.0, Assertions.within(0.01));
+        Assertions.assertThat(totals.getFirst().getDouble("p")).isCloseTo(90.0, Assertions.within(0.01));
+    }
+
     private static ClickhouseConfig configFor(final String database, final boolean manageSchema) {
         final var config = new ClickhouseConfig();
         config.setEndpoint("http://" + CLICKHOUSE.getHost() + ":" + CLICKHOUSE.getMappedPort(8123));
@@ -188,12 +221,17 @@ public class ClickhouseRepositoryIT {
     }
 
     private static EnrichedFlow testFlow(final Instant now, final int srcPort, final int dstPort, final long bytes) throws Exception {
+        return testFlow(now.minusSeconds(10), now, srcPort, dstPort, bytes, 7L);
+    }
+
+    private static EnrichedFlow testFlow(final Instant deltaSwitched, final Instant lastSwitched, final int srcPort,
+                                         final int dstPort, final long bytes, final long packets) throws Exception {
         return EnrichedFlow.builder()
-                .receivedAt(now)
-                .timestamp(now)
-                .firstSwitched(now.minusSeconds(10))
-                .deltaSwitched(now.minusSeconds(10))
-                .lastSwitched(now)
+                .receivedAt(lastSwitched)
+                .timestamp(lastSwitched)
+                .firstSwitched(deltaSwitched)
+                .deltaSwitched(deltaSwitched)
+                .lastSwitched(lastSwitched)
                 .flowProtocol(Flow.FlowProtocol.IPFIX)
                 .tenant("default")
                 .organisation("default")
@@ -211,7 +249,7 @@ public class ClickhouseRepositoryIT {
                 .inputSnmp(1)
                 .outputSnmp(2)
                 .bytes(bytes)
-                .packets(7L)
+                .packets(packets)
                 .direction(Flow.Direction.INGRESS)
                 .engineId(0)
                 .engineType(0)


### PR DESCRIPTION
Closes #270.

## The bug (found while building the dashboards)

The `samples` bucket-expansion view divided each flow's per-bucket share by `bucket_count` instead of normalizing by flow duration — **every rate ever read through `samples` was biased low** (62.7% conservation on a 6h synthetic dataset; minimal repro: a 90s/6000-byte flow returned 3000). The view even computed `flow_duration` and never used it. Fixed to a time-proportional, exactly-conserving share; a new conservation IT pins the 2000/4000 split and exact totals. Manage-mode collectors self-heal on restart; a docs warning covers hand-created views (provisioned deployments don't self-heal).

## Review hardening (medium review, 8 angles + 4 empirical verifiers on a live ClickHouse)

- **Poison-row guard**: one corrupt flow (`lastSwitched < deltaSwitched` — reachable via NetFlow9 sysuptime wrap with the clock-correction enricher disabled) made `range()` throw `ARGUMENT_OUT_OF_BOUND`, killing *every* `samples()` query. `greatest()` clamp → such rows degrade to one full-bytes bucket.
- **intDiv bucket math**: ClickHouse `/` is Float64 division; at nanosecond-epoch magnitude its ULP (~256ns) silently absorbed boundary arithmetic (the first version of the boundary fix was a proven no-op).
- **No more boundary artifact**: flows ending exactly on a bucket boundary emitted a spurious zero-contribution bucket; the IT previously papered over it with `WHERE bytes > 0` — now asserts the true shape.

## The dashboards

Two provisioned dashboards for the compose stack (`deployment/clickhouse`, included by `deployment/riptide`):

- **Riptide - Top 10** — stacked top-10 bps panels (source/destination AS with org names, talkers, destinations, applications, services, protocols, exporters, ingress interfaces), throughput/volume/flow-count stats, and a source-AS statistics table (Min/Max/Last/Average/95th/Total) with **zero-padded percentiles** (verified: a one-bucket burst otherwise inflates Average 361×) and **current-bucket exclusion** (verified ~6× sawtooth). Variables: bucket size, tenant, zone, flow locality.
- **Riptide - Traffic Paths (Sankey)** — path diagrams via `netsage-sankey-panel`: source AS → ingress interface → application → destination AS; host conversations; tenant → zone → application.

**Performance**: `samples()` panel queries carry raw-column predicates (`lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL $bucket SECOND`) so ClickHouse PREWHERE-filters *before* the ARRAY JOIN — measured **−90% rows read**, byte-identical results (the naive upper bound without the one-bucket widening provably changes results).

## Verification

- 675 unit tests + ClickHouse ITs green (`mvn verify` incl. SpotBugs); conservation ratio exactly 1.0 at ival=60 and ival=10, zero artifact rows.
- All 32 panel-query variants (16 panels × All/filtered) executed against riptide's real schema + 200k seeded flows; representative panels + the statistics table round-tripped through **Grafana's own `/api/ds/query`** (macro expansion, series pivoting, plugin format verified empirically).

⚠️ Note for existing `gf-data` volumes: the datasource gains a pinned `uid` — user-created dashboards referencing the old auto-generated uid need repointing.
