### PR TITLE
ci(build): rebuild PRs on every push, not just on open

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,11 @@ run-name: Build and Test the application
 on:
   workflow_dispatch:
   push:
-    tags-ignore:
+    branches: [ 'main' ]  # post-merge run on main; tags are the release workflow's
   pull_request:
-    branches: [ 'main' ]  # Builds PRs targeting main
-    types: [ opened, reopened ]  # Default: covers new pushes to PR
+    branches: [ 'main' ]  # every PR targeting main, on open and on each new push
+    # No `types:` filter — naming one replaces the default set, and dropping
+    # `synchronize` from it means pushes to an open PR never rebuild.
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Drops the `types:` filter so the default `opened, synchronize, reopened` set applies again, and scopes `push:` to `main` (replacing the empty `tags-ignore:`, which `actionlint` rejects as a syntax error).

Effect: pushes to an open PR — including fork PRs — rebuild, and a branch plus its PR no longer run the same build twice.

Closes #295