### PR TITLE
feat(enrichment): persist the matched node name as exporterName

### DIFF
--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-kentik-sankey.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-kentik-sankey.json
@@ -153,9 +153,9 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "SELECT DISTINCT exporterAddr FROM ${database}.flows ORDER BY exporterAddr"
+          "rawSql": "SELECT DISTINCT if(exporterName != '', exporterName, exporterAddr) AS __text, exporterAddr AS __value FROM ${database}.flows ORDER BY __text"
         },
-        "definition": "SELECT DISTINCT exporterAddr FROM ${database}.flows ORDER BY exporterAddr",
+        "definition": "SELECT DISTINCT if(exporterName != '', exporterName, exporterAddr) AS __text, exporterAddr AS __value FROM ${database}.flows ORDER BY __text",
         "refresh": 1,
         "includeAll": true,
         "multi": true,
@@ -198,7 +198,7 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "SELECT concat(toString(srcAs), ': ', ifNull(srcAsOrg, 'unknown')) AS \"Source AS\",\n       concat(exporterAddr, ' - ', ifNull(inputSnmpIfName, concat('if', toString(inputSnmp)))) AS \"Ingress\",\n       concat(exporterAddr, ' - ', ifNull(outputSnmpIfName, concat('if', toString(outputSnmp)))) AS \"Egress\",\n       concat(toString(dstAs), ': ', ifNull(dstAsOrg, 'unknown')) AS \"Destination AS\",\n       round(sum(bytes) * 8 / (toUnixTimestamp($__toTime) - toUnixTimestamp($__fromTime))) AS \"Bits/s\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Source AS\", \"Ingress\", \"Egress\", \"Destination AS\"\nORDER BY \"Bits/s\" DESC\nLIMIT $depth",
+          "rawSql": "SELECT concat(toString(srcAs), ': ', ifNull(srcAsOrg, 'unknown')) AS \"Source AS\",\n       concat(if(exporterName != '', exporterName, exporterAddr), ' - ', ifNull(inputSnmpIfName, concat('if', toString(inputSnmp)))) AS \"Ingress\",\n       concat(if(exporterName != '', exporterName, exporterAddr), ' - ', ifNull(outputSnmpIfName, concat('if', toString(outputSnmp)))) AS \"Egress\",\n       concat(toString(dstAs), ': ', ifNull(dstAsOrg, 'unknown')) AS \"Destination AS\",\n       round(sum(bytes) * 8 / (toUnixTimestamp($__toTime) - toUnixTimestamp($__fromTime))) AS \"Bits/s\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Source AS\", \"Ingress\", \"Egress\", \"Destination AS\"\nORDER BY \"Bits/s\" DESC\nLIMIT $depth",
           "refId": "A"
         }
       ]
@@ -228,7 +228,7 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "SELECT if(srcCountry = '', 'unknown', srcCountry) AS \"Source Country\",\n       concat(toString(srcAs), ': ', ifNull(srcAsOrg, 'unknown')) AS \"Source AS\",\n       exporterAddr AS \"Exporter\",\n       ifNull(dstAddrHostname, replaceOne(toString(dstAddr), '::ffff:', '')) AS \"Destination\",\n       concat(transform(protocol, [1, 2, 6, 17, 41, 47, 50, 51, 58, 89, 132], ['ICMP', 'IGMP', 'TCP', 'UDP', 'IPv6', 'GRE', 'ESP', 'AH', 'IPv6-ICMP', 'OSPFIGP', 'SCTP'], concat('proto-', toString(protocol))), '/', toString(dstPort)) AS \"Service\",\n       round(sum(bytes) * 8 / (toUnixTimestamp($__toTime) - toUnixTimestamp($__fromTime))) AS \"Bits/s\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Source Country\", \"Source AS\", \"Exporter\", \"Destination\", \"Service\"\nORDER BY \"Bits/s\" DESC\nLIMIT $depth",
+          "rawSql": "SELECT if(srcCountry = '', 'unknown', srcCountry) AS \"Source Country\",\n       concat(toString(srcAs), ': ', ifNull(srcAsOrg, 'unknown')) AS \"Source AS\",\n       if(exporterName != '', exporterName, exporterAddr) AS \"Exporter\",\n       ifNull(dstAddrHostname, replaceOne(toString(dstAddr), '::ffff:', '')) AS \"Destination\",\n       concat(transform(protocol, [1, 2, 6, 17, 41, 47, 50, 51, 58, 89, 132], ['ICMP', 'IGMP', 'TCP', 'UDP', 'IPv6', 'GRE', 'ESP', 'AH', 'IPv6-ICMP', 'OSPFIGP', 'SCTP'], concat('proto-', toString(protocol))), '/', toString(dstPort)) AS \"Service\",\n       round(sum(bytes) * 8 / (toUnixTimestamp($__toTime) - toUnixTimestamp($__fromTime))) AS \"Bits/s\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Source Country\", \"Source AS\", \"Exporter\", \"Destination\", \"Service\"\nORDER BY \"Bits/s\" DESC\nLIMIT $depth",
           "refId": "A"
         }
       ]
