### PR TITLE
feat(dashboards): Sankey traffic-path dashboard

### DIFF
--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-kentik-sankey.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-kentik-sankey.json
@@ -1,0 +1,302 @@
+{
+  "uid": "riptide-kentik-sankey",
+  "title": "Riptide - Kentik-style Traffic Paths (Sankey)",
+  "tags": [
+    "riptide",
+    "netflow",
+    "kentik"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "5m",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "editable": true,
+  "graphTooltip": 0,
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "label": "Datasource",
+        "type": "datasource",
+        "query": "grafana-clickhouse-datasource",
+        "refresh": 1,
+        "hide": 0,
+        "current": {},
+        "options": [],
+        "includeAll": false,
+        "multi": false
+      },
+      {
+        "name": "database",
+        "label": "Database",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${datasource}"
+        },
+        "query": {
+          "editorType": "sql",
+          "format": 1,
+          "queryType": "table",
+          "rawSql": "SELECT DISTINCT database FROM system.tables WHERE name = 'flows'"
+        },
+        "refresh": 1,
+        "includeAll": false,
+        "multi": false,
+        "sort": 1,
+        "current": {
+          "selected": true,
+          "text": "riptide",
+          "value": "riptide"
+        },
+        "definition": "SELECT DISTINCT database FROM system.tables WHERE name = 'flows'"
+      },
+      {
+        "name": "depth",
+        "label": "Depth (paths)",
+        "type": "custom",
+        "query": "8,15,25,50",
+        "options": [],
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "selected": true,
+          "text": "15",
+          "value": "15"
+        }
+      },
+      {
+        "name": "tenant",
+        "label": "Tenant",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${datasource}"
+        },
+        "query": {
+          "editorType": "sql",
+          "format": 1,
+          "rawSql": "SELECT DISTINCT tenant FROM ${database}.flows ORDER BY tenant",
+          "queryType": "table"
+        },
+        "refresh": 1,
+        "includeAll": true,
+        "multi": true,
+        "sort": 1,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "definition": "SELECT DISTINCT tenant FROM ${database}.flows ORDER BY tenant"
+      },
+      {
+        "name": "zone",
+        "label": "Zone",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${datasource}"
+        },
+        "query": {
+          "editorType": "sql",
+          "format": 1,
+          "rawSql": "SELECT DISTINCT zone FROM ${database}.flows ORDER BY zone",
+          "queryType": "table"
+        },
+        "refresh": 1,
+        "includeAll": true,
+        "multi": true,
+        "sort": 1,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "definition": "SELECT DISTINCT zone FROM ${database}.flows ORDER BY zone"
+      },
+      {
+        "name": "locality",
+        "label": "Flow locality",
+        "type": "custom",
+        "query": "PUBLIC,PRIVATE",
+        "options": [],
+        "includeAll": true,
+        "multi": false,
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "netsage-sankey-panel",
+      "title": "Peering: Source AS - Ingress - Egress - Destination AS",
+      "description": "Replicates Kentik's Discover Peers Sankey and the 'cost per customer' chain (customer \u2192 ingress interface \u2192 egress interface \u2192 adjacent ASN). https://kb.kentik.com/docs/discover-peers",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${datasource}"
+      },
+      "options": {},
+      "gridPos": {
+        "h": 13,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "${datasource}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "queryType": "table",
+          "rawSql": "SELECT concat(toString(srcAs), ': ', ifNull(srcAsOrg, 'unknown')) AS \"Source AS\",\n       concat(exporterAddr, ' - ', ifNull(inputSnmpIfName, concat('if', toString(inputSnmp)))) AS \"Ingress\",\n       concat(exporterAddr, ' - ', ifNull(outputSnmpIfName, concat('if', toString(outputSnmp)))) AS \"Egress\",\n       concat(toString(dstAs), ': ', ifNull(dstAsOrg, 'unknown')) AS \"Destination AS\",\n       round(sum(bytes) * 8 / (toUnixTimestamp($__toTime) - toUnixTimestamp($__fromTime))) AS \"Bits/s\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Source AS\", \"Ingress\", \"Egress\", \"Destination AS\"\nORDER BY \"Bits/s\" DESC\nLIMIT $depth",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "netsage-sankey-panel",
+      "title": "Situational awareness: Source Country - Source AS - Destination host - Service",
+      "description": "Replicates Kentik's DDoS situational-awareness chain (Source Country \u2192 Source ASN \u2192 Destination IP \u2192 Destination Protocol). https://www.kentik.com/blog/insight-delivered-the-power-of-sankey-diagrams/",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${datasource}"
+      },
+      "options": {},
+      "gridPos": {
+        "h": 13,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 2,
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "${datasource}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "queryType": "table",
+          "rawSql": "SELECT if(srcCountry = '', 'unknown', srcCountry) AS \"Source Country\",\n       concat(toString(srcAs), ': ', ifNull(srcAsOrg, 'unknown')) AS \"Source AS\",\n       ifNull(dstAddrHostname, replaceOne(toString(dstAddr), '::ffff:', '')) AS \"Destination\",\n       concat(transform(protocol, [1, 2, 6, 17, 41, 47, 50, 51, 58, 89, 132], ['ICMP', 'IGMP', 'TCP', 'UDP', 'IPv6', 'GRE', 'ESP', 'AH', 'IPv6-ICMP', 'OSPFIGP', 'SCTP'], concat('proto-', toString(protocol))), '/', toString(dstPort)) AS \"Service\",\n       round(sum(bytes) * 8 / (toUnixTimestamp($__toTime) - toUnixTimestamp($__fromTime))) AS \"Bits/s\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Source Country\", \"Source AS\", \"Destination\", \"Service\"\nORDER BY \"Bits/s\" DESC\nLIMIT $depth",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "netsage-sankey-panel",
+      "title": "Geo termination: Destination AS - Destination Country - Destination City",
+      "description": "Replicates Kentik's geo-planning chain (Dest Country \u2192 Dest Region \u2192 Dest City); riptide carries country and city, with the destination AS as the leading column. https://www.kentik.com/blog/insight-delivered-the-power-of-sankey-diagrams/",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${datasource}"
+      },
+      "options": {},
+      "gridPos": {
+        "h": 13,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 3,
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "${datasource}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "queryType": "table",
+          "rawSql": "SELECT concat(toString(dstAs), ': ', ifNull(dstAsOrg, 'unknown')) AS \"Destination AS\",\n       if(dstCountry = '', 'unknown', dstCountry) AS \"Destination Country\",\n       if(dstCity = '', 'unknown', dstCity) AS \"Destination City\",\n       round(sum(bytes) * 8 / (toUnixTimestamp($__toTime) - toUnixTimestamp($__fromTime))) AS \"Bits/s\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Destination AS\", \"Destination Country\", \"Destination City\"\nORDER BY \"Bits/s\" DESC\nLIMIT $depth",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "netsage-sankey-panel",
+      "title": "Origination/termination: Source City - Source Locality - Destination Locality - Destination City",
+      "description": "Replicates the Data Explorer example chain (Source City \u2192 Source Traffic Origination \u2192 Destination Traffic Termination \u2192 Destination City), with riptide's locality as the origination/termination analog. https://kb.kentik.com/docs/chart-visualization-types",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${datasource}"
+      },
+      "options": {},
+      "gridPos": {
+        "h": 13,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "id": 4,
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "${datasource}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "queryType": "table",
+          "rawSql": "SELECT if(srcCity = '', 'unknown', srcCity) AS \"Source City\",\n       toString(srcLocality) AS \"Source Locality\",\n       toString(dstLocality) AS \"Destination Locality\",\n       if(dstCity = '', 'unknown', dstCity) AS \"Destination City\",\n       round(sum(bytes) * 8 / (toUnixTimestamp($__toTime) - toUnixTimestamp($__fromTime))) AS \"Bits/s\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Source City\", \"Source Locality\", \"Destination Locality\", \"Destination City\"\nORDER BY \"Bits/s\" DESC\nLIMIT $depth",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "netsage-sankey-panel",
+      "title": "Ultimate Exit: Ingress - Egress - Destination AS",
+      "description": "Replicates Kentik's Ultimate Exit Sankey (Entry Site \u2192 Exit Site \u2192 Destination AS), mapped to riptide's ingress/egress interfaces. https://kb.kentik.com/docs/using-ultimate-exit",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${datasource}"
+      },
+      "options": {},
+      "gridPos": {
+        "h": 13,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "id": 5,
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "${datasource}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "queryType": "table",
+          "rawSql": "SELECT concat(exporterAddr, ' - ', ifNull(inputSnmpIfName, concat('if', toString(inputSnmp)))) AS \"Entry\",\n       concat(exporterAddr, ' - ', ifNull(outputSnmpIfName, concat('if', toString(outputSnmp)))) AS \"Exit\",\n       concat(toString(dstAs), ': ', ifNull(dstAsOrg, 'unknown')) AS \"Destination AS\",\n       round(sum(bytes) * 8 / (toUnixTimestamp($__toTime) - toUnixTimestamp($__fromTime))) AS \"Bits/s\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Entry\", \"Exit\", \"Destination AS\"\nORDER BY \"Bits/s\" DESC\nLIMIT $depth",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "links": []
+}


