### PR TITLE
docs: add release, support and community documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,52 @@
+name: Bug report
+description: Something in Riptide behaves differently than it should
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Found a **security** problem? Please don't file it here — see
+        [SECURITY.md](https://github.com/Riptide-Labs/riptide/blob/main/SECURITY.md)
+        for private reporting.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What you saw, and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How can we reproduce it?
+      description: |
+        Steps, configuration, and — for anything touching flow parsing or
+        enrichment — a pcap. A pcap is by far the fastest path to a fix.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Riptide version
+      description: The container image tag, package version, or `riptide --version`.
+      placeholder: "0.5.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: How are you running it?
+      options:
+        - Container image
+        - DEB/RPM package
+        - Jar directly
+        - Nix
+        - From source
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Paste the log lines around the problem. This is rendered as code, no backticks needed.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question or help with a setup
+    url: https://matrix.to/#/#riptide:gitter.im
+    about: Chat with us on Matrix — usually faster than an issue for "how do I ...".
+  - name: Documentation
+    url: https://riptide.space/docs/
+    about: Configuration, deployment and development guides.
+  - name: Report a security vulnerability
+    url: https://github.com/Riptide-Labs/riptide/security/advisories/new
+    about: Private disclosure. Please do not use a public issue.

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,22 @@
+name: Enhancement
+description: Suggest a change or a new capability
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: |
+        Describe the situation you are in, not the solution you have in mind —
+        that usually surfaces a simpler answer than either of us started with.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like to see?
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What have you tried or considered?
+      description: Workarounds you are using today, or approaches you rejected and why.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+<!--
+Thanks for the pull request! A couple of things that make review quick:
+ - one focused change per PR
+ - commits are Conventional Commits, signed off with `git commit -s`
+ - AI-assisted? add an `Assisted-by: <Agent>:<model>` trailer (see CONTRIBUTING.md)
+-->
+
+## What does this change?
+
+<!-- What behaviour is different afterwards, and why. -->
+
+Closes #
+
+## How was it verified?
+
+<!--
+The command you ran and what it showed — `make`, `make e2e`, a pcap replay, a
+screenshot of a dashboard. "CI is green" is fine when CI genuinely covers it.
+-->
+
+## Anything reviewers should look at closely?
+
+<!-- Trade-offs you made, things you were unsure about, follow-ups you left out. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,130 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**ronny@no42.org**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org
+[Mozilla CoC]: https://github.com/mozilla/diversity

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,4 +14,38 @@ In short:
 - [Pull requests](https://riptide.space/docs/develop/pull-requests) — CI quality gates,
   **DCO sign-off (`git commit -s`)**, Conventional Commits
 
+## Working from an issue
+
+Open an issue before the pull request — a [bug report](https://github.com/Riptide-Labs/riptide/issues/new?template=bug.yml)
+or an [enhancement](https://github.com/Riptide-Labs/riptide/issues/new?template=enhancement.yml).
+It gives the change somewhere to be discussed before you have written it, and
+lets the PR close it with `Closes #123`.
+
+## Sign-off and AI assistance
+
+Every commit needs a `Signed-off-by` trailer from a human identity, created with
+`git commit -s`. It certifies the [Developer Certificate of Origin](https://developercertificate.org/):
+you have the right to submit the code under this project's licence.
+
+If an AI coding assistant helped write the change, add an `Assisted-by` trailer
+naming the agent and model:
+
+```
+feat(flows): decode IPFIX option templates
+
+Assisted-by: ClaudeCode:claude-opus-4-8
+Signed-off-by: Jane Doe <jane@example.org>
+```
+
+The trailer is a statement of provenance, not a disclaimer. **The human who
+signs off remains responsible for the change** — for reviewing it as if they had
+written it by hand, and for its licence compliance. An `Assisted-by` trailer
+never appears without a `Signed-off-by` next to it, and the sign-off is never an
+AI's name.
+
+## Security problems
+
+Please don't open a public issue for a vulnerability — see [SECURITY.md](SECURITY.md)
+for private reporting.
+
 Riptide is licensed [GPL-3.0-or-later](LICENSE).

--- a/README.md
+++ b/README.md
@@ -113,26 +113,15 @@ You can also bind mount your configuration to `/app/application.properties`.
 
 # 📦 Make a release
 
-Here is an example if you want to release a new version 1.0.0.
-> [!NOTE]
-> The `main` branch is protected and requires a pull request to merge changes. Create a branch named `release` to make release related changes.
-> Send a PR to merge the release branch into `main`.
-
 ```
 git checkout -b release
 make release RELEASE_VERSION=1.0.0
 ```
 
-The following key functions are provided:
-
-1. Set the release version in the Maven pom.xml
-2. Commit new version in the pom.xml and create a git tag
-3. Set the Maven pom.xml to a new snapshot version
-4. Commit new snapshot version in the pom.xml
-5. Optional: Push commits and tags to the release branch to publish the release, add `PUSH_RELEASE=true`
-
-The CI/CD pipeline to build and publish container images for releases is triggered by pushed git version tags.
-The version number from the pom.xml is driving the container image version tag.
+Pushing the resulting `vX.Y.Z` tag is what publishes the release: signed jar,
+DEB and RPM packages, an SBOM and a multi-arch container image on
+`ghcr.io/riptide-labs/riptide`. The full procedure, the image tagging scheme and
+the `cosign verify` commands are in **[RELEASING.md](RELEASING.md)**.
 
 # 👋 Say hello
 
@@ -144,7 +133,18 @@ You can find us at:
 
 # 👮 Contribution Guidelines
 
-* [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
+Start with **[CONTRIBUTING.md](CONTRIBUTING.md)**. In short: work from an issue,
+[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), sign off
+every commit with `git commit -s`, and label AI-assisted work with an
+`Assisted-by:` trailer.
+
+Found a security problem? Please don't open an issue — see
+[SECURITY.md](SECURITY.md).
+
+# 📜 License
+
+Riptide is licensed under the **GNU General Public License v3.0 or later**
+(`GPL-3.0-or-later`). See [LICENSE](LICENSE) for the full text.
 
 
 ## Contributors ✨

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,115 @@
+# Releasing Riptide
+
+Riptide follows [Semantic Versioning](https://semver.org/). The version lives in
+`pom.xml` and nowhere else — everything downstream (packages, image tags,
+release title) is derived from it.
+
+Which part to bump follows from the Conventional Commit types since the last
+tag: a `!` or `BREAKING CHANGE:` footer means major, `feat` means minor,
+anything else patch.
+
+## Cutting a release
+
+`main` is protected, so the version bump goes through a pull request like any
+other change. Example for 1.0.0:
+
+```bash
+git checkout -b release
+make release RELEASE_VERSION=1.0.0
+```
+
+`make release` refuses to run unless you are on the `release` branch, in sync
+with origin, with a clean tree and a version tag that does not exist yet. It
+then:
+
+1. sets the release version in `pom.xml`
+2. commits it and creates the annotated tag `v1.0.0`
+3. sets `pom.xml` to the next snapshot version
+4. commits that
+
+Nothing has left your machine at this point. Add `PUSH_RELEASE=true` to push the
+commits and the tag in the same step, or push them yourself once you are happy:
+
+```bash
+git push origin HEAD
+git push origin v1.0.0
+```
+
+Open a PR to merge `release` into `main` and squash-merge it as usual.
+
+**The tag push is what releases.** Everything below happens in
+[`release.yml`](.github/workflows/release.yml) with no further input.
+
+## What the pipeline produces
+
+The workflow triggers on tags matching `v*.*.*` and refuses to run if the tag
+disagrees with the version in `pom.xml`, or if that version is a `SNAPSHOT`.
+
+| Artifact | Where it lands |
+|---|---|
+| `riptide-flows-X.Y.Z.jar` | GitHub Release |
+| `riptide_X.Y.Z_all.deb`, `riptide-X.Y.Z-1.noarch.rpm` | GitHub Release |
+| `riptide-X.Y.Z.spdx.json` (SBOM) | GitHub Release |
+| `*.sigstore.json` (cosign bundles) | GitHub Release |
+| Multi-arch image (`linux/amd64`, `linux/arm64`) | `ghcr.io/riptide-labs/riptide` |
+| Build provenance | attached to the release artifacts and pushed to GHCR |
+
+The release is published immediately — it is not a draft. Write the release
+notes afterwards with `gh release edit vX.Y.Z --notes-file notes.md`.
+
+### Container image tags
+
+| Tag | Points at |
+|---|---|
+| `X.Y.Z` | that exact release, forever |
+| `X.Y` | newest patch of that minor |
+| `latest` | newest **stable** release |
+| `rc` | current `main`, rebuilt on every push — not a release |
+
+A prerelease tag (`v1.0.0-rc1`) is marked as a prerelease on GitHub and gets
+**only** its exact `X.Y.Z` tag. It never moves `X.Y` or `latest`.
+
+## Verifying a release
+
+Everything is signed with [cosign](https://docs.sigstore.dev/) keyless signing —
+no key to distribute, the signing identity *is* the release workflow.
+
+```bash
+# container image
+cosign verify ghcr.io/riptide-labs/riptide:<version> \
+  --certificate-identity-regexp '^https://github.com/Riptide-Labs/riptide/\.github/workflows/release\.yml@refs/tags/v.*$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+# a downloaded artifact, against its bundle from the same release
+cosign verify-blob riptide-flows-<version>.jar \
+  --bundle riptide-flows-<version>.jar.sigstore.json \
+  --certificate-identity-regexp '^https://github.com/Riptide-Labs/riptide/\.github/workflows/release\.yml@refs/tags/v.*$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+# build provenance: which workflow, commit and inputs produced this
+gh attestation verify riptide-flows-<version>.jar --repo Riptide-Labs/riptide
+```
+
+Not every release carries all of these — see the table in
+[SECURITY.md](SECURITY.md#verifying-what-you-run). In particular, images
+0.4.9–0.4.11 have no valid signature at all
+([#294](https://github.com/Riptide-Labs/riptide/issues/294)).
+
+## After the tag
+
+Watch the run and confirm it before announcing anything:
+
+```bash
+gh run watch                                  # release workflow to green
+gh release view vX.Y.Z                        # artifacts + SBOM + bundles attached
+cosign verify ghcr.io/riptide-labs/riptide:X.Y.Z …   # signature is real
+```
+
+`latest` and `X.Y` should now resolve to the new version. If the workflow fails
+partway, fix forward with a new patch version rather than re-pushing the tag —
+the release is already partly public.
+
+## Changing the pipeline
+
+If you change what the release produces, change this file in the same PR. A
+`RELEASING.md` that describes last year's pipeline is worse than none.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,41 @@
+# Support
+
+Riptide is maintained by a small team. Here is where each kind of question goes.
+
+## "How do I ...?"
+
+Start with the **[documentation](https://riptide.space/docs/)** — configuration,
+deployment and enrichment all have their own sections.
+
+If that doesn't answer it, ask in **[Riptide Chat on Matrix](https://matrix.to/#/#riptide:gitter.im)**.
+For usage questions this is usually faster than an issue, and other users see
+the answer too.
+
+## "This looks like a bug"
+
+Open a **[bug report](https://github.com/Riptide-Labs/riptide/issues/new?template=bug.yml)**.
+
+For anything in the flow-parsing or enrichment path, attach a pcap. It turns a
+guessing game into a test case and is by far the fastest route to a fix.
+
+## "Riptide should be able to ..."
+
+Open an **[enhancement](https://github.com/Riptide-Labs/riptide/issues/new?template=enhancement.yml)**
+describing the problem you are trying to solve. Discussing it before the code
+exists usually produces a simpler answer.
+
+## "I found a security problem"
+
+Please **don't** open a public issue — see [SECURITY.md](SECURITY.md) for
+private reporting.
+
+## "I want to contribute"
+
+[CONTRIBUTING.md](CONTRIBUTING.md) covers the development environment, the CI
+quality gates, DCO sign-off and the AI-assistance policy.
+
+## Response times
+
+There is no SLA — this is an open source project, and issues are answered when
+maintainers have time. Chasing a stale issue with a polite comment is fine and
+sometimes exactly what it needs.

--- a/docs/docs/develop/pull-requests.md
+++ b/docs/docs/develop/pull-requests.md
@@ -28,6 +28,11 @@ Run the Maven-side gates locally before pushing: `make` (= `mvn verify`).
 - **DCO sign-off required**: commit with `git commit -s`. The sign-off certifies the
   [Developer Certificate of Origin](https://developercertificate.org/) with your own
   identity.
+- **AI assistance is declared**: if a coding assistant helped, add an
+  `Assisted-by: <Agent>:<model>` trailer above the sign-off, e.g.
+  `Assisted-by: ClaudeCode:claude-opus-4-8`. It records provenance — the human who
+  signs off is still responsible for reviewing the change and for its licence
+  compliance, and the sign-off is never an AI's name.
 
 ## License
 


### PR DESCRIPTION
Closes #305

- **RELEASING.md** — the `make release` flow, what the tag push produces, the container tagging scheme (a prerelease never moves `:latest` or `:X.Y`), and the cosign/`gh attestation` verification commands. Artifact names and the identity regexp are taken from published releases, not invented.
- **CONTRIBUTING.md + docs site** — the `Assisted-by: <Agent>:<model>` trailer, and that the human signing off stays responsible for review and licence compliance.
- **Issue forms** for bugs (asks for a pcap, which is what actually gets flow bugs fixed) and enhancements, plus a config routing questions to Matrix and vulnerabilities to private reporting.
- **PR template** with a `Closes #` line.
- **CODE_OF_CONDUCT.md** (Contributor Covenant 2.1, reporting to ronny@no42.org) and **SUPPORT.md**.
- **README** — License section added; the release section reduced to a pointer instead of a second, drifting copy of the procedure.

> [!IMPORTANT]
> **Merge #304 first.** README, CONTRIBUTING, RELEASING and SUPPORT all link to `SECURITY.md`, which is introduced in #304. Merging this one first leaves four broken links on main until #304 lands.

Repo settings applied out-of-band with your approval: topics added (netflow, ipfix, sflow, clickhouse, network-monitoring, network-traffic-analysis, java, spring-boot), rebase merges disabled (squash-only now), `triage`/`breaking-change`/`priority: high|medium|low` labels created, and `lint` added to the required status checks alongside `build` and `e2e`.