@@ -258,7 +258,7 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "SELECT exporterAddr AS \"Exporter\",\n       concat(toString(dstAs), ': ', ifNull(dstAsOrg, 'unknown')) AS \"Destination AS\",\n       if(dstCountry = '', 'unknown', dstCountry) AS \"Destination Country\",\n       if(dstCity = '', 'unknown', dstCity) AS \"Destination City\",\n       round(sum(bytes) * 8 / (toUnixTimestamp($__toTime) - toUnixTimestamp($__fromTime))) AS \"Bits/s\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Exporter\", \"Destination AS\", \"Destination Country\", \"Destination City\"\nORDER BY \"Bits/s\" DESC\nLIMIT $depth",
+          "rawSql": "SELECT if(exporterName != '', exporterName, exporterAddr) AS \"Exporter\",\n       concat(toString(dstAs), ': ', ifNull(dstAsOrg, 'unknown')) AS \"Destination AS\",\n       if(dstCountry = '', 'unknown', dstCountry) AS \"Destination Country\",\n       if(dstCity = '', 'unknown', dstCity) AS \"Destination City\",\n       round(sum(bytes) * 8 / (toUnixTimestamp($__toTime) - toUnixTimestamp($__fromTime))) AS \"Bits/s\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Exporter\", \"Destination AS\", \"Destination Country\", \"Destination City\"\nORDER BY \"Bits/s\" DESC\nLIMIT $depth",
           "refId": "A"
         }
       ]
@@ -288,7 +288,7 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "SELECT if(srcCity = '', 'unknown', srcCity) AS \"Source City\",\n       toString(srcLocality) AS \"Source Locality\",\n       exporterAddr AS \"Exporter\",\n       toString(dstLocality) AS \"Destination Locality\",\n       if(dstCity = '', 'unknown', dstCity) AS \"Destination City\",\n       round(sum(bytes) * 8 / (toUnixTimestamp($__toTime) - toUnixTimestamp($__fromTime))) AS \"Bits/s\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Source City\", \"Source Locality\", \"Exporter\", \"Destination Locality\", \"Destination City\"\nORDER BY \"Bits/s\" DESC\nLIMIT $depth",
+          "rawSql": "SELECT if(srcCity = '', 'unknown', srcCity) AS \"Source City\",\n       toString(srcLocality) AS \"Source Locality\",\n       if(exporterName != '', exporterName, exporterAddr) AS \"Exporter\",\n       toString(dstLocality) AS \"Destination Locality\",\n       if(dstCity = '', 'unknown', dstCity) AS \"Destination City\",\n       round(sum(bytes) * 8 / (toUnixTimestamp($__toTime) - toUnixTimestamp($__fromTime))) AS \"Bits/s\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Source City\", \"Source Locality\", \"Exporter\", \"Destination Locality\", \"Destination City\"\nORDER BY \"Bits/s\" DESC\nLIMIT $depth",
           "refId": "A"
         }
       ]
@@ -318,7 +318,7 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "SELECT concat(exporterAddr, ' - ', ifNull(inputSnmpIfName, concat('if', toString(inputSnmp)))) AS \"Entry\",\n       concat(exporterAddr, ' - ', ifNull(outputSnmpIfName, concat('if', toString(outputSnmp)))) AS \"Exit\",\n       concat(toString(dstAs), ': ', ifNull(dstAsOrg, 'unknown')) AS \"Destination AS\",\n       round(sum(bytes) * 8 / (toUnixTimestamp($__toTime) - toUnixTimestamp($__fromTime))) AS \"Bits/s\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Entry\", \"Exit\", \"Destination AS\"\nORDER BY \"Bits/s\" DESC\nLIMIT $depth",
+          "rawSql": "SELECT concat(if(exporterName != '', exporterName, exporterAddr), ' - ', ifNull(inputSnmpIfName, concat('if', toString(inputSnmp)))) AS \"Entry\",\n       concat(if(exporterName != '', exporterName, exporterAddr), ' - ', ifNull(outputSnmpIfName, concat('if', toString(outputSnmp)))) AS \"Exit\",\n       concat(toString(dstAs), ': ', ifNull(dstAsOrg, 'unknown')) AS \"Destination AS\",\n       round(sum(bytes) * 8 / (toUnixTimestamp($__toTime) - toUnixTimestamp($__fromTime))) AS \"Bits/s\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Entry\", \"Exit\", \"Destination AS\"\nORDER BY \"Bits/s\" DESC\nLIMIT $depth",
           "refId": "A"
         }
       ]

