### PR TITLE
ci(release): keep prereleases off :latest and pin the tag to the pom

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,22 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - 'v*'
+      - 'v*.*.*'
+
+permissions:
+  contents: read
+
+# A half-published release is worse than a late one — never cancel in flight.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # upload release assets
+      packages: write  # push the container image to GHCR
       id-token: write  # keyless cosign signing via the workflow's OIDC identity
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -29,13 +39,29 @@ jobs:
           if [[ "${POM_VERSION}" == *"SNAPSHOT"* ]]; then
             echo "Error: Your pom has a SNAPSHOT release. Set the pom to a version number without SNAPSHOT."
             exit 1
-          else
-            echo "VERSION=${POM_VERSION}" >> ${GITHUB_ENV}
           fi
-      - name: Set data and short git hash
+          if [[ "${GITHUB_REF_NAME}" != "v${POM_VERSION}" ]]; then
+            echo "Error: tag ${GITHUB_REF_NAME} does not match pom version ${POM_VERSION}."
+            echo "The image and the binaries would self-report a version nobody can find."
+            exit 1
+          fi
+          echo "VERSION=${POM_VERSION}" >> ${GITHUB_ENV}
+      - name: Resolve image tags
+        run: |
+          # A prerelease (v1.2.0-rc1) gets its exact version tag and nothing
+          # else: :latest and the floating :X.Y must keep pointing at the newest
+          # *stable* release.
+          if [[ "${GITHUB_REF_NAME}" == *-* ]]; then
+            echo "PRERELEASE=true" >> ${GITHUB_ENV}
+            echo "IMAGE_TAGS=ghcr.io/riptide-labs/riptide:${VERSION}" >> ${GITHUB_ENV}
+          else
+            echo "PRERELEASE=false" >> ${GITHUB_ENV}
+            echo "IMAGE_TAGS=ghcr.io/riptide-labs/riptide:${VERSION},ghcr.io/riptide-labs/riptide:${VERSION%.*},ghcr.io/riptide-labs/riptide:latest" >> ${GITHUB_ENV}
+          fi
+      - name: Set date and short git hash
         run: |
           echo "SHORT_GIT_SHA=$(git rev-parse --short HEAD)" >> ${GITHUB_ENV}
-          echo "BUILD_DATE"=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          echo "BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> ${GITHUB_ENV}
       - name: Build with tests
         run: |
           make
@@ -53,7 +79,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - name: Set up Docker Buildx
@@ -69,9 +95,7 @@ jobs:
             DATE=${{ env.BUILD_DATE }}
             GIT_SHORT_HASH=${{ env.SHORT_GIT_SHA }}
             VERSION=${{ env.VERSION }}
-          tags: |
-            ghcr.io/riptide-labs/riptide:${{ env.VERSION }}
-            ghcr.io/riptide-labs/riptide:latest
+          tags: ${{ env.IMAGE_TAGS }}
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: Sign container image
@@ -88,6 +112,7 @@ jobs:
       - name: Release ${{ github.ref_name }}
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
+          prerelease: ${{ env.PRERELEASE == 'true' }}
           files: |
             target/*.jar
             target/*.deb


### PR DESCRIPTION
Six corrections to the tag-triggered release:

- `v*` → `v*.*.*`; prereleases are marked as such and get their exact version tag only, leaving `:latest` and the new floating `:X.Y` on the newest stable release.
- Fail the build when the tag disagrees with the pom version.
- Fix the missing `>> $GITHUB_ENV` redirect that left `BUILD_DATE` — and every released image's `DATE` build-arg — empty.
- Push to GHCR with `GITHUB_TOKEN` + `packages: write` instead of `GHCR_PAT`.
- Top-level `permissions: contents: read`, plus a non-cancelling concurrency group.

Release stays published-on-tag (not draft), as today.

Closes #296