### PR TITLE
fix(flows): fall back to total counters when exporters send no delta counts

### DIFF
--- a/src/main/java/org/riptide/flows/parser/ipfix/IpFixFlowBuilder.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/IpFixFlowBuilder.java
@@ -63,12 +63,21 @@ public class IpFixFlowBuilder {
 
             @Override
             public long getBytes() {
+                // The total counters come last: some exporters (e.g. Juniper SRX inline J-Flow)
+                // send only octetTotalCount/packetTotalCount, never the delta variants. Like
+                // NetGauze and nfdump we treat the total as the record's count — a knowing
+                // approximation that over-counts a long-lived flow if its exporter re-reports
+                // growing totals at each active timeout.
                 return Optionals.first(
                                 rawFlow.octetDeltaCount,
                                 rawFlow.postOctetDeltaCount,
                                 rawFlow.layer2OctetDeltaCount,
                                 rawFlow.postLayer2OctetDeltaCount,
-                                rawFlow.transportOctetDeltaCount)
+                                rawFlow.transportOctetDeltaCount,
+                                rawFlow.octetTotalCount,
+                                rawFlow.postOctetTotalCount,
+                                rawFlow.layer2OctetTotalCount,
+                                rawFlow.postLayer2OctetTotalCount)
                         .orElse(0L);
             }
 
