### PR TITLE
ci(lint): run the workflow lint on every PR

### DIFF
--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -12,10 +12,11 @@ on:
   workflow_dispatch:
   push:
     branches: [ 'main' ]
-    paths: [ '.github/workflows/**', 'Makefile' ]
+  # No `paths:` filter. `lint` is a required status check, and a required check
+  # that is filtered out never reports — it does not pass, it stays pending, and
+  # the PR can never merge. The job costs ten seconds; the filter cost merges.
   pull_request:
     branches: [ 'main' ]
-    paths: [ '.github/workflows/**', 'Makefile' ]
 
 permissions:
   contents: read


### PR DESCRIPTION
Fixes a regression I introduced when adding `lint` to the required status checks on main.

`lint-actions.yml` has a `paths:` filter, so on a PR that touches neither `.github/workflows/**` nor `Makefile` the check never reports. GitHub treats a required-but-unreported check as pending, not passing, so those PRs can never merge:

```
$ gh pr view 306 --json mergeStateStatus  → BLOCKED
$ gh pr checks 306 | grep -c lint         → 0
```

Dropping the filter costs ten seconds per PR and unblocks them. #304 and #306 need a branch update after this lands so the check runs on their heads.