### PR TITLE
ci(release): sign container images and release artifacts with cosign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # upload release assets
+      id-token: write  # keyless cosign signing via the workflow's OIDC identity
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up JDK 25 for x64
@@ -56,6 +59,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Build and push container image
+        id: build-image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
@@ -68,6 +72,20 @@ jobs:
           tags: |
             ghcr.io/riptide-labs/riptide:${{ env.VERSION }}
             ghcr.io/riptide-labs/riptide:latest
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      - name: Sign container image
+        run: |
+          # Sign the digest, not a tag: covers every tag pointing at this image.
+          cosign sign --yes "ghcr.io/riptide-labs/riptide@${{ steps.build-image.outputs.digest }}"
+      - name: Sign release artifacts
+        run: |
+          for artifact in target/*.jar target/*.deb target/*.rpm; do
+            cosign sign-blob --yes \
+              --output-signature "${artifact}.sig" \
+              --output-certificate "${artifact}.pem" \
+              "${artifact}"
+          done
       - name: Release ${{ github.ref_name }}
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
@@ -75,3 +93,5 @@ jobs:
             target/*.jar
             target/*.deb
             target/*.rpm
+            target/*.sig
+            target/*.pem


### PR DESCRIPTION
## What

Adds keyless (OIDC) cosign signing to the tag-triggered release workflow:

- **Container image**: `cosign sign` against the pushed manifest-list digest (`steps.build-image.outputs.digest`), so the signature covers every tag pointing at that image (`0.x.y` and `latest`).
- **JAR / DEB / RPM**: `cosign sign-blob` per artifact; the `.sig` signature and `.pem` certificate are uploaded to the GitHub release alongside the artifacts.
- The release job now declares explicit `permissions` (`contents: write` for release upload, `id-token: write` for the OIDC identity).
- `sigstore/cosign-installer` pinned to `6f9f177` (v4.1.2); Dependabot's `github-actions` ecosystem keeps the pin current.

Signing is keyless: no key material to manage, signatures verify against the workflow's OIDC identity and are recorded in the Rekor transparency log.

## Verification (consumer side)

```bash
cosign verify ghcr.io/riptide-labs/riptide:<version> \
  --certificate-identity-regexp 'https://github.com/Riptide-Labs/riptide/\.github/workflows/release\.yml.*' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com

cosign verify-blob riptide-flows-<version>.jar \
  --signature riptide-flows-<version>.jar.sig \
  --certificate riptide-flows-<version>.jar.pem \
  --certificate-identity-regexp 'https://github.com/Riptide-Labs/riptide/\.github/workflows/release\.yml.*' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com
```

## Notes

- Validated with actionlint: the new steps are clean; two pre-existing `SC2086` infos in the SNAPSHOT-check and git-hash steps are untouched (out of scope).
- End-to-end proof comes with the next release tag — the signing steps only run in the tag-triggered job. /code-review (medium) on the diff: no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)