### PR TITLE
fix(snmp): skip unknown ifIndex 0 and negative-cache SNMP lookup misses

### DIFF
--- a/src/main/java/org/riptide/snmp/CachingSnmpService.java
+++ b/src/main/java/org/riptide/snmp/CachingSnmpService.java
@@ -32,22 +32,37 @@ public class CachingSnmpService implements SnmpService {
     // ifIndex reassignment after device reboots (RFC 2863).
     private final Cache<Tuple<InetSocketAddress, Integer>, Optional<IfInfo>> ifIndexCache;
 
+    // Misses are cached separately with their own (shorter) TTL: every delegate miss is a
+    // full table walk against the device, so an ifIndex that stays unresolvable must cost
+    // one walk per TTL, not one per flow. Separate cache because Guava has no per-entry TTL.
+    private final Cache<Tuple<InetSocketAddress, Integer>, Boolean> missCache;
+
     public CachingSnmpService(final SnmpService delegate, final SnmpCacheConfig cacheConfig) {
         this.delegate = Objects.requireNonNull(delegate);
         this.cacheConfig = Objects.requireNonNull(cacheConfig);
         ifIndexCache = CacheBuilder.newBuilder()
                 .expireAfterWrite(Duration.ofMillis(cacheConfig.getRetentionMs()))
                 .build();
+        missCache = CacheBuilder.newBuilder()
+                .expireAfterWrite(Duration.ofMillis(cacheConfig.getNegativeRetentionMs()))
+                // unlike ifIndexCache (bounded by real interfaces), misses are attacker-shaped:
+                // a rogue exporter spraying distinct ifIndexes must not grow the heap
+                .maximumSize(10_000)
+                .build();
     }
 
     /** Config hot-reload hook: changed nodes may mean changed endpoints or credentials. */
     public void invalidateAll() {
         this.ifIndexCache.invalidateAll();
+        this.missCache.invalidateAll();
     }
 
     @Override
     public Optional<IfInfo> getIfInfo(final SnmpEndpoint snmpEndpoint, final int ifIndex) {
         final var key = Tuple.of(snmpEndpoint.getInetSocketAddress(), ifIndex);
+        if (this.missCache.getIfPresent(key) != null) {
+            return Optional.empty();
+        }
         final Optional<IfInfo> ifInfo;
         try {
             ifInfo = ifIndexCache.get(key, () -> this.delegate.getIfInfo(snmpEndpoint, ifIndex));
@@ -57,6 +72,7 @@ public class CachingSnmpService implements SnmpService {
         }
         if (ifInfo.isEmpty()) {
             ifIndexCache.invalidate(key);
+            missCache.put(key, Boolean.TRUE);
             log.warn("Cannot determine interface info for ifIndex {} for endpoint {}", ifIndex, snmpEndpoint);
         }
         return ifInfo;

--- a/src/main/java/org/riptide/snmp/SnmpCacheConfig.java
+++ b/src/main/java/org/riptide/snmp/SnmpCacheConfig.java
@@ -21,4 +21,11 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class SnmpCacheConfig {
 
     private long retentionMs = 600_000;
+
+    /**
+     * TTL for cached lookup misses. Bounds the cost of an ifIndex that stays
+     * unresolvable (absent from the agent's IF-MIB, or an unreachable agent) to one
+     * table walk per TTL instead of one per flow. 0 disables negative caching.
+     */
+    private long negativeRetentionMs = 60_000;
 }

--- a/src/main/java/org/riptide/snmp/SnmpEnricher.java
+++ b/src/main/java/org/riptide/snmp/SnmpEnricher.java
@@ -66,7 +66,13 @@ public class SnmpEnricher implements Enricher {
     }
 
     private void apply(final Optional<Node> node, final Optional<SnmpEndpoint> snmpEndpoint, final Source source,
-                       final int ifIndex, final Consumer<IfInfo> setter) {
+                       final Integer ifIndex, final Consumer<IfInfo> setter) {
+        // ifIndex 0 is the NetFlow/IPFIX "unknown interface" marker (valid indexes start at 1,
+        // RFC 2863) — exporters tagging a single direction emit it on every flow, and no rung
+        // of the ladder can ever resolve it
+        if (ifIndex == null || ifIndex <= 0) {
+            return;
+        }
         final IfInfo pinned = node
                 .map(n -> n.definition().getInterfaces().get(ifIndex))
                 .orElse(null);

--- a/src/test/java/org/riptide/snmp/SnmpEnricherTest.java
+++ b/src/test/java/org/riptide/snmp/SnmpEnricherTest.java
@@ -37,7 +37,8 @@ import static org.mockito.Mockito.when;
         "riptide.nodes.test-agent.snmp.community=" + TestSnmpAgent.COMMUNITY,
         // enrichment-ladder per-field pin: static alias overrides SNMP, rest is live
         "riptide.nodes.test-agent.interfaces.1.alias=Uplink pinned by file",
-        "riptide.snmp.cache.retentionMs=4242"
+        "riptide.snmp.cache.retentionMs=4242",
+        "riptide.snmp.cache.negativeRetentionMs=2121"
 })
 public class SnmpEnricherTest {
 
@@ -168,6 +169,38 @@ public class SnmpEnricherTest {
     public void cacheRetentionBindsFromProperties(@Autowired final SnmpCacheConfig cacheConfig) {
         // regression: a bare public field never binds — both caches then run at 0 ms TTL
         assertThat(cacheConfig.getRetentionMs()).isEqualTo(4242);
+        assertThat(cacheConfig.getNegativeRetentionMs()).isEqualTo(2121);
+    }
+
+    @Test
+    public void unknownIfIndexZeroSkipsTheWholeLadder() throws Exception {
+        // single-direction exporters (e.g. pmacct nfprobe) emit ifIndex 0 on the untagged
+        // side of every flow — that must not hit SNMP at all
+        final SnmpService snmpService = Mockito.mock(SnmpService.class);
+
+        final var enrichers = List.<Enricher>of(new SnmpEnricher(snmpService, this.nodeRegistry, emptyInterfaceTable()));
+        final var repository = new TestRepository(metricRegistry);
+        final var pipeline = new Pipeline(enrichers, repository.asPersister(), this.metricRegistry, this.flowMapper);
+
+        final Flow flow = Mockito.mock(Flow.class);
+        when(flow.getSrcAddr()).thenReturn(InetAddress.getByName("10.10.10.10"));
+        when(flow.getDstAddr()).thenReturn(InetAddress.getByName("10.20.20.10"));
+        when(flow.getInputSnmp()).thenReturn(0);
+        when(flow.getOutputSnmp()).thenReturn(0);
+
+        final var source = new Source("here", InetAddress.getByName("127.0.0.1"));
+
+        pipeline.process(source, List.of(flow));
+
+        Mockito.verifyNoInteractions(snmpService);
+        assertThat(repository.flows()).allSatisfy(enrichedFlow -> {
+            assertThat(enrichedFlow.getInputSnmpIfName()).isNull();
+            assertThat(enrichedFlow.getInputSnmpIfAlias()).isNull();
+            assertThat(enrichedFlow.getInputSnmpIfSpeed()).isNull();
+            assertThat(enrichedFlow.getOutputSnmpIfName()).isNull();
+            assertThat(enrichedFlow.getOutputSnmpIfAlias()).isNull();
+            assertThat(enrichedFlow.getOutputSnmpIfSpeed()).isNull();
+        });
     }
 
     private static ExporterInterfaceTable emptyInterfaceTable() {

--- a/src/test/java/org/riptide/snmp/SnmpTest.java
+++ b/src/test/java/org/riptide/snmp/SnmpTest.java
@@ -212,6 +212,8 @@ public class SnmpTest {
         final int port = getNextPort();
         final SnmpCacheConfig snmpCacheConfig = new SnmpCacheConfig();
         snmpCacheConfig.setRetentionMs(600000);
+        // negative caching off: this test exercises miss -> recovery without waiting for the TTL
+        snmpCacheConfig.setNegativeRetentionMs(0);
 
         final SnmpService snmpCache = new CachingSnmpService(new DefaultSnmpService(SECRET_RESOLVERS), snmpCacheConfig);
         final SnmpEndpoint snmpEndpoint = communityV2c(new IPAddressString("127.0.0.1"), port, TestSnmpAgent.COMMUNITY);
@@ -234,5 +236,31 @@ public class SnmpTest {
         assertThat(snmpCache.getIfInfo(snmpEndpoint, 1).get().name()).isEqualTo("eth0");
         assertThat(snmpCache.getIfInfo(snmpEndpoint, 2)).isInstanceOf(Optional.class).isPresent();
         assertThat(snmpCache.getIfInfo(snmpEndpoint, 2).get().name()).isEqualTo("lo0");
+    }
+
+    @Test
+    public void missesAreNegativelyCachedToOneDelegateCallPerTtl() {
+        final SnmpCacheConfig snmpCacheConfig = new SnmpCacheConfig();
+        snmpCacheConfig.setRetentionMs(600000);
+        snmpCacheConfig.setNegativeRetentionMs(600000);
+
+        final AtomicInteger delegateCalls = new AtomicInteger();
+        final SnmpService alwaysMissing = (endpoint, ifIndex) -> {
+            delegateCalls.incrementAndGet();
+            return Optional.empty();
+        };
+        final CachingSnmpService snmpCache = new CachingSnmpService(alwaysMissing, snmpCacheConfig);
+        final SnmpEndpoint snmpEndpoint = communityV2c(new IPAddressString("127.0.0.1"), getNextPort(), TestSnmpAgent.COMMUNITY);
+
+        // every delegate miss is a full table walk — repeated lookups must not repeat it
+        assertThat(snmpCache.getIfInfo(snmpEndpoint, 7)).isInstanceOf(Optional.class).isEmpty();
+        assertThat(snmpCache.getIfInfo(snmpEndpoint, 7)).isInstanceOf(Optional.class).isEmpty();
+        assertThat(snmpCache.getIfInfo(snmpEndpoint, 7)).isInstanceOf(Optional.class).isEmpty();
+        assertThat(delegateCalls.get()).isEqualTo(1);
+
+        // hot-reload invalidation clears the negative entries too
+        snmpCache.invalidateAll();
+        assertThat(snmpCache.getIfInfo(snmpEndpoint, 7)).isInstanceOf(Optional.class).isEmpty();
+        assertThat(delegateCalls.get()).isEqualTo(2);
     }
 }


### PR DESCRIPTION
## Problem

Exporters that tag a single direction per flow record (pmacct `nfprobe` with `nfprobe_direction`/`nfprobe_ifindex` from a `pretag.map`) emit ifIndex **0** — the IPFIX/NetFlow "unknown interface" marker — on the untagged side of *every* flow. Verified by capturing the live IPFIX export: records carry exactly `input=N, output=0` (ingress) or `input=0, output=N` (egress).

`SnmpEnricher` passed ifIndex 0 into the enrichment ladder, and `CachingSnmpService` deliberately did not cache misses — so every flow triggered a full SNMP interface-table walk against the exporter plus a WARN, flooding the log at ~40 lines/s per exporter.

## Fix

- **`SnmpEnricher`**: skip the whole ladder (pinned/options/live) for ifIndex `null` or `<= 0` — valid indexes start at 1 (RFC 2863), so the marker can never resolve. The `int -> Integer` widening also removes a latent auto-unbox NPE (`EnrichedFlow.inputSnmp`/`outputSnmp` are nullable).
- **`CachingSnmpService`**: misses now go into a bounded (10k entries) negative cache with its own TTL — `riptide.snmp.cache.negativeRetentionMs`, default 60 s, `0` disables. A genuinely unresolvable ifIndex (or an agent that is temporarily unreachable) costs one table walk + one WARN per TTL instead of one per flow.

## Tradeoffs / notes

- A transient SNMP blip now delays (re-)enrichment for a given `(endpoint, ifIndex)` by up to `negativeRetentionMs`; config hot-reload still clears both caches immediately.
- A pinned `riptide.nodes.*.interfaces.0.*` entry is no longer consulted — index 0 is the reserved unknown marker.
- Future improvement (out of scope here): the delegate walks the whole interface table per ifIndex; caching the walked table per endpoint would make positive lookups for sibling indexes free and subsume the negative cache.

## Verification

- New tests: `unknownIfIndexZeroSkipsTheWholeLadder` (zero SNMP interaction for ifIndex 0), `missesAreNegativelyCachedToOneDelegateCallPerTtl`, config-binding regression for the new property.
- `mvn verify` green (unit tests + SpotBugs/checkstyle/Error Prone).
- `/code-review medium` run; findings applied (bounded miss cache) or consciously accepted (transient-miss TTL tradeoff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)