### PR TITLE
ci(release): add SBOM, build provenance, dependency review and a security policy

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,35 @@
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Blocks a PR that would introduce a dependency with a known high-severity
+# vulnerability. Dependabot's alerts find these too, but only once the
+# dependency is already on main.
+name: Dependency Review
+run-name: Review dependency changes in this PR
+on:
+  pull_request:
+    branches: [ 'main' ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-review-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write  # post the summary comment when the review fails
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     permissions:
-      contents: write  # upload release assets
-      packages: write  # push the container image to GHCR
-      id-token: write  # keyless cosign signing via the workflow's OIDC identity
+      contents: write      # upload release assets
+      packages: write      # push the container image to GHCR
+      id-token: write      # keyless cosign signing via the workflow's OIDC identity
+      attestations: write  # SLSA build provenance for the artifacts and the image
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -84,6 +85,15 @@ jobs:
           name: riptide-jar
           path: |
             target/*.jar
+      # SPDX over the source tree, so the SBOM describes what went into the
+      # build rather than what syft can infer from the finished jar.
+      - name: Generate SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          format: spdx-json
+          artifact-name: riptide-${{ env.VERSION }}.spdx.json
+          output-file: target/riptide-${{ env.VERSION }}.spdx.json
       - name: Login to Registry
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
@@ -118,9 +128,22 @@ jobs:
         run: |
           # cosign 3.x writes the sigstore bundle (sig + cert + Rekor proof in one file);
           # the legacy --output-signature/--output-certificate pair no longer works alone.
-          for artifact in target/*.jar target/*.deb target/*.rpm; do
+          for artifact in target/*.jar target/*.deb target/*.rpm target/*.spdx.json; do
             cosign sign-blob --yes --bundle "${artifact}.sigstore.json" "${artifact}"
           done
+      # Provenance answers a different question than the cosign signature does:
+      # not "did this come from us" but "which workflow, commit and inputs
+      # produced it". Verify with `gh attestation verify`.
+      - name: Attest build provenance for the release artifacts
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: 'target/*.jar, target/*.deb, target/*.rpm'
+      - name: Attest build provenance for the container image
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ghcr.io/riptide-labs/riptide
+          subject-digest: ${{ steps.build-image.outputs.digest }}
+          push-to-registry: true
       - name: Release ${{ github.ref_name }}
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
@@ -129,4 +152,5 @@ jobs:
             target/*.jar
             target/*.deb
             target/*.rpm
+            target/*.spdx.json
             target/*.sigstore.json

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,47 @@
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# OpenSSF Scorecard grades this repository against supply-chain best practice —
+# an external auditor for much of what the workflows here already enforce.
+# Results land in the Security tab as code scanning alerts.
+name: Scorecard
+run-name: OpenSSF Scorecard supply-chain analysis
+on:
+  workflow_dispatch:
+  branch_protection_rule:
+  push:
+    branches: [ 'main' ]
+  schedule:
+    - cron: '17 4 * * 1' # weekly, Monday morning
+
+permissions:
+  contents: read
+
+concurrency:
+  group: scorecard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analysis:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write  # upload the SARIF results
+      id-token: write         # publish the signed results to the public API
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publishes the score so the README badge and deps.dev can read it.
+          # Public repositories only.
+          publish_results: true
+      - name: Upload results to the Security tab
+        uses: github/codeql-action/upload-sarif@f58f0d11ebf5dedd870fab2f999275f7602cfa46 # codeql-bundle-v2.26.0
+        with:
+          sarif_file: results.sarif

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,61 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security problem.**
+
+Report it through GitHub's private vulnerability reporting:
+[**Report a vulnerability**](https://github.com/Riptide-Labs/riptide/security/advisories/new).
+Only the maintainers see the report until an advisory is published.
+
+Useful things to include, as far as you have them: the affected version
+(`riptide --version` or the image tag), what an attacker gains, and the
+smallest reproduction you can manage — a pcap that triggers the problem is
+ideal for anything in the flow-parsing path.
+
+You can expect an acknowledgement within a few days. Riptide is maintained by a
+small team, so please allow reasonable time for a fix before disclosing
+publicly; we will keep you updated and credit you in the advisory unless you
+prefer otherwise.
+
+## Supported versions
+
+Fixes go onto `main` and ship in the next release. Only the latest release is
+supported — there are no maintenance branches for older versions.
+
+## Verifying what you run
+
+Every release is signed with [cosign](https://docs.sigstore.dev/) keyless
+signing and carries SLSA build provenance, so you can check that a binary or
+image really came from this repository's release workflow rather than from
+someone else:
+
+```bash
+# container image
+cosign verify ghcr.io/riptide-labs/riptide:<version> \
+  --certificate-identity-regexp '^https://github.com/Riptide-Labs/riptide/\.github/workflows/release\.yml@refs/tags/v.*$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+# a downloaded artifact, against its .sigstore.json bundle from the release
+cosign verify-blob riptide-flows-<version>.jar \
+  --bundle riptide-flows-<version>.jar.sigstore.json \
+  --certificate-identity-regexp '^https://github.com/Riptide-Labs/riptide/\.github/workflows/release\.yml@refs/tags/v.*$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+# build provenance — which workflow, commit and inputs produced it
+gh attestation verify riptide-flows-<version>.jar --repo Riptide-Labs/riptide
+```
+
+What is available depends on the release:
+
+| Release | Image signature | Artifact bundles | SBOM | Provenance |
+|---|---|---|---|---|
+| 0.4.9 – 0.4.11 | ❌ deleted ([#294](https://github.com/Riptide-Labs/riptide/issues/294)) | — | — | — |
+| 0.5.0 | ✅ | — | — | — |
+| next release onwards | ✅ | ✅ | ✅ | ✅ |
+
+The 0.4.9–0.4.11 images themselves are unchanged; a cleanup step on `main`
+deleted their signature objects, so they can no longer be verified. Prefer
+0.5.0 or later if signature verification matters to you.
+
+And the obvious caveat: a signature proves origin, not the absence of bugs.


### PR DESCRIPTION
**Stacked on #301** — based on `ci/actions-hygiene` because both touch `release.yml`. GitHub retargets this to `main` once #301 merges.

- **SBOM**: syft/SPDX-JSON over the source tree (what went *into* the build, not what syft can infer from a finished jar), signed alongside the other artifacts and attached to the release.
- **Provenance**: `actions/attest-build-provenance` for jar/deb/rpm and for the image digest, pushed to the registry. Answers a different question than the cosign signature — not "did this come from us" but "which workflow, commit and inputs produced it".
- **dependency-review** on PRs, `fail-on-severity: high`.
- **Scorecard** weekly + on push to main, SARIF into the Security tab.
- **SECURITY.md** with private vulnerability reporting as the entry point.

Two things I checked rather than assumed:

1. The cosign identity regexp in SECURITY.md is verified against the real published image:
   ```
   $ cosign verify ghcr.io/riptide-labs/riptide:0.5.0 \
       --certificate-identity-regexp '^https://github.com/Riptide-Labs/riptide/\.github/workflows/release\.yml@refs/tags/v.*$' … → OK
   ```
2. v0.5.0 has **no** `.sigstore.json` assets — its release run failed after the image push, and blob signing landed in #289 afterwards. So SECURITY.md uses `<version>` placeholders and a table stating exactly which release carries what, rather than implying 0.5.0 has bundles it doesn't.

`make lint-actions` passes on all 10 workflows.

**Not included — needs your approval, since these are repo settings rather than code:** secret scanning, push protection, and private vulnerability reporting are all still disabled. SECURITY.md points reporters at PVR, so that one should be enabled before this merges.

Closes #302