### PR TITLE
ci: enforce the Actions rules with actionlint and zizmor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,6 @@
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 name: Riptide Build
 run-name: Build and Test the application
 on:
@@ -8,11 +11,23 @@ on:
     branches: [ 'main' ]  # every PR targeting main, on open and on each new push
     # No `types:` filter — naming one replaces the default set, and dropping
     # `synchronize` from it means pushes to an open PR never rebuild.
+
+permissions:
+  contents: read
+
+# Superseded pushes to the same PR are wasted runner minutes.
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Set up JDK 25 for x64
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
@@ -20,11 +35,13 @@ jobs:
           distribution: 'temurin'
           architecture: x64
           cache: maven
-      - name: Set version number, data and short git hash
+      - name: Set version number, date and short git hash
         run: |
-          echo "VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> ${GITHUB_ENV}
-          echo "SHORT_GIT_SHA=$(git rev-parse --short HEAD)" >> ${GITHUB_ENV}
-          echo "BUILD_DATE"=$(date -u +"%Y-%m-%dT%H:%M:%SZ") >> ${GITHUB_ENV}
+          {
+            echo "VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
+            echo "SHORT_GIT_SHA=$(git rev-parse --short HEAD)"
+            echo "BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          } >> "${GITHUB_ENV}"
       - name: Build with tests
         run: |
           make
@@ -36,9 +53,12 @@ jobs:
           path: |
             target/*.jar
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Set up JDK 25 for x64
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,14 +17,21 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
     permissions:
       contents: read
       security-events: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Set up JDK 25 for x64
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,13 +26,15 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # tags needed so the docs build can resolve the latest release version
           fetch-tags: true
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -72,7 +74,8 @@ jobs:
   deploy:
     if: github.event_name != 'pull_request'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -1,0 +1,53 @@
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Enforces the workflow rules mechanically rather than by memory: actionlint
+# for syntax and shell bugs (it is what caught the empty `tags-ignore:` and the
+# `synchronize`-dropping `types:` filter), zizmor for the security posture
+# (unpinned actions, over-broad permissions, credential persistence, template
+# injection).
+name: Lint Actions
+run-name: Lint the GitHub Actions workflows
+on:
+  workflow_dispatch:
+  push:
+    branches: [ 'main' ]
+    paths: [ '.github/workflows/**', 'Makefile' ]
+  pull_request:
+    branches: [ 'main' ]
+    paths: [ '.github/workflows/**', 'Makefile' ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-actions-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Install actionlint
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+          # sha256 of actionlint_1.7.12_linux_amd64.tar.gz from the release checksums
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -fsSL "${url}" -o actionlint.tar.gz
+          echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum --check
+          tar -xzf actionlint.tar.gz actionlint
+          sudo install -m 0755 actionlint /usr/local/bin/actionlint
+      - name: Install zizmor
+        env:
+          ZIZMOR_VERSION: 1.27.0
+        run: |
+          pipx install "zizmor==${ZIZMOR_VERSION}"
+      - name: Lint workflows
+        run: |
+          make lint-actions

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -17,11 +17,22 @@ on:
       - 'nix/**'
       - 'pom.xml'
       - '.github/workflows/nix.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nix-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   nix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@786fff0690178f1234e4e1fe9b536e94f5433196 # v20
       - name: Build the package

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -15,11 +15,22 @@ on:
       - 'deployment/package/**'
       - 'Makefile'
       - '.github/workflows/packages.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: packages-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   packages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Set up JDK 25 for x64
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -13,13 +13,21 @@ permissions:
   contents: read
   packages: write
 
+# Only the newest main commit needs to be :rc — cancel the ones it overtook.
+concurrency:
+  group: publish-rc
+  cancel-in-progress: true
+
 jobs:
   publish:
     # :rc always reflects main — also guards manual dispatches from other refs
     if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Set up JDK 25 for x64
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
@@ -29,9 +37,11 @@ jobs:
           cache: maven
       - name: Set version, date and short git hash
         run: |
-          echo "VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> ${GITHUB_ENV}
-          echo "SHORT_GIT_SHA=$(git rev-parse --short HEAD)" >> ${GITHUB_ENV}
-          echo "BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> ${GITHUB_ENV}
+          {
+            echo "VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
+            echo "SHORT_GIT_SHA=$(git rev-parse --short HEAD)"
+            echo "BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          } >> "${GITHUB_ENV}"
       - name: Build with tests
         run: |
           make

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,16 @@ concurrency:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
     permissions:
       contents: write  # upload release assets
       packages: write  # push the container image to GHCR
       id-token: write  # keyless cosign signing via the workflow's OIDC identity
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Set up JDK 25 for x64
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
@@ -45,23 +48,30 @@ jobs:
             echo "The image and the binaries would self-report a version nobody can find."
             exit 1
           fi
-          echo "VERSION=${POM_VERSION}" >> ${GITHUB_ENV}
+          echo "VERSION=${POM_VERSION}" >> "${GITHUB_ENV}"
       - name: Resolve image tags
         run: |
           # A prerelease (v1.2.0-rc1) gets its exact version tag and nothing
           # else: :latest and the floating :X.Y must keep pointing at the newest
           # *stable* release.
+          image="ghcr.io/riptide-labs/riptide"
           if [[ "${GITHUB_REF_NAME}" == *-* ]]; then
-            echo "PRERELEASE=true" >> ${GITHUB_ENV}
-            echo "IMAGE_TAGS=ghcr.io/riptide-labs/riptide:${VERSION}" >> ${GITHUB_ENV}
+            {
+              echo "PRERELEASE=true"
+              echo "IMAGE_TAGS=${image}:${VERSION}"
+            } >> "${GITHUB_ENV}"
           else
-            echo "PRERELEASE=false" >> ${GITHUB_ENV}
-            echo "IMAGE_TAGS=ghcr.io/riptide-labs/riptide:${VERSION},ghcr.io/riptide-labs/riptide:${VERSION%.*},ghcr.io/riptide-labs/riptide:latest" >> ${GITHUB_ENV}
+            {
+              echo "PRERELEASE=false"
+              echo "IMAGE_TAGS=${image}:${VERSION},${image}:${VERSION%.*},${image}:latest"
+            } >> "${GITHUB_ENV}"
           fi
       - name: Set date and short git hash
         run: |
-          echo "SHORT_GIT_SHA=$(git rev-parse --short HEAD)" >> ${GITHUB_ENV}
-          echo "BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> ${GITHUB_ENV}
+          {
+            echo "SHORT_GIT_SHA=$(git rev-parse --short HEAD)"
+            echo "BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          } >> "${GITHUB_ENV}"
       - name: Build with tests
         run: |
           make
@@ -99,9 +109,11 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: Sign container image
+        env:
+          IMAGE_DIGEST: ${{ steps.build-image.outputs.digest }}
         run: |
           # Sign the digest, not a tag: covers every tag pointing at this image.
-          cosign sign --yes "ghcr.io/riptide-labs/riptide@${{ steps.build-image.outputs.digest }}"
+          cosign sign --yes "ghcr.io/riptide-labs/riptide@${IMAGE_DIGEST}"
       - name: Sign release artifacts
         run: |
           # cosign 3.x writes the sigstore bundle (sig + cert + Rekor proof in one file);

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,29 @@
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Deliberate exceptions to the zizmor audits. Anything not listed here is a
+# finding the workflows are expected to be free of — see `make lint-actions`.
+rules:
+  cache-poisoning:
+    ignore:
+      # The three publishing workflows restore a dependency cache (maven for the
+      # release and rc images, npm for the docs site) before producing something
+      # that leaves the runner. zizmor rates that High on the assumption that an
+      # attacker can seed the cache; GitHub's cache scoping is what makes that
+      # not hold here — a pull-request run writes only to its own branch scope
+      # and cannot write to the default branch's, which is the only scope these
+      # three restore from. Poisoning the cache therefore already requires push
+      # access to main, at which point the cache is not the weak link.
+      #
+      # Revisit if GitHub changes cache scoping, or if any of these workflows
+      # starts running on `pull_request_target`.
+      - release.yml
+      - publish-rc.yml
+      - docs.yml
+  superfluous-actions:
+    ignore:
+      # `gh release create` would replace softprops/action-gh-release here, but
+      # the action handles the artifact globs and the prerelease flag in one
+      # declarative block. Pinned by SHA and Dependabot-tracked; not worth the
+      # hand-rolled shell.
+      - release.yml

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ help:
 	@echo "  nix-check:    Run the flake checks incl. the NixOS module eval (requires Nix)"
 	@echo "  coverage:     Run the unit test suite and render the JaCoCo coverage report"
 	@echo "  e2e:          Run integration and e2e tests (*IT, requires Docker) in addition to the unit suite"
+	@echo "  lint-actions: Lint the GitHub Actions workflows (actionlint + zizmor)"
 	@echo "  docs:         Build the Docusaurus documentation site into docs/build"
 	@echo "  docs-serve:   Run the documentation site locally with live reload"
 	@echo "  clean:        Clean the build artifacts"
@@ -83,6 +84,16 @@ coverage: deps-jar
 e2e: deps-jar deps-oci
 	mvn $(BUILD_OPTS) --batch-mode --update-snapshots verify -Pe2e
 	@echo "Coverage report (incl. e2e): target/site/jacoco/index.html"
+
+.PHONY: deps-lint-actions
+deps-lint-actions:
+	command -v actionlint
+	command -v zizmor
+
+.PHONY: lint-actions
+lint-actions: deps-lint-actions
+	actionlint
+	zizmor --persona=regular .github/workflows
 
 .PHONY: deps-docs
 deps-docs:


### PR DESCRIPTION
Adds `make lint-actions` (actionlint + zizmor) as a CI gate, and fixes everything it reported.

**Enforced now, not remembered:** actionlint is what flags the empty `tags-ignore:` and would have flagged the `synchronize`-dropping `types:` filter — the two bugs fixed in #297/#298 that had been live for months.

Changes across all 8 workflows: `timeout-minutes` on all 9 jobs, `ubuntu-24.04` instead of `ubuntu-latest`, concurrency groups, `permissions: contents: read` defaults, `persist-credentials: false` on every checkout, image digest routed through `env:`, `$GITHUB_ENV` writes grouped and quoted, SPDX header on `build.yml`.

**Two deliberate suppressions**, reasoned in `.github/zizmor.yml`:
- `cache-poisoning` (High) on release/rc/docs — zizmor assumes an attacker can seed the cache these restore, but GitHub scopes cache writes per branch: a PR run cannot write the default branch's scope, which is the only one these restore from. Poisoning already requires push access to main. Flagging it here so you can disagree — the alternative is dropping `cache: maven`, which costs a couple of minutes on every rc build.
- `superfluous-actions` on the release step — keeping `softprops/action-gh-release` over hand-rolled `gh release create`.

Two pin comments I checked and left alone: `codeql-bundle-v2.26.0` is the exact release tag for that SHA, and `nix-installer-action` only tags majors upstream (`v20`, `v22`) — neither is fixable to a `vX.Y.Z` comment.

Verification (local, both exit 0):

```
$ actionlint; echo $?            → 0
$ zizmor --persona=regular …     → No findings to report. (4 ignored, 14 suppressed)
$ make lint-actions; echo $?     → 0
$ grep -rn 'ubuntu-latest' .github/workflows/   → clean
$ grep -rn 'uses:' … | grep -vE '@[0-9a-f]{40}' → clean
```

Closes #300