--- a/src/main/java/org/riptide/node/ExporterNameEnricher.java
+++ b/src/main/java/org/riptide/node/ExporterNameEnricher.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.node;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.riptide.pipeline.EnrichedFlow;
+import org.riptide.pipeline.Enricher;
+import org.riptide.pipeline.EnricherOrder;
+import org.riptide.pipeline.Source;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Stamps the matched node's name onto every flow as {@code exporterName} — the
+ * human-readable identity dashboards prefer over the raw exporter address. Flows from
+ * an exporter no node covers keep the field unset (persisted as the empty string).
+ */
+@Component
+@Order(EnricherOrder.EXPORTER_NAME)
+@RequiredArgsConstructor
+public class ExporterNameEnricher extends Enricher.Single {
+
+    @NonNull
+    private final NodeRegistry nodeRegistry;
+
+    @Override
+    protected CompletableFuture<Void> enrich(final Source source, final EnrichedFlow flow) {
+        this.nodeRegistry.lookup(source.identity())
+                .ifPresent(node -> flow.setExporterName(node.label()));
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/src/main/java/org/riptide/pipeline/EnrichedFlow.java
+++ b/src/main/java/org/riptide/pipeline/EnrichedFlow.java
@@ -81,6 +81,7 @@ public class EnrichedFlow {
     private String srcCity;
     private String dstCountry;
     private String dstCity;
+    private String exporterName;
 
     public Integer getDscp() {
         return getTos() != null ? getTos() >>> 2 : null;
@@ -113,6 +114,7 @@ public class EnrichedFlow {
         @Mapping(target = "srcCity", ignore = true)
         @Mapping(target = "dstCountry", ignore = true)
         @Mapping(target = "dstCity", ignore = true)
+        @Mapping(target = "exporterName", ignore = true)
 
         @Mapping(target = ".", source = "source")
         @Mapping(target = ".", source = "flow")

--- a/src/main/java/org/riptide/pipeline/EnricherOrder.java
+++ b/src/main/java/org/riptide/pipeline/EnricherOrder.java
@@ -14,6 +14,7 @@ package org.riptide.pipeline;
  */
 public final class EnricherOrder {
 
+    public static final int EXPORTER_NAME = 50;
     public static final int CLASSIFICATION = 100;
     public static final int CLOCK_CORRECTION = 200;
     public static final int HOSTNAMES = 300;

--- a/src/main/java/org/riptide/provisioning/ProvisioningDdl.java
+++ b/src/main/java/org/riptide/provisioning/ProvisioningDdl.java
@@ -48,9 +48,9 @@ public final class ProvisioningDdl {
         final String flows = FlowsSchema.qualifiedFlows(database);
         final List<String> statements = new ArrayList<>();
         // Additive schema upgrades first (same precondition as the GRANTs below: the table
-        // exists). Emitted on every run so re-running onboard upgrades a pre-geo table in
+        // exists). Emitted on every run so re-running onboard upgrades a pre-existing table in
         // place; IF NOT EXISTS makes them no-ops everywhere else.
-        statements.addAll(FlowsSchema.addGeoColumns(database));
+        statements.addAll(FlowsSchema.addAdditiveColumns(database));
         statements.addAll(List.of(
                 "CREATE ROLE IF NOT EXISTS flow_writer",
                 "GRANT INSERT ON " + flows + " TO flow_writer",

--- a/src/main/java/org/riptide/repository/clickhouse/ClickhouseFlow.java
+++ b/src/main/java/org/riptide/repository/clickhouse/ClickhouseFlow.java
@@ -91,4 +91,5 @@ public class ClickhouseFlow {
     private String srcCity = "";
     private String dstCountry = "";
     private String dstCity = "";
+    private String exporterName = "";
 }

--- a/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
+++ b/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
@@ -114,9 +114,9 @@ public class ClickhouseRepository implements FlowRepository {
             ensureDatabase();
             this.client.execute(FlowsSchema.createFlowsTable(this.config.getDatabase())).get();
             this.client.execute(FlowsSchema.createSamplesView(this.config.getDatabase())).get();
-            // Additive upgrades manage mode owns: a pre-geo table that IF NOT EXISTS no-oped
-            // over gains the geo columns in place (no data loss); on a fresh table these no-op.
-            for (final String ddl : FlowsSchema.addGeoColumns(this.config.getDatabase())) {
+            // Additive upgrades manage mode owns: a pre-existing table that IF NOT EXISTS no-oped
+            // over gains the additive columns in place (no data loss); on a fresh table these no-op.
+            for (final String ddl : FlowsSchema.addAdditiveColumns(this.config.getDatabase())) {
                 this.client.execute(ddl).get();
             }
         }
@@ -185,12 +185,12 @@ public class ClickhouseRepository implements FlowRepository {
                 .sorted()
                 .toList();
         if (!missing.isEmpty()) {
-            if (FlowsSchema.geoColumnNames().containsAll(missing)) {
-                // Only the additive geo columns are missing — in validate mode riptide never
+            if (FlowsSchema.additiveColumnNames().containsAll(missing)) {
+                // Only additive columns are missing — in validate mode riptide never
                 // alters the schema, but the fix is a safe, data-preserving onboard re-run.
                 throw new IllegalStateException(
                         "flows table in database '" + this.config.getDatabase()
-                                + "' is missing the geo column(s) " + missing
+                                + "' is missing the column(s) " + missing
                                 + " — re-run 'riptide onboard' to add them in place (no data loss), or set "
                                 + "riptide.clickhouse.manage-schema=true to let riptide add them.");
             }

--- a/src/main/java/org/riptide/schema/FlowsSchema.java
+++ b/src/main/java/org/riptide/schema/FlowsSchema.java
@@ -78,29 +78,34 @@ public final class FlowsSchema {
         return ident(database) + ".flows";
     }
 
-    /** The GeoIP columns and their types — the one home for both CREATE and ALTER emission. */
-    private static final Map<String, String> GEO_COLUMNS = new LinkedHashMap<>();
+    /**
+     * Columns added after the 0.4.x schema, upgradeable in place — the one home for both
+     * CREATE and ALTER emission. Order matters: it is the trailing column order of
+     * {@link #createFlowsTable}, so a fresh and an upgraded table end up identical.
+     */
+    private static final Map<String, String> ADDITIVE_COLUMNS = new LinkedHashMap<>();
 
     static {
-        GEO_COLUMNS.put("srcCountry", "LowCardinality(String)");
-        GEO_COLUMNS.put("srcCity", "LowCardinality(String)");
-        GEO_COLUMNS.put("dstCountry", "LowCardinality(String)");
-        GEO_COLUMNS.put("dstCity", "LowCardinality(String)");
+        ADDITIVE_COLUMNS.put("srcCountry", "LowCardinality(String)");
+        ADDITIVE_COLUMNS.put("srcCity", "LowCardinality(String)");
+        ADDITIVE_COLUMNS.put("dstCountry", "LowCardinality(String)");
+        ADDITIVE_COLUMNS.put("dstCity", "LowCardinality(String)");
+        ADDITIVE_COLUMNS.put("exporterName", "LowCardinality(String)");
     }
 
-    /** The GeoIP column names, for callers distinguishing additive-upgradeable columns. */
-    public static Set<String> geoColumnNames() {
-        return Collections.unmodifiableSet(GEO_COLUMNS.keySet());
+    /** The additive column names, for callers distinguishing in-place-upgradeable columns. */
+    public static Set<String> additiveColumnNames() {
+        return Collections.unmodifiableSet(ADDITIVE_COLUMNS.keySet());
     }
 
     /**
-     * Idempotent additive upgrade: {@code ALTER TABLE … ADD COLUMN IF NOT EXISTS} for each geo
-     * column. Safe on any table — a fresh one (columns exist, no-op) or a pre-geo one (columns
-     * appended in definition order, matching {@link #createFlowsTable}'s trailing placement).
+     * Idempotent additive upgrade: {@code ALTER TABLE … ADD COLUMN IF NOT EXISTS} for each
+     * additive column. Safe on any table — a fresh one (columns exist, no-op) or a pre-upgrade
+     * one (columns appended in definition order, matching {@link #createFlowsTable}).
      */
-    public static List<String> addGeoColumns(final String database) {
+    public static List<String> addAdditiveColumns(final String database) {
         final String flows = qualifiedFlows(database);
-        return GEO_COLUMNS.entrySet().stream()
+        return ADDITIVE_COLUMNS.entrySet().stream()
                 .map(column -> "ALTER TABLE " + flows + " ADD COLUMN IF NOT EXISTS "
                         + column.getKey() + " " + column.getValue())
                 .toList();
@@ -214,12 +219,13 @@ public final class FlowsSchema {
 
             clockCorrection Nullable(Int64),
 
-            -- GeoIP enrichment; '' = unknown. Kept last so a pre-geo table upgraded via
-            -- addGeoColumns() has the same column order as a freshly created one.
+            -- Additive columns (0.5.x); '' = unknown. Kept last so a pre-existing table
+            -- upgraded via addAdditiveColumns() has the same column order as a fresh one.
             srcCountry LowCardinality(String),
             srcCity LowCardinality(String),
             dstCountry LowCardinality(String),
-            dstCity LowCardinality(String)
+            dstCity LowCardinality(String),
+            exporterName LowCardinality(String)
         ) ENGINE = MergeTree()
         ORDER BY (
             tenant, organisation,

--- a/src/test/java/org/riptide/node/ExporterNameEnricherTest.java
+++ b/src/test/java/org/riptide/node/ExporterNameEnricherTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.node;
+
+import inet.ipaddr.IPAddressString;
+import org.junit.jupiter.api.Test;
+import org.riptide.pipeline.EnrichedFlow;
+import org.riptide.pipeline.ExporterIdentity;
+import org.riptide.pipeline.Source;
+
+import java.net.InetAddress;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExporterNameEnricherTest {
+
+    private static NodeRegistry registry() {
+        final NodeDefinition node = new NodeDefinition();
+        node.setSubnetAddress(new IPAddressString("192.168.10.1/32"));
+        final NodeRegistry registry = new NodeRegistry();
+        registry.setNodes(Map.of("bbone-fw01", node));
+        registry.validate();
+        return registry;
+    }
+
+    @Test
+    void matchedNodeNameIsStamped() throws Exception {
+        final var flow = EnrichedFlow.builder().build();
+        final var source = new Source("default",
+                new ExporterIdentity.NetflowIpfix(InetAddress.getByName("192.168.10.1"), 0));
+
+        new ExporterNameEnricher(registry()).enrich(source, List.of(flow)).get();
+
+        assertThat(flow.getExporterName()).isEqualTo("bbone-fw01");
+    }
+
+    @Test
+    void unmatchedExporterStaysUnnamed() throws Exception {
+        final var flow = EnrichedFlow.builder().build();
+        final var source = new Source("default",
+                new ExporterIdentity.NetflowIpfix(InetAddress.getByName("203.0.113.99"), 0));
+
+        new ExporterNameEnricher(registry()).enrich(source, List.of(flow)).get();
+
+        assertThat(flow.getExporterName()).isNull(); // persisted as '' via the ClickhouseFlow initializer
+    }
+}

--- a/src/test/java/org/riptide/pipeline/EnricherOrderTest.java
+++ b/src/test/java/org/riptide/pipeline/EnricherOrderTest.java
@@ -10,6 +10,7 @@ import org.riptide.classification.ClassificationEnricher;
 import org.riptide.clock.ClockCorrectionEnricher;
 import org.riptide.geoip.GeoIpEnricher;
 import org.riptide.locality.LocalityEnricher;
+import org.riptide.node.ExporterNameEnricher;
 import org.riptide.routing.RoutingEnricher;
 import org.riptide.snmp.SnmpEnricher;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,6 +37,7 @@ public class EnricherOrderTest {
         // HostnamesEnricher is disabled by default (riptide.enricher.hostnames.enabled=false);
         // its slot between ClockCorrection and Locality is pinned by EnricherOrder.HOSTNAMES.
         assertThat(enrichers).extracting(enricher -> (Class) enricher.getClass()).containsExactly(
+                ExporterNameEnricher.class,
                 ClassificationEnricher.class,
                 ClockCorrectionEnricher.class,
                 LocalityEnricher.class,

--- a/src/test/java/org/riptide/provisioning/ProvisioningDdlTest.java
+++ b/src/test/java/org/riptide/provisioning/ProvisioningDdlTest.java
@@ -52,21 +52,23 @@ class ProvisioningDdlTest {
     }
 
     @Test
-    void ensureSharedUpgradesGeoColumnsFirst() {
-        // Additive geo-column upgrades are emitted on every run (before the grants, same
-        // table-exists precondition) so re-running onboard upgrades a pre-geo table in place.
+    void ensureSharedUpgradesAdditiveColumnsFirst() {
+        // Additive column upgrades are emitted on every run (before the grants, same
+        // table-exists precondition) so re-running onboard upgrades a pre-existing table in place.
         final List<String> sql = ProvisioningDdl.ensureShared("riptide", 50_000_000_000L);
         assertThat(sql.get(0)).isEqualTo(
                 "ALTER TABLE `riptide`.flows ADD COLUMN IF NOT EXISTS srcCountry LowCardinality(String)");
-        assertThat(sql.subList(0, 4)).allMatch(s -> s.contains("ADD COLUMN IF NOT EXISTS"));
-        assertThat(sql).filteredOn(s -> s.contains("ADD COLUMN")).hasSize(4);
+        assertThat(sql.subList(0, 5)).allMatch(s -> s.contains("ADD COLUMN IF NOT EXISTS"));
+        assertThat(sql).filteredOn(s -> s.contains("ADD COLUMN")).hasSize(5);
+        assertThat(sql.get(4)).contains("exporterName LowCardinality(String)");
     }
 
     @Test
-    void bootstrapSchemaIncludesGeoColumns() {
+    void bootstrapSchemaIncludesAdditiveColumns() {
         assertThat(ProvisioningDdl.bootstrapSchema("riptide", 30).get(1))
                 .contains("srcCountry LowCardinality(String)")
-                .contains("dstCity LowCardinality(String)");
+                .contains("dstCity LowCardinality(String)")
+                .contains("exporterName LowCardinality(String)");
     }
 
     @Test

--- a/src/test/java/org/riptide/repository/clickhouse/ClickhouseRepositoryIT.java
+++ b/src/test/java/org/riptide/repository/clickhouse/ClickhouseRepositoryIT.java
@@ -208,7 +208,7 @@ public class ClickhouseRepositoryIT {
 
         // Simulate a pre-geo table: keep a persisted row, then drop the geo columns.
         repo.persist(List.of(testFlow(Instant.now().truncatedTo(ChronoUnit.MILLIS), 60001, 443, 100L)));
-        for (final String column : List.of("srcCountry", "srcCity", "dstCountry", "dstCity")) {
+        for (final String column : List.of("srcCountry", "srcCity", "dstCountry", "dstCity", "exporterName")) {
             queryClient.execute("ALTER TABLE " + database + ".flows DROP COLUMN " + column).get();
         }
 
@@ -216,7 +216,7 @@ public class ClickhouseRepositoryIT {
         final var validating = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), configFor(database, false), RESOLVERS);
         Assertions.assertThatThrownBy(validating::start)
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("geo column")
+                .hasMessageContaining("exporterName")
                 .hasMessageContaining("riptide onboard");
 
         // Manage mode adds the columns back in place; the pre-geo row survives and reads ''.


### PR DESCRIPTION
## What

Answers "show the exporter name if available, fall back to the IP" — which needed a new column, since node names (`riptide.nodes.<name>` keys) never reached ClickHouse:

- **`ExporterNameEnricher`** (first in the chain, `@Order(50)`): stamps the node registry's matched label onto each flow as `exporterName`; unmatched exporters persist `''`. Same `NodeRegistry.lookup(source.identity())` path the SNMP enricher uses — no new lookup machinery.
- **Schema**: `exporterName LowCardinality(String)` joins the additive-column mechanism, which generalizes from `addGeoColumns()` to `addAdditiveColumns()` (the geo review's altitude finding predicted this second consumer). Manage mode heals pre-existing tables at startup, onboard emits the ALTERs every run, validate mode names the missing columns and points at onboard — all unchanged in behavior, now covering five columns.
- **Dashboard** (`riptide-traffic-paths.json`): the exporter dimension and ingress/egress labels render `if(exporterName != '', exporterName, exporterAddr)`, and the Exporter filter variable shows names while filtering by address (`__text`/`__value`).

## Verification

- `make jar`: **720 tests, BUILD SUCCESS** (new enricher tests, updated chain-order/DDL tests; ClickHouse IT extended to drop/heal/round-trip the new column).
- All five dashboard panels plus the filter-variable query executed against a schema-identical scratch database on production ClickHouse with one named and one unnamed fixture exporter: named rows render `bbone-fw01`, unnamed fall back to the IP, in every panel.
- Existing deployments: rows persisted before this release read `''` and therefore display as IPs — exactly the requested fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