### PR DESCRIPTION
## What

A new provisioned Grafana dashboard (now `riptide-traffic-paths.json`, uid `riptide-traffic-paths`) bringing established Sankey traffic-path visualizations to `riptide.flows`: 2–5-dimension chains with a visualization-depth control and bits/s bands, covering peering, DDoS situational awareness, geo planning, and entry-to-exit workflows.

Five panels, each with a description of its analytical intent:

| Panel | Analytical workflow |
|---|---|
| Source AS → Ingress → Egress → Destination AS | Peering / cost-per-customer chain |
| Source Country → Source AS → Destination host → Service | DDoS situational-awareness chain — uses the 0.5.0 GeoIP columns |
| Destination AS → Country → City | Geo-planning chain |
| Source City → Locality → Locality → Destination City | Origination/termination chain (locality as the analog) |
| Ingress → Egress → Destination AS | Entry-to-exit paths |

Conventions adopted: **bits/s** as the band metric (computed over the selected range), a **Depth** variable (8/15/25/50 paths, default 15), preset chains per direction rather than mirrored charts. House conventions kept: `netsage-sankey-panel`, `${datasource}`/`${database}`/tenant/zone/locality template variables identical to `riptide-sankey.json`.

## Verification

- All five panel queries executed against a schema-identical scratch database on the production ClickHouse (cloned `riptide.flows` plus the exact 0.5.0 geo `ADD COLUMN`s) with fixture rows: every chain resolves and the bits/s math is exact (123456789 B over 6h → 45725 b/s). Scratch database dropped afterwards.
- Dashboard JSON reviewed against the sibling dashboards: uid/panel-id uniqueness, tiling, variable references (no stale `$limit`), target shape, GROUP BY consistency — clean.
- Deployment note: the three non-geo panels work against any 0.4.x schema; the two geo panels need riptide ≥ 0.5.0 (columns exist, values are `unknown` until GeoIP databases are configured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
