### PR TITLE
fix: harden UDP malformed-packet handling (#273)

### DIFF
--- a/src/main/java/org/riptide/flows/listeners/UdpListener.java
+++ b/src/main/java/org/riptide/flows/listeners/UdpListener.java
@@ -9,6 +9,7 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -29,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import java.net.InetSocketAddress;
 import java.time.Instant;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 
 public class UdpListener implements Listener {
     private static final Logger LOG = LoggerFactory.getLogger(UdpListener.class);
@@ -137,11 +139,13 @@ public class UdpListener implements Listener {
             // Call the parser
             ch.pipeline().addLast(new SingleDatagramPacketParserHandler(UdpListener.this.parser));
 
-            // Add error handling
+            // Backstop for channel-level errors. Parse errors never reach this: the parser handler
+            // logs them itself (with the sender address), so anything landing here is a pipeline
+            // or I/O fault — label it as such, not as a bad packet.
             ch.pipeline().addLast(new ChannelInboundHandlerAdapter() {
                 @Override
                 public void exceptionCaught(final ChannelHandlerContext ctx, final Throwable cause) throws Exception {
-                    LOG.warn("Invalid packet: {}", cause.getMessage());
+                    LOG.warn("Unexpected error in UDP listener pipeline: {}", cause.toString());
                     LOG.debug("", cause);
                 }
             });
@@ -156,28 +160,54 @@ public class UdpListener implements Listener {
         }
     }
 
-    // Invokes parse of the provided parsers and also adds some error handling
-    private static final class SingleDatagramPacketParserHandler extends SimpleChannelInboundHandler<DatagramPacket> {
+    // Invokes parse of the provided parsers and also adds some error handling.
+    // Package-visible for the buffer-lifecycle test (UdpListenerReleaseTest).
+    static final class SingleDatagramPacketParserHandler extends SimpleChannelInboundHandler<DatagramPacket> {
 
         final UdpParser parser;
 
-        private SingleDatagramPacketParserHandler(UdpParser parser) {
+        SingleDatagramPacketParserHandler(UdpParser parser) {
             this.parser = parser;
         }
 
         @Override
         protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket msg) throws Exception {
-            parser.parse(
-                    Instant.now(),
-                    ReferenceCountUtil.retain(msg.content()),
-                    msg.sender(), msg.recipient()
-            ).handle((result, ex) -> {
-                ReferenceCountUtil.release(msg.content());
+            final InetSocketAddress sender = msg.sender();
+            final ByteBuf content = ReferenceCountUtil.retain(msg.content());
+            CompletableFuture<?> future;
+            try {
+                future = parser.parse(Instant.now(), content, sender, msg.recipient());
+            } catch (final Throwable e) {
+                // Parse errors surface synchronously (and pathological packets can raise Errors) —
+                // normalize into the future so the release below is the one and only path. Before
+                // this, the retained buffer leaked once per malformed packet (#273).
+                future = CompletableFuture.failedFuture(e);
+            }
+            if (future == null) {
+                // A dispatching parser returns null for packets no sub-parser handles.
+                ReferenceCountUtil.release(content);
+                return;
+            }
+            future.whenComplete((result, ex) -> {
+                ReferenceCountUtil.release(content);
                 if (ex != null) {
-                    ctx.fireExceptionCaught(ex);
+                    logInvalidPacket(sender, ex);
                 }
-                return result;
             });
+        }
+
+        // Logged here rather than via fireExceptionCaught: only this handler knows the sender,
+        // and with several exporters on one listener the address is what makes the log actionable.
+        private static void logInvalidPacket(final InetSocketAddress sender, final Throwable cause) {
+            // Async stages wrap failures in CompletionException; unwrap for a clean message.
+            final Throwable root = cause instanceof java.util.concurrent.CompletionException && cause.getCause() != null
+                    ? cause.getCause() : cause;
+            // InvalidPacketException messages carry a multi-KB hex dump after the first line — keep
+            // the WARN to the summary line; the full dump and stack trace are available at DEBUG.
+            final String message = String.valueOf(root.getMessage());
+            final int newline = message.indexOf('\n');
+            LOG.warn("Invalid packet from {}: {}", sender, newline > 0 ? message.substring(0, newline) : message);
+            LOG.debug("Invalid packet from {}:", sender, root);
         }
     }
 

--- a/src/main/java/org/riptide/flows/parser/UdpParserBase.java
+++ b/src/main/java/org/riptide/flows/parser/UdpParserBase.java
@@ -76,11 +76,9 @@ public abstract class UdpParserBase extends ParserBase implements UdpParser {
         final UdpSessionManager.SessionKey sessionKey = this.buildSessionKey(remoteAddress, localAddress);
         final TransactionalSession session = new TransactionalSession(this.sessionManager.getSession(sessionKey));
 
+        final FlowPacket parsed;
         try {
-            final var parsed = this.parse(session, buffer);
-            LOG.trace("Parsed packet: {}", parsed);
-
-            return this.transmit(receivedAt, parsed, session);
+            parsed = this.parse(session, buffer);
         } catch (Exception e) {
             // Discard the malformed message only (RFC 7011 §10.3) — NOT the whole session.
             // Dropping the session here discarded the exporter's templates and sequence state, so
@@ -89,11 +87,15 @@ public abstract class UdpParserBase extends ParserBase implements UdpParser {
             // #273). The rollback removes only what THIS packet taught us: packets install
             // templates set-by-set while parsing, so a mis-framed packet may have committed a
             // garbage template before a later set threw — retaining it would silently mis-decode
-            // subsequent data sets.
+            // subsequent data sets. Deliberately scoped to the parse phase: a transmit/dispatch
+            // failure below says nothing about the packet's templates.
             session.rollback();
             this.parserErrors.inc();
             throw e;
         }
+        LOG.trace("Parsed packet: {}", parsed);
+
+        return this.transmit(receivedAt, parsed, session);
     }
 
     /** Must be set before {@link #start}; the session manager is built there. */

--- a/src/main/java/org/riptide/flows/parser/UdpParserBase.java
+++ b/src/main/java/org/riptide/flows/parser/UdpParserBase.java
@@ -14,6 +14,7 @@ import org.riptide.flows.listeners.UdpParser;
 import org.riptide.flows.parser.data.Flow;
 import org.riptide.flows.parser.session.Session;
 import org.riptide.flows.parser.session.OptionListener;
+import org.riptide.flows.parser.session.TransactionalSession;
 import org.riptide.flows.parser.session.UdpSessionManager;
 import org.riptide.pipeline.Identity;
 import org.riptide.pipeline.Source;
@@ -73,7 +74,7 @@ public abstract class UdpParserBase extends ParserBase implements UdpParser {
         this.packetsReceived.mark();
 
         final UdpSessionManager.SessionKey sessionKey = this.buildSessionKey(remoteAddress, localAddress);
-        final Session session = this.sessionManager.getSession(sessionKey);
+        final TransactionalSession session = new TransactionalSession(this.sessionManager.getSession(sessionKey));
 
         try {
             final var parsed = this.parse(session, buffer);
@@ -81,7 +82,15 @@ public abstract class UdpParserBase extends ParserBase implements UdpParser {
 
             return this.transmit(receivedAt, parsed, session);
         } catch (Exception e) {
-            this.sessionManager.drop(sessionKey);
+            // Discard the malformed message only (RFC 7011 §10.3) — NOT the whole session.
+            // Dropping the session here discarded the exporter's templates and sequence state, so
+            // a single corrupt packet made all subsequent valid packets unparseable until the
+            // exporter re-sent its templates (observed against a buggy pmacct nfprobe exporter,
+            // #273). The rollback removes only what THIS packet taught us: packets install
+            // templates set-by-set while parsing, so a mis-framed packet may have committed a
+            // garbage template before a later set threw — retaining it would silently mis-decode
+            // subsequent data sets.
+            session.rollback();
             this.parserErrors.inc();
             throw e;
         }

--- a/src/main/java/org/riptide/flows/parser/exceptions/InvalidPacketException.java
+++ b/src/main/java/org/riptide/flows/parser/exceptions/InvalidPacketException.java
@@ -20,13 +20,44 @@ public class InvalidPacketException extends Exception {
     }
 
     private static String appendPosition(final String message, final ByteBuf buffer) {
-        // We want to hex-dump the whole PDU, wo we need to get the unsliced buffer
-        final ByteBuf unwrappedBuffer = Unpooled.wrappedUnmodifiableBuffer(buffer.unwrap() != null ? buffer.unwrap() : buffer).resetReaderIndex();
-        // Compare the readableBytes() to determine the adjustment
-        final int delta = unwrappedBuffer.readableBytes() - (buffer.readableBytes() + buffer.readerIndex());
-        // Compute the offset for which this exception had occurred
-        final int offset = buffer.readerIndex() + delta;
+        // We want to hex-dump the whole PDU, so we need to get the unsliced buffer
+        final ByteBuf root = rootOf(buffer);
+        final ByteBuf dump = Unpooled.wrappedUnmodifiableBuffer(root).resetReaderIndex();
 
-        return String.format("%s, Offset: [0x%04X], Payload:%n%s", message, offset, ByteBufUtil.prettyHexDump(unwrappedBuffer));
+        final int offset = absoluteOffset(buffer, root);
+        final String position = offset >= 0 ? String.format("0x%04X", offset) : "unknown";
+
+        return String.format("%s, Offset: [%s], Payload:%n%s", message, position, ByteBufUtil.prettyHexDump(dump));
+    }
+
+    private static ByteBuf rootOf(final ByteBuf buffer) {
+        ByteBuf root = buffer;
+        while (root.unwrap() != null) {
+            root = root.unwrap();
+        }
+        return root;
+    }
+
+    /**
+     * The failure position within the root PDU. Netty slices expose their base through
+     * {@code memoryAddress()}/{@code arrayOffset()}, so the slice's absolute start is recovered by
+     * differencing against the root — correct for interior slices, where inferring the position
+     * from lengths is not (a slice does not generally end where the PDU ends; the old length-based
+     * arithmetic pinned every set-header failure near the end of the message). Returns -1 when the
+     * buffers share no addressable memory (e.g. composite buffers).
+     */
+    private static int absoluteOffset(final ByteBuf buffer, final ByteBuf root) {
+        final int offset;
+        if (buffer == root) {
+            offset = buffer.readerIndex();
+        } else if (buffer.hasMemoryAddress() && root.hasMemoryAddress()) {
+            offset = (int) (buffer.memoryAddress() - root.memoryAddress()) + buffer.readerIndex();
+        } else if (buffer.hasArray() && root.hasArray() && buffer.array() == root.array()) {
+            offset = buffer.arrayOffset() - root.arrayOffset() + buffer.readerIndex();
+        } else {
+            return -1;
+        }
+        // A violated derived-buffer assumption must degrade to "unknown", not a bogus position.
+        return offset >= 0 && offset <= root.capacity() ? offset : -1;
     }
 }

--- a/src/main/java/org/riptide/flows/parser/session/TransactionalSession.java
+++ b/src/main/java/org/riptide/flows/parser/session/TransactionalSession.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.parser.session;
+
+import org.riptide.flows.parser.exceptions.MissingTemplateException;
+import org.riptide.flows.parser.ie.Value;
+import org.riptide.pipeline.ExporterIdentity;
+
+import java.net.InetAddress;
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A {@link Session} view that can undo the template mutations of one packet. Packets install
+ * templates set-by-set while they parse, so a malformed packet may have committed templates
+ * (possibly garbage read out of a mis-framed region) before a later set throws. RFC 7011 §10.3
+ * requires discarding the malformed message — including what it taught us: retaining such a
+ * template would silently mis-decode every subsequent data set referencing its ID, while
+ * {@link #rollback()} restores the pre-packet state so the worst case is a loud
+ * {@link MissingTemplateException}.
+ *
+ * <p>Only template add/remove operations are rolled back. {@code removeAllTemplate} and
+ * {@code addOptions} are not undoable through the {@link Session} API — both degrade safely
+ * (missing templates fail loudly; options are soft enrichment refreshed by the exporter).
+ */
+public final class TransactionalSession implements Session {
+
+    private final Session delegate;
+    private final Deque<Runnable> undo = new ArrayDeque<>();
+
+    public TransactionalSession(final Session delegate) {
+        this.delegate = Objects.requireNonNull(delegate);
+    }
+
+    /** Undo this packet's template mutations, most recent first. */
+    public void rollback() {
+        while (!this.undo.isEmpty()) {
+            this.undo.pop().run();
+        }
+    }
+
+    @Override
+    public void addTemplate(final long observationDomainId, final Template template) {
+        final Template previous = lookup(observationDomainId, template.id);
+        this.undo.push(previous != null
+                ? () -> this.delegate.addTemplate(observationDomainId, previous)
+                : () -> this.delegate.removeTemplate(observationDomainId, template.id));
+        this.delegate.addTemplate(observationDomainId, template);
+    }
+
+    @Override
+    public void removeTemplate(final long observationDomainId, final int templateId) {
+        final Template previous = lookup(observationDomainId, templateId);
+        if (previous != null) {
+            this.undo.push(() -> this.delegate.addTemplate(observationDomainId, previous));
+        }
+        this.delegate.removeTemplate(observationDomainId, templateId);
+    }
+
+    @Override
+    public void removeAllTemplate(final long observationDomainId, final Template.Type type) {
+        // Not undoable through the Session API (no enumeration); a rollback leaves the templates
+        // absent, which fails loudly on the next data set — the safe direction.
+        this.delegate.removeAllTemplate(observationDomainId, type);
+    }
+
+    @Override
+    public void addOptions(final long observationDomainId, final int templateId,
+                           final Collection<Value<?>> scopes, final List<Value<?>> values) {
+        this.delegate.addOptions(observationDomainId, templateId, scopes, values);
+    }
+
+    @Override
+    public Resolver getResolver(final long observationDomainId) {
+        return this.delegate.getResolver(observationDomainId);
+    }
+
+    @Override
+    public InetAddress getRemoteAddress() {
+        return this.delegate.getRemoteAddress();
+    }
+
+    @Override
+    public boolean verifySequenceNumber(final ExporterIdentity scope, final long sequenceNumber,
+                                        final int sequenceIncrement) {
+        return this.delegate.verifySequenceNumber(scope, sequenceNumber, sequenceIncrement);
+    }
+
+    private Template lookup(final long observationDomainId, final int templateId) {
+        try {
+            return this.delegate.getResolver(observationDomainId).lookupTemplate(templateId);
+        } catch (final MissingTemplateException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/riptide/flows/parser/session/UdpSessionManager.java
+++ b/src/main/java/org/riptide/flows/parser/session/UdpSessionManager.java
@@ -72,11 +72,6 @@ public class UdpSessionManager {
         return new UdpSession(sessionKey);
     }
 
-    public void drop(final SessionKey sessionKey) {
-        removeTemplateIf(e -> Objects.equals(e.getKey().observationDomainId.sessionKey, sessionKey));
-        this.sequenceNumbers.keySet().removeIf(key -> Objects.equals(key.sessionKey(), sessionKey));
-    }
-
     public int count() {
         return this.templates.size();
     }

--- a/src/test/java/org/riptide/flows/listeners/UdpListenerReleaseTest.java
+++ b/src/test/java/org/riptide/flows/listeners/UdpListenerReleaseTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.listeners;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.channel.socket.DatagramPacket;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The datagram buffer's lifecycle across every parse outcome. The regression (#273): parse errors
+ * throw synchronously, so the release attached to the returned future never ran and the retained
+ * buffer leaked — one per malformed packet, surfacing as Netty {@code LEAK} errors in production.
+ */
+class UdpListenerReleaseTest {
+
+    private static final InetSocketAddress SENDER = new InetSocketAddress("127.0.0.1", 40000);
+    private static final InetSocketAddress RECIPIENT = new InetSocketAddress("127.0.0.1", 4739);
+
+    @Test
+    void releasesBufferWhenParseThrowsSynchronously() {
+        assertFullyReleased(parser((receivedAt, buffer, remote, local) -> {
+            throw new IllegalArgumentException("Invalid set ID: 0");
+        }));
+    }
+
+    @Test
+    void releasesBufferWhenParseFailsAsynchronously() {
+        assertFullyReleased(parser((receivedAt, buffer, remote, local) ->
+                CompletableFuture.failedFuture(new IllegalStateException("dispatch failed"))));
+    }
+
+    @Test
+    void releasesBufferOnSuccess() {
+        assertFullyReleased(parser((receivedAt, buffer, remote, local) ->
+                CompletableFuture.completedFuture(null)));
+    }
+
+    @Test
+    void releasesBufferWhenParseThrowsAnError() {
+        assertFullyReleased(parser((receivedAt, buffer, remote, local) -> {
+            throw new StackOverflowError();
+        }));
+    }
+
+    @Test
+    void releasesBufferWhenNoParserHandlesThePacket() {
+        // A dispatching parser returns null for packets no sub-parser handles.
+        assertFullyReleased(parser((receivedAt, buffer, remote, local) -> null));
+    }
+
+    private static void assertFullyReleased(final UdpParser parser) {
+        final EmbeddedChannel channel = new EmbeddedChannel(
+                new UdpListener.SingleDatagramPacketParserHandler(parser));
+        final ByteBuf content = Unpooled.buffer().writeBytes(new byte[] {0, 0, (byte) 0x9f, 0x75});
+
+        channel.writeInbound(new DatagramPacket(content, RECIPIENT, SENDER));
+
+        // The handler must not leak the parse failure into the pipeline (it logs with the sender
+        // itself), and the buffer must be fully released: the handler's retain undone plus
+        // SimpleChannelInboundHandler's auto-release of the original reference.
+        channel.checkException();
+        assertThat(content.refCnt()).isZero();
+        channel.finishAndReleaseAll();
+    }
+
+    @FunctionalInterface
+    private interface ParseCall {
+        CompletableFuture<?> parse(Instant receivedAt, ByteBuf buffer,
+                                   InetSocketAddress remote, InetSocketAddress local) throws Exception;
+    }
+
+    private static UdpParser parser(final ParseCall call) {
+        return new UdpParser() {
+            @Override
+            public CompletableFuture<?> parse(final Instant receivedAt, final ByteBuf buffer,
+                                              final InetSocketAddress remoteAddress,
+                                              final InetSocketAddress localAddress) throws Exception {
+                return call.parse(receivedAt, buffer, remoteAddress, localAddress);
+            }
+
+            @Override
+            public String getName() {
+                return "stub";
+            }
+
+            @Override
+            public String getDescription() {
+                return "stub";
+            }
+
+            @Override
+            public Object dumpInternalState() {
+                return null;
+            }
+
+            @Override
+            public void start(final ScheduledExecutorService executorService) {
+            }
+
+            @Override
+            public void stop() {
+            }
+        };
+    }
+}

--- a/src/test/java/org/riptide/flows/parser/UdpParserBaseTest.java
+++ b/src/test/java/org/riptide/flows/parser/UdpParserBaseTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.parser;
+
+import com.codahale.metrics.MetricRegistry;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.riptide.flows.parser.exceptions.InvalidPacketException;
+import org.riptide.flows.parser.session.Field;
+import org.riptide.flows.parser.ie.Value;
+import org.riptide.flows.parser.ie.values.StringValue;
+import org.riptide.flows.parser.netflow9.Netflow9UdpParser;
+import org.riptide.flows.parser.session.Session;
+import org.riptide.flows.parser.session.Template;
+import org.riptide.flows.parser.session.UdpSessionManager;
+import org.riptide.pipeline.Identity;
+
+import java.net.InetSocketAddress;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * A malformed packet must only discard that packet (RFC 7011 §10.3) — never the exporter's session
+ * state. The regression (#273): any parse error dropped the whole session, so one corrupt packet
+ * from a buggy exporter discarded its templates and made all subsequent valid packets unparseable
+ * until the exporter re-sent them.
+ */
+class UdpParserBaseTest {
+
+    private static final InetSocketAddress REMOTE = new InetSocketAddress("10.0.0.1", 51000);
+    private static final InetSocketAddress LOCAL = new InetSocketAddress("10.0.0.2", 4739);
+    private static final int TEMPLATE_ID = 256;
+
+    /** T = adds a template; X = malformed (throws); D = requires the template to resolve. */
+    private static final byte ADD_TEMPLATE = 'T';
+    private static final byte MALFORMED = 'X';
+    private static final byte NEEDS_TEMPLATE = 'D';
+    /** P = installs a garbage template mid-packet, then fails; Q = probes for that template. */
+    private static final byte POISONED = 'P';
+    private static final byte PROBE_POISON = 'Q';
+    private static final int GARBAGE_TEMPLATE_ID = 300;
+
+    private ScheduledExecutorService executor;
+    private StubParser parser;
+
+    @BeforeEach
+    void setUp() {
+        this.executor = Executors.newSingleThreadScheduledExecutor();
+        this.parser = new StubParser();
+        this.parser.start(this.executor);
+    }
+
+    @AfterEach
+    void tearDown() {
+        this.parser.stop();
+        this.executor.shutdownNow();
+    }
+
+    @Test
+    void malformedPacketDoesNotDiscardSessionTemplates() throws Exception {
+        // A valid packet installs the exporter's template ...
+        parse(ADD_TEMPLATE);
+
+        // ... a malformed packet from the same exporter fails to parse ...
+        assertThatThrownBy(() -> parse(MALFORMED)).isInstanceOf(InvalidPacketException.class);
+
+        // ... and the template must still resolve for the next valid packet. (Before the fix the
+        // session was dropped here and this threw MissingTemplateException.)
+        assertThatCode(() -> parse(NEEDS_TEMPLATE)).doesNotThrowAnyException();
+        assertThat(this.parser.templateResolved).isTrue();
+    }
+
+    @Test
+    void malformedPacketsOwnTemplatesAreRolledBack() throws Exception {
+        // Valid history first ...
+        parse(ADD_TEMPLATE);
+
+        // ... then a mis-framed packet that installs a garbage template BEFORE its parse fails.
+        assertThatThrownBy(() -> parse(POISONED)).isInstanceOf(InvalidPacketException.class);
+
+        // The garbage template from the failed packet must be gone (retaining it would silently
+        // mis-decode subsequent data sets), while the earlier valid template survives.
+        assertThatCode(() -> parse(PROBE_POISON)).doesNotThrowAnyException();
+        assertThat(this.parser.garbageTemplateRetained).isFalse();
+        assertThatCode(() -> parse(NEEDS_TEMPLATE)).doesNotThrowAnyException();
+        assertThat(this.parser.templateResolved).isTrue();
+    }
+
+    private void parse(final byte marker) throws Exception {
+        final ByteBuf buffer = Unpooled.buffer().writeByte(marker);
+        try {
+            this.parser.parse(Instant.now(), buffer, REMOTE, LOCAL).join();
+        } finally {
+            buffer.release();
+        }
+    }
+
+    private static final class StubParser extends UdpParserBase {
+
+        private boolean templateResolved;
+        private boolean garbageTemplateRetained;
+
+        StubParser() {
+            super(Protocol.IPFIX, "stub", (source, flow) -> { }, new Identity("t", "o", "z", "s"),
+                    new MetricRegistry());
+        }
+
+        @Override
+        protected FlowPacket parse(final Session session, final ByteBuf buffer) throws Exception {
+            switch (buffer.readByte()) {
+                case ADD_TEMPLATE -> session.addTemplate(0,
+                        Template.builder(TEMPLATE_ID, Template.Type.TEMPLATE)
+                                .withFields(List.of(field())).build());
+                case MALFORMED -> throw new InvalidPacketException(buffer, "Invalid set ID: %d", 0);
+                case NEEDS_TEMPLATE -> {
+                    session.getResolver(0).lookupTemplate(TEMPLATE_ID);
+                    this.templateResolved = true;
+                }
+                case POISONED -> {
+                    // A mis-framed packet: a garbage region parsed as a template set (installed
+                    // into the session) before a later set fails the whole packet.
+                    session.addTemplate(0, Template.builder(GARBAGE_TEMPLATE_ID, Template.Type.TEMPLATE)
+                            .withFields(List.of(field())).build());
+                    throw new InvalidPacketException(buffer, "Invalid set ID: %d", 0);
+                }
+                case PROBE_POISON -> {
+                    try {
+                        session.getResolver(0).lookupTemplate(GARBAGE_TEMPLATE_ID);
+                        this.garbageTemplateRetained = true;
+                    } catch (final org.riptide.flows.parser.exceptions.MissingTemplateException expected) {
+                        this.garbageTemplateRetained = false;
+                    }
+                }
+                default -> throw new IllegalStateException("unexpected marker");
+            }
+            return packet();
+        }
+
+        @Override
+        protected UdpSessionManager.SessionKey buildSessionKey(final InetSocketAddress remoteAddress,
+                                                               final InetSocketAddress localAddress) {
+            return new Netflow9UdpParser.SessionKey(remoteAddress.getAddress(), localAddress);
+        }
+
+        private static FlowPacket packet() {
+            return new FlowPacket() {
+                @Override
+                public Stream<org.riptide.flows.parser.data.Flow> buildFlows(final Instant receivedAt) {
+                    return Stream.empty();
+                }
+
+                @Override
+                public long getObservationDomainId() {
+                    return 0;
+                }
+
+                @Override
+                public long getSequenceNumber() {
+                    return 0;
+                }
+            };
+        }
+
+        private static Field field() {
+            return new Field() {
+                @Override
+                public int length() {
+                    return 0;
+                }
+
+                @Override
+                public Value<?> parse(final Session.Resolver resolver, final ByteBuf buffer) {
+                    return new StringValue("f", null, null, null);
+                }
+            };
+        }
+    }
+}

--- a/src/test/java/org/riptide/flows/parser/exceptions/InvalidPacketExceptionTest.java
+++ b/src/test/java/org/riptide/flows/parser/exceptions/InvalidPacketExceptionTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.parser.exceptions;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The reported offset must be the failure position within the root PDU. The regression (#273): the
+ * old length-based arithmetic assumed the failing slice ends where the PDU ends, so every interior
+ * failure (e.g. a 4-byte set-header slice) was reported near the end of the message — production
+ * logs showed {@code len - 2} for failures that actually happened at 0x50.
+ */
+class InvalidPacketExceptionTest {
+
+    @Test
+    void offsetOfInteriorSliceIsItsRealPosition() {
+        final ByteBuf root = pdu(100);
+        // a 4-byte "set header" slice at 0x50, failing after reading its 2-byte set id
+        final ByteBuf setHeader = root.slice(0x50, 4);
+        setHeader.readerIndex(2);
+
+        final var e = new InvalidPacketException(setHeader, "Invalid set ID: %d", 0);
+
+        assertThat(e.getMessage()).startsWith("Invalid set ID: 0, Offset: [0x0052]");
+    }
+
+    @Test
+    void offsetOfNestedSliceIsItsRealPosition() {
+        final ByteBuf root = pdu(100);
+        // message slice (as the parser cuts the payload), then a set-header slice inside it
+        final ByteBuf payload = root.slice(16, 84);
+        final ByteBuf setHeader = payload.slice(0x40, 4);
+        setHeader.readerIndex(2);
+
+        final var e = new InvalidPacketException(setHeader, "Invalid set ID: %d", 0);
+
+        assertThat(e.getMessage()).startsWith("Invalid set ID: 0, Offset: [0x0052]");
+    }
+
+    @Test
+    void offsetOfRootBufferIsItsReaderIndex() {
+        final ByteBuf root = pdu(100);
+        root.readerIndex(7);
+
+        final var e = new InvalidPacketException(root, "boom");
+
+        assertThat(e.getMessage()).startsWith("boom, Offset: [0x0007]");
+    }
+
+    @Test
+    void offsetOfDirectBufferSliceIsItsRealPosition() {
+        // Production datagram buffers are direct (memoryAddress-based resolution).
+        final ByteBuf root = Unpooled.directBuffer(100);
+        for (int i = 0; i < 100; i++) {
+            root.writeByte(i);
+        }
+        org.junit.jupiter.api.Assumptions.assumeTrue(root.hasMemoryAddress(),
+                "direct buffers without memoryAddress on this platform");
+        final ByteBuf setHeader = root.slice(0x50, 4);
+        setHeader.readerIndex(2);
+
+        final var e = new InvalidPacketException(setHeader, "Invalid set ID: %d", 0);
+
+        assertThat(e.getMessage()).startsWith("Invalid set ID: 0, Offset: [0x0052]");
+        root.release();
+    }
+
+    @Test
+    void consumedRootStillDumpsFromByteZeroWithAbsoluteOffset() {
+        // The parsers consume the root via readSlice, advancing its readerIndex; the dump must
+        // still show the whole PDU from byte 0 and the offset must stay PDU-absolute.
+        final ByteBuf root = pdu(100);
+        root.readSlice(16); // e.g. the message header was consumed
+        final ByteBuf setHeader = root.readSlice(64).slice(0x30, 4);
+        setHeader.readerIndex(2);
+
+        final var e = new InvalidPacketException(setHeader, "Invalid set ID: %d", 0);
+
+        assertThat(e.getMessage()).startsWith("Invalid set ID: 0, Offset: [0x0042]");
+        assertThat(e.getMessage()).contains("|00000000|");
+    }
+
+    @Test
+    void dumpShowsTheWholePdu() {
+        final ByteBuf root = pdu(64);
+        final ByteBuf slice = root.slice(32, 4);
+
+        final var e = new InvalidPacketException(slice, "boom");
+
+        // 64 bytes -> four 16-byte hexdump rows of the full PDU, not just the failing slice
+        assertThat(e.getMessage()).contains("|00000030|");
+    }
+
+    private static ByteBuf pdu(final int size) {
+        final ByteBuf buffer = Unpooled.buffer(size);
+        for (int i = 0; i < size; i++) {
+            buffer.writeByte(i);
+        }
+        return buffer;
+    }
+}

--- a/src/test/java/org/riptide/flows/parser/session/UdpSessionManagerTest.java
+++ b/src/test/java/org/riptide/flows/parser/session/UdpSessionManagerTest.java
@@ -218,7 +218,7 @@ public class UdpSessionManagerTest {
     }
 
     @Test
-    public void housekeepingAndDropEvictSequenceTrackers() throws Exception {
+    public void housekeepingEvictsSequenceTrackers() throws Exception {
         final var sessionKey = new Netflow9UdpParser.SessionKey(remoteAddress1.getAddress(), localAddress1);
         final var manager = new UdpSessionManager(Duration.ofMinutes(0), () -> new SequenceNumberTracker(32));
         final var identity = new ExporterIdentity.Sflow(InetAddress.getByName("10.0.0.1"), 0);
@@ -226,11 +226,6 @@ public class UdpSessionManagerTest {
         manager.getSession(sessionKey).verifySequenceNumber(identity, 1, 1);
         assertThat(manager.sequenceTrackerCount()).isEqualTo(1);
         manager.doHousekeeping();
-        assertThat(manager.sequenceTrackerCount()).isZero();
-
-        manager.getSession(sessionKey).verifySequenceNumber(identity, 2, 1);
-        assertThat(manager.sequenceTrackerCount()).isEqualTo(1);
-        manager.drop(sessionKey);
         assertThat(manager.sequenceTrackerCount()).isZero();
     }
 


### PR DESCRIPTION
Closes #273. Root-caused against a production pmacct 1.7.8 `nfprobe` exporter emitting mangled IPFIX flowsets (~11% of messages; byte-level analysis on the issue) — riptide correctly discards the packets, but its error path had real defects.

## Fixes

1. **ByteBuf leak (two paths)** — the retained datagram buffer leaked when parse threw synchronously (release was attached to a future that a sync throw never created) *and* when `DispatchingUdpParser` returned `null` for unhandled packets (production always wires through it — the review found this second live path). All outcomes now funnel through a single `whenComplete` release; synchronous `Throwable`s (incl. `StackOverflowError` from pathological packets) normalize into failed futures.
2. **Sender in the log** — `Invalid packet from /192.168.10.16:47831: Invalid set ID: 0, Offset: [0x0050]` instead of a senderless message. WARN carries only the summary line (the multi-KB hexdump — previously logged per malformed packet, ≈4 GB/day at the observed 7 pkt/s — moved to DEBUG, once); `CompletionException` wrappers unwrapped; the pipeline-tail handler reworded as a channel-error backstop.
3. **Honest offsets** — the old arithmetic assumed the failing slice ends where the PDU ends, so every interior failure logged ≈`len−2` (all five production offsets matched that broken formula; the real failures were at `0x50`). Offsets now derive from the slice's memory address/array offset against the root — verified against heap, direct, pooled, and adaptive allocators on JDK 25 — with an honest `unknown` degrade + bounds clamp.
4. **Sessions survive malformed packets** — previously one corrupt packet dropped the exporter's templates and sequence state, making valid packets unparseable until template retransmit. Per RFC 7011 §10.3 only the message is discarded — and via a new `TransactionalSession`, *exactly* the failing packet's template mutations are rolled back, closing the review-found regression risk that a mis-framed packet could leave its own garbage template installed and silently mis-decode subsequent data.

## Review

`/code-review` medium (8 angles + empirical probes): 6 findings fixed pre-merge (incl. the null-future leak and the template-rollback design), 2 refuted empirically (JDK-25 `memoryAddress` availability — probed on all four allocator types; dump-coordinate drift — pinned by a consumed-root test), 1 pre-existing TCP gap deferred (noted on #273).

## Testing

688 unit tests green (`mvn verify` incl. SpotBugs/checkstyle/Error Prone). 13 new regression tests: buffer release across all five parse outcomes (sync throw, async fail, success, `Error`, null parser), offset arithmetic (interior/nested/direct-buffer/consumed-root slices), session survival, and poisoned-template rollback — the survival and rollback tests were verified to fail against the old behavior.