### PR TITLE
ci(release): use cosign 3 bundle format for blob signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,11 +80,10 @@ jobs:
           cosign sign --yes "ghcr.io/riptide-labs/riptide@${{ steps.build-image.outputs.digest }}"
       - name: Sign release artifacts
         run: |
+          # cosign 3.x writes the sigstore bundle (sig + cert + Rekor proof in one file);
+          # the legacy --output-signature/--output-certificate pair no longer works alone.
           for artifact in target/*.jar target/*.deb target/*.rpm; do
-            cosign sign-blob --yes \
-              --output-signature "${artifact}.sig" \
-              --output-certificate "${artifact}.pem" \
-              "${artifact}"
+            cosign sign-blob --yes --bundle "${artifact}.sigstore.json" "${artifact}"
           done
       - name: Release ${{ github.ref_name }}
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
@@ -93,5 +92,4 @@ jobs:
             target/*.jar
             target/*.deb
             target/*.rpm
-            target/*.sig
-            target/*.pem
+            target/*.sigstore.json


### PR DESCRIPTION
The first signed release (v0.5.0) failed in the "Sign release artifacts" step: cosign-installer v4 installs **cosign 3.x**, where `sign-blob` emits the sigstore bundle by default and the legacy `--output-signature`/`--output-certificate` pair dies with `create bundle file: open : no such file or directory`. The container image signing (`cosign sign`) succeeded — only blob signing and the (dependent) release-creation step were affected.

Fix: sign each artifact into the modern single-file bundle (`<artifact>.sigstore.json`, containing signature + certificate + Rekor proof) and attach those to the GitHub release.

Consumer verification becomes:

```bash
cosign verify-blob riptide-flows-<v>.jar \
  --bundle riptide-flows-<v>.jar.sigstore.json \
  --certificate-identity-regexp 'https://github.com/Riptide-Labs/riptide/\.github/workflows/release\.yml.*' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com
```

The v0.5.0 release object is being assembled manually from the run's artifacts per the established recovery flow; the signing steps only execute in tag-triggered jobs, so this fix proves out fully at v0.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)