### PR TITLE
fix: store flow timestamps as absolute instants regardless of host timezone (#276)

### DIFF
--- a/src/main/java/org/riptide/repository/clickhouse/ClickhouseFlow.java
+++ b/src/main/java/org/riptide/repository/clickhouse/ClickhouseFlow.java
@@ -8,13 +8,16 @@ package org.riptide.repository.clickhouse;
 import lombok.Data;
 
 import java.net.Inet6Address;
-import java.sql.Timestamp;
 import java.time.Duration;
+import java.time.OffsetDateTime;
 
 
 @Data
 public class ClickhouseFlow {
-    private Timestamp timestamp;
+    // OffsetDateTime (UTC), not java.sql.Timestamp: the client-v2 encodes a Timestamp from its
+    // JVM-local wall clock, shifting DateTime64 values by the host's UTC offset on a non-UTC host
+    // (#276). An offset-carrying type serializes to an absolute instant regardless of host zone.
+    private OffsetDateTime timestamp;
 
     private byte flowProtocol;
 
@@ -24,11 +27,11 @@ public class ClickhouseFlow {
     private String system;
     private String exporterAddr;
 
-    private Timestamp receivedAt;
+    private OffsetDateTime receivedAt;
 
-    private Timestamp firstSwitched;
-    private Timestamp deltaSwitched;
-    private Timestamp lastSwitched;
+    private OffsetDateTime firstSwitched;
+    private OffsetDateTime deltaSwitched;
+    private OffsetDateTime lastSwitched;
 
     private int inputSnmp;
     private String inputSnmpIfName;

--- a/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
+++ b/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
@@ -28,8 +28,9 @@ import java.net.Inet6Address;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.net.InetAddress;
-import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -200,8 +201,10 @@ public class ClickhouseRepository implements FlowRepository {
         })
         public abstract ClickhouseFlow flow(EnrichedFlow flow);
 
-        protected Timestamp timestamp(final Instant value) {
-            return Timestamp.from(value);
+        protected OffsetDateTime timestamp(final Instant value) {
+            // UTC offset so the client-v2 DateTime64 encoding is an absolute instant, independent
+            // of the collector host's timezone (#276).
+            return value.atOffset(ZoneOffset.UTC);
         }
 
         @SneakyThrows

--- a/src/main/java/org/riptide/schema/FlowsSchema.java
+++ b/src/main/java/org/riptide/schema/FlowsSchema.java
@@ -97,7 +97,9 @@ public final class FlowsSchema {
     @Language("ClickHouse")
     private static final String FLOWS_TABLE = """
         CREATE TABLE IF NOT EXISTS @@flows@@ (
-            timestamp DateTime64(3),
+            -- Time columns pin the UTC timezone so the stored instants also display and parse in
+            -- UTC — the schema is timezone-explicit, not dependent on the server's local zone (#276).
+            timestamp DateTime64(3, 'UTC'),
 
             flowProtocol Enum8(
                 'NetflowV5' = 1,
@@ -112,11 +114,11 @@ public final class FlowsSchema {
             system String,
             exporterAddr String,
 
-            receivedAt DateTime64(9),
+            receivedAt DateTime64(9, 'UTC'),
 
-            firstSwitched DateTime64(9),
-            deltaSwitched DateTime64(9),
-            lastSwitched DateTime64(9),
+            firstSwitched DateTime64(9, 'UTC'),
+            deltaSwitched DateTime64(9, 'UTC'),
+            lastSwitched DateTime64(9, 'UTC'),
 
             inputSnmp UInt32,
             inputSnmpIfName Nullable(String),

--- a/src/test/java/org/riptide/repository/clickhouse/TimestampTimezoneIT.java
+++ b/src/test/java/org/riptide/repository/clickhouse/TimestampTimezoneIT.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.repository.clickhouse;
+
+import com.clickhouse.client.api.Client;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.riptide.config.ClickhouseConfig;
+import org.riptide.flows.parser.data.Flow;
+import org.riptide.pipeline.EnrichedFlow;
+import org.riptide.secrets.SecretRef;
+import org.riptide.secrets.SecretResolvers;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.net.InetAddress;
+import java.time.Instant;
+import java.util.List;
+import java.util.TimeZone;
+
+/**
+ * Flow timestamps must be stored as absolute instants no matter the collector host's timezone.
+ * Regression for #276: the columns were {@code java.sql.Timestamp}, which the ClickHouse client
+ * encodes from its JVM-local wall clock, so on a non-UTC host every stored value was shifted by
+ * the host's UTC offset (a Europe/Berlin production box stored everything +2h).
+ *
+ * <p>The bug only manifests against a non-UTC ClickHouse server, so this uses a dedicated
+ * Europe/Berlin container and runs under a deliberately different JVM default zone
+ * (America/New_York) — both non-UTC, neither matching the other — a combination that stored the
+ * wrong instant before the {@code OffsetDateTime} fix and stores the exact instant after.
+ */
+@Testcontainers
+public class TimestampTimezoneIT {
+
+    @Container
+    private static final GenericContainer<?> CLICKHOUSE = new GenericContainer<>("clickhouse/clickhouse-server:25.3")
+            .withEnv("TZ", "Europe/Berlin")
+            .withEnv("CLICKHOUSE_DB", "riptide")
+            .withEnv("CLICKHOUSE_USER", "riptide")
+            .withEnv("CLICKHOUSE_PASSWORD", "riptide")
+            .withExposedPorts(8123)
+            .waitingFor(Wait.forHttp("/ping").forPort(8123).forStatusCode(200));
+
+    private static final SecretResolvers RESOLVERS = SecretResolvers.defaults();
+
+    @Test
+    void storesAbsoluteInstantsRegardlessOfHostTimezone() throws Exception {
+        final TimeZone original = TimeZone.getDefault();
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone("America/New_York")); // -04:00, and != server zone
+
+            final var endpoint = "http://" + CLICKHOUSE.getHost() + ":" + CLICKHOUSE.getMappedPort(8123);
+            final var config = new ClickhouseConfig();
+            config.setEndpoint(endpoint);
+            config.setUsername(SecretRef.of("riptide"));
+            config.setPassword(SecretRef.of("riptide"));
+
+            // Build the repository after the zone change so its client picks it up.
+            final var repository = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), config, RESOLVERS);
+            repository.start();
+
+            final var flowEnd = Instant.parse("2026-07-16T12:00:00Z");
+            final var flowStart = flowEnd.minusSeconds(30);
+            repository.persist(List.of(flow(flowStart, flowEnd)));
+
+            try (Client query = new Client.Builder().addEndpoint(endpoint)
+                    .setUsername("riptide").setPassword("riptide").setDefaultDatabase("riptide").build()) {
+                // toUnixTimestamp is an absolute epoch — no display-zone ambiguity. Every time column
+                // must equal its source instant, not host_offset seconds away from it.
+                final var row = query.queryAll(
+                        "SELECT toUnixTimestamp(timestamp) AS ts, toUnixTimestamp(receivedAt) AS ra, "
+                                + "toUnixTimestamp(deltaSwitched) AS ds, toUnixTimestamp(lastSwitched) AS ls "
+                                + "FROM flows").getFirst();
+                Assertions.assertThat(row.getLong("ts")).isEqualTo(flowEnd.getEpochSecond());
+                Assertions.assertThat(row.getLong("ra")).isEqualTo(flowEnd.getEpochSecond());
+                Assertions.assertThat(row.getLong("ds")).isEqualTo(flowStart.getEpochSecond());
+                Assertions.assertThat(row.getLong("ls")).isEqualTo(flowEnd.getEpochSecond());
+            }
+        } finally {
+            TimeZone.setDefault(original);
+        }
+    }
+
+    private static EnrichedFlow flow(final Instant start, final Instant end) throws Exception {
+        return EnrichedFlow.builder()
+                .receivedAt(end)
+                .timestamp(end)
+                .firstSwitched(start)
+                .deltaSwitched(start)
+                .lastSwitched(end)
+                .flowProtocol(Flow.FlowProtocol.IPFIX)
+                .tenant("default").organisation("default").zone("default").system("default")
+                .exporterAddr("203.0.113.7")
+                .srcAddr(InetAddress.getByName("192.0.2.10")).srcPort(1234).srcAs(64512L).srcMaskLen(24)
+                .dstAddr(InetAddress.getByName("198.51.100.20")).dstPort(53).dstAs(64513L).dstMaskLen(24)
+                .inputSnmp(1).outputSnmp(2)
+                .bytes(100L).packets(1L)
+                .direction(Flow.Direction.INGRESS)
+                .engineId(0).engineType(0).vlan(0)
+                .ipProtocolVersion(4).protocol(17).tcpFlags(0).tos(0)
+                .samplingAlgorithm(Flow.SamplingAlgorithm.Unassigned).samplingInterval(1.0)
+                .srcLocality(Flow.Locality.PUBLIC).dstLocality(Flow.Locality.PUBLIC).flowLocality(Flow.Locality.PUBLIC)
+                .build();
+    }
+}

--- a/src/test/java/org/riptide/schema/FlowsSchemaTest.java
+++ b/src/test/java/org/riptide/schema/FlowsSchemaTest.java
@@ -36,6 +36,19 @@ class FlowsSchemaTest {
     }
 
     @Test
+    void timeColumnsPinUtcTimezone() {
+        // The schema is timezone-explicit so stored instants display/parse in UTC regardless of the
+        // server's local zone (#276) — every time column carries the 'UTC' timezone argument.
+        final String ddl = FlowsSchema.createFlowsTable("riptide");
+        assertThat(ddl)
+                .contains("timestamp DateTime64(3, 'UTC')")
+                .contains("receivedAt DateTime64(9, 'UTC')")
+                .contains("firstSwitched DateTime64(9, 'UTC')")
+                .contains("deltaSwitched DateTime64(9, 'UTC')")
+                .contains("lastSwitched DateTime64(9, 'UTC')");
+    }
+
+    @Test
     void createSamplesViewQualifiesBothViewAndSourceTable() {
         final String ddl = FlowsSchema.createSamplesView("riptide");
         assertThat(ddl.strip()).startsWith("CREATE OR REPLACE VIEW `riptide`.samples AS");


### PR DESCRIPTION
Closes #276. Found while investigating why a production dashboard's `now-6h` window looked sparse at the right edge: flows were being stored **+2h in the future** on a Europe/Berlin collector, despite every host clock being chrony-synced to µs and the exporter emitting correct UTC times on the wire.

## Root cause

`ClickhouseFlow`'s five time columns were `java.sql.Timestamp`. The clickhouse client-v2 encodes a `Timestamp` into `DateTime64` from its **JVM-local wall clock**, so the stored ticks are shifted by the host's UTC offset. `receivedAt` is riptide's own `Instant.now()` at packet receipt — it can't legitimately be in the future — which localized the bug to serialization, not clocks.

## Empirical basis (not a guess)

I ran the real client against a **Europe/Berlin** ClickHouse server across the full matrix:

| field type | JVM=UTC | JVM=Berlin | JVM=New_York |
|---|---|---|---|
| `java.sql.Timestamp` | ✅ 0 | ❌ +2h | ❌ −4h |
| `OffsetDateTime`(UTC) | ✅ 0 | ✅ 0 | ✅ 0 |
| `LocalDateTime`(UTC) | ✅ 0 | ✅ 0 | ✅ 0 |
| `ZonedDateTime`(UTC) | ✅ 0 | ✅ 0 | ✅ 0 |

`useTimeZone("UTC")` on the client builder was also tested and makes **no** difference for `Timestamp` — the fix has to change the type.

## The fix

Map the source `Instant`s to `OffsetDateTime` at UTC (`value.atOffset(ZoneOffset.UTC)`) and type the POJO fields accordingly. An offset-carrying temporal serializes to an absolute instant regardless of JVM **or** server zone. The ClickHouse column type (`DateTime64`) is unchanged, so the `samples` view and all queries are unaffected. `ClickhouseFlow` is insert-only, so no read path is touched.

## Testing

- New `TimestampTimezoneIT`: a Europe/Berlin ClickHouse container + a New_York JVM default zone (both non-UTC, mutually different) asserts every time column round-trips to the exact source instant. **Test-the-test verified**: reintroducing the old behavior fails it `expected 1784203200 but was 1784188800` (−4h), the fix passes it.
- 688 unit tests + 18 ClickHouse ITs green (incl. samples-conservation and tenant-isolation, which read timestamps).

**Operational workaround** (already applied to the affected box): `TZ=UTC` on the collector service — equivalent, no deploy. This code fix makes it unnecessary going forward.