@@ -201,7 +210,7 @@ public class IpFixFlowBuilder {
 
             @Override
             public long getPackets() {
-                return Optionals.first(rawFlow.packetDeltaCount, rawFlow.postPacketDeltaCount, rawFlow.transportPacketDeltaCount).orElse(0L);
+                return Optionals.first(rawFlow.packetDeltaCount, rawFlow.postPacketDeltaCount, rawFlow.transportPacketDeltaCount, rawFlow.packetTotalCount, rawFlow.postPacketTotalCount).orElse(0L);
             }
 
             @Override

--- a/src/main/java/org/riptide/flows/parser/ipfix/IpfixRawFlow.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/IpfixRawFlow.java
@@ -24,6 +24,10 @@ public class IpfixRawFlow {
     public Long layer2OctetDeltaCount;
     public Long postLayer2OctetDeltaCount;
     public Long transportOctetDeltaCount;
+    public Long octetTotalCount;
+    public Long postOctetTotalCount;
+    public Long layer2OctetTotalCount;
+    public Long postLayer2OctetTotalCount;
     public Long bgpDestinationAsNumber;
     public Integer flowDirection;
     public InetAddress destinationIPv6Address;
@@ -59,6 +63,8 @@ public class IpfixRawFlow {
     public Long packetDeltaCount;
     public Long postPacketDeltaCount;
     public Long transportPacketDeltaCount;
+    public Long packetTotalCount;
+    public Long postPacketTotalCount;
     public Integer protocolIdentifier;
     public Integer samplingAlgorithm;
     public Integer samplerMode;

--- a/src/main/java/org/riptide/flows/parser/netflow9/Netflow9FlowBuilder.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/Netflow9FlowBuilder.java
@@ -174,12 +174,14 @@ public class Netflow9FlowBuilder {
 
             @Override
             public long getBytes() {
-                return Optionals.of(raw.IN_BYTES).orElse(0L);
+                // Total counters last, as in the IPFIX builder: exporters using permanent-cache
+                // counters (field 85/86) send no IN_BYTES/IN_PKTS.
+                return Optionals.first(raw.IN_BYTES, raw.IN_PERMANENT_BYTES).orElse(0L);
             }
 
             @Override
             public long getPackets() {
-                return Optionals.of(raw.IN_PKTS).orElse(0L);
+                return Optionals.first(raw.IN_PKTS, raw.IN_PERMANENT_PKTS).orElse(0L);
             }
 
             @Override

--- a/src/main/java/org/riptide/flows/parser/netflow9/Netflow9RawFlow.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/Netflow9RawFlow.java
@@ -15,6 +15,7 @@ public class Netflow9RawFlow {
     public Duration sysUpTime;
     public int recordCount;
     public Long IN_BYTES;
+    public Long IN_PERMANENT_BYTES;
     public Integer DIRECTION;
     public InetAddress IPV6_DST_ADDR;
     public InetAddress IPV4_DST_ADDR;
@@ -40,6 +41,7 @@ public class Netflow9RawFlow {
     public Integer egressPhysicalInterface;
     public Integer OUTPUT_SNMP;
     public Long IN_PKTS;
+    public Long IN_PERMANENT_PKTS;
     public Integer PROTOCOL;
     public Integer SAMPLING_ALGORITHM;
     public Double SAMPLING_INTERVAL;

--- a/src/test/java/org/riptide/flows/ipfix/FlowCountersTest.java
+++ b/src/test/java/org/riptide/flows/ipfix/FlowCountersTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.ipfix;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.riptide.flows.parser.ie.values.UnsignedValue;
+import org.riptide.flows.parser.ie.values.ValueConversionService;
+import org.riptide.flows.parser.ipfix.IpFixFlowBuilder;
+import org.riptide.flows.parser.ipfix.IpfixRawFlow;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.Instant;
+
+@SpringBootTest
+public class FlowCountersTest {
+    @Autowired
+    @Qualifier("ipfixValueConversionService")
+    private ValueConversionService conversionService;
+
+    @Test
+    void totalCountersUsedWhenDeltasAbsent() {
+        // Juniper SRX inline J-Flow exports octetTotalCount/packetTotalCount (IE 85/86)
+        // instead of the delta variants; such flows used to be persisted with bytes = 0.
+        final var raw = new IpfixRawFlow();
+        raw.exportTime = Instant.EPOCH;
+        raw.octetTotalCount = 4711L;
+        raw.packetTotalCount = 42L;
+
+        final var flow = new IpFixFlowBuilder(conversionService).buildFlow(Instant.EPOCH, raw);
+
+        Assertions.assertThat(flow.getBytes()).isEqualTo(4711L);
+        Assertions.assertThat(flow.getPackets()).isEqualTo(42L);
+    }
+
+    @Test
+    void totalCountersArePopulatedByName() {
+        // The raw-flow fields are filled via reflection keyed on the IE name from the IANA
+        // registry — a typo in the field name would silently no-op, so drive the real wiring.
+        final var raw = new IpfixRawFlow();
+        raw.exportTime = Instant.EPOCH;
+        conversionService.apply(new UnsignedValue("octetTotalCount", 4711L), raw);
+        conversionService.apply(new UnsignedValue("packetTotalCount", 42L), raw);
+
+        final var flow = new IpFixFlowBuilder(conversionService).buildFlow(Instant.EPOCH, raw);
+
+        Assertions.assertThat(flow.getBytes()).isEqualTo(4711L);
+        Assertions.assertThat(flow.getPackets()).isEqualTo(42L);
+    }
+
+    @Test
+    void siblingTotalCountersArePopulatedByName() {
+        // The post/layer2 totals are last in the fallback chains; each must reach its field
+        // through the same name-keyed reflection.
+        for (final var name : new String[]{"postOctetTotalCount", "layer2OctetTotalCount", "postLayer2OctetTotalCount"}) {
+            final var raw = new IpfixRawFlow();
+            raw.exportTime = Instant.EPOCH;
+            conversionService.apply(new UnsignedValue(name, 4711L), raw);
+            conversionService.apply(new UnsignedValue("postPacketTotalCount", 42L), raw);
+
+            final var flow = new IpFixFlowBuilder(conversionService).buildFlow(Instant.EPOCH, raw);
+
+            Assertions.assertThat(flow.getBytes()).as(name).isEqualTo(4711L);
+            Assertions.assertThat(flow.getPackets()).as("postPacketTotalCount").isEqualTo(42L);
+        }
+    }
+
+    @Test
+    void deltaCountersPreferredOverTotals() {
+        final var raw = new IpfixRawFlow();
+        raw.exportTime = Instant.EPOCH;
+        raw.octetDeltaCount = 100L;
+        raw.packetDeltaCount = 10L;
+        raw.octetTotalCount = 4711L;
+        raw.packetTotalCount = 42L;
+
+        final var flow = new IpFixFlowBuilder(conversionService).buildFlow(Instant.EPOCH, raw);
+
+        Assertions.assertThat(flow.getBytes()).isEqualTo(100L);
+        Assertions.assertThat(flow.getPackets()).isEqualTo(10L);
+    }
+}

--- a/src/test/java/org/riptide/flows/netflow9/FlowCountersTest.java
+++ b/src/test/java/org/riptide/flows/netflow9/FlowCountersTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.netflow9;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.riptide.flows.parser.ie.values.UnsignedValue;
+import org.riptide.flows.parser.ie.values.ValueConversionService;
+import org.riptide.flows.parser.netflow9.Netflow9FlowBuilder;
+import org.riptide.flows.parser.netflow9.Netflow9RawFlow;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.Duration;
+import java.time.Instant;
+
+@SpringBootTest
+public class FlowCountersTest {
+
+    @Autowired
+    @Qualifier("netflow9ValueConversionService")
+    private ValueConversionService valueConversionService;
+
+    @Test
+    void permanentCountersUsedWhenInCountersAbsent() {
+        // Exporters using permanent-cache counters (field 85/86) send no IN_BYTES/IN_PKTS;
+        // such flows used to be persisted with bytes = 0. Drive the name-keyed reflection too.
+        final var raw = new Netflow9RawFlow();
+        raw.unixSecs = Instant.EPOCH;
+        raw.sysUpTime = Duration.ZERO;
+        valueConversionService.apply(new UnsignedValue("IN_PERMANENT_BYTES", 4711L), raw);
+        valueConversionService.apply(new UnsignedValue("IN_PERMANENT_PKTS", 42L), raw);
+
+        final var flow = new Netflow9FlowBuilder(valueConversionService).buildFlow(Instant.EPOCH, raw);
+
+        Assertions.assertThat(flow.getBytes()).isEqualTo(4711L);
+        Assertions.assertThat(flow.getPackets()).isEqualTo(42L);
+    }
+
+    @Test
+    void inCountersPreferredOverPermanentCounters() {
+        final var raw = new Netflow9RawFlow();
+        raw.unixSecs = Instant.EPOCH;
+        raw.sysUpTime = Duration.ZERO;
+        raw.IN_BYTES = 100L;
+        raw.IN_PKTS = 10L;
+        raw.IN_PERMANENT_BYTES = 4711L;
+        raw.IN_PERMANENT_PKTS = 42L;
+
+        final var flow = new Netflow9FlowBuilder(valueConversionService).buildFlow(Instant.EPOCH, raw);
+
+        Assertions.assertThat(flow.getBytes()).isEqualTo(100L);
+        Assertions.assertThat(flow.getPackets()).isEqualTo(10L);
+    }
+}


### PR DESCRIPTION
## Problem

A Juniper SRX 345 (inline J-Flow) exported ~71k flows/hour that were all persisted with `bytes = 0` / `packets = 0`, making the exporter invisible in every bytes-ranked view (e.g. Top 10 Exporters). Packet capture of the SRX's IPFIX templates showed it exports `octetTotalCount`/`packetTotalCount` (IE 85/86) instead of the delta variants — the builder's fallback chains only read the five `*DeltaCount` elements and fell back to `0L`.

## Fix

- **IPFIX**: append the total counters after the delta variants in the `getBytes()`/`getPackets()` fallback chains, including the post/layer2 siblings defined in the IANA registry (`postOctetTotalCount` 171, `postPacketTotalCount` 172, `layer2OctetTotalCount` 353, `postLayer2OctetTotalCount` 420). Deltas still win when both are present.
- **NetFlow v9**: same gap, same fix — fall back to `IN_PERMANENT_BYTES`/`IN_PERMANENT_PKTS` (field 85/86, already in the v9 registry) when `IN_BYTES`/`IN_PKTS` are absent.
- **Tests**: new `FlowCountersTest` classes for both protocols cover totals-only records, delta preference, and — importantly — the name-keyed reflection wiring through `ValueConversionService`, so a field-name typo can't silently no-op.

This matches how NetGauze treats total counters (equivalent counters wherever counts matter) and what nfdump/ElastiFlow do; goflow2 requires a manual mapping config for the same case. Known, deliberate approximation shared with those collectors: the total is taken as the record's count, which over-counts a long-lived flow if its exporter re-reports growing totals at each active timeout (per-flow delta tracking in the UDP session would be the exact fix and is out of scope here). The code comment states this.

## Verification

- `make jar` (mvn verify incl. SpotBugs/checkstyle/Error Prone): 697 tests, `BUILD SUCCESS`.
- `/code-review` (high effort, 8 finder angles + adversarial verify) ran on the initial diff; the confirmed findings (missing sibling totals, NFv9 asymmetry, reflection wiring untested) are fixed in this PR, the plausible over-count caveat is documented above.
- Live validation pending deploy: the SRX at issue currently ingests fine except for the zeroed counters, so after deploy `sum(bytes)` per exporter in ClickHouse should immediately show it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)