### PR TITLE
feat(clickhouse): 1-minute rollup tables and materialized views

### DIFF
--- a/docs/docs/configuration/clickhouse.md
+++ b/docs/docs/configuration/clickhouse.md
@@ -48,8 +48,9 @@ what ClickHouse accepts under backtick quoting; rename such a database or use va
   manual DDL — the configured user needs `CREATE` rights), the `flows` table with
   `CREATE TABLE IF NOT EXISTS` (an existing table is not replaced, so its data survives), and
   the `samples` view with `CREATE OR REPLACE VIEW` (a view holds no data, so it is always
-  refreshed and can never go stale). A fresh install is created; a restart keeps the data — so
-  **flow data now survives a Riptide restart**.
+  refreshed and can never go stale), and the [1-minute rollups](#rollups) with
+  `CREATE TABLE IF NOT EXISTS` / `CREATE MATERIALIZED VIEW IF NOT EXISTS`. A fresh install is
+  created; a restart keeps the data — so **flow data now survives a Riptide restart**.
 
   :::warning[Hand-created `samples` views need re-creating]
 
@@ -64,9 +65,10 @@ what ClickHouse accepts under backtick quoting; rename such a database or use va
   provisioning-pointing error** if it does not. Use this when an admin owns the schema and
   RBAC and each riptide process is a narrowly-scoped writer that only uses the table. On a fresh
   single-node server the admin-side
-  [`onboard --create-schema`](../deploy/multi-tenancy.md#what-it-provisions) bootstraps the database
-  and `flows` table as part of provisioning; without the flag, `onboard` requires the schema to
-  exist and fails loudly if it does not (replicated clusters pre-create the table admin-side).
+  [`onboard --create-schema`](../deploy/multi-tenancy.md#what-it-provisions) bootstraps the database,
+  the `flows` table and the [rollups](#rollups) as part of provisioning; without the flag, `onboard`
+  requires the schema to exist and fails loudly if it does not (replicated clusters pre-create the
+  table admin-side).
 
 In both modes, startup verifies the `flows` table is present and carries every column riptide
 inserts (including the `tenant`/`organisation`/`zone`/`system` identity columns) by reading the
@@ -87,6 +89,65 @@ Enrichment results are denormalized into the flow row at write time — exporter
 resolved interface data (`inputSnmpIfName`/`ifAlias`/`ifSpeed` and the `output…`
 counterparts), hostnames, classification, and locality — so queries never need join-time
 lookups.
+
+## Rollups
+
+Alongside `flows` sit four **1-minute rollups**: `SummingMergeTree` tables kept up to date by
+materialized views on `flows`. A dashboard that asks "top applications over the last 30 days"
+reads a few thousand pre-aggregated rows instead of scanning every flow.
+
+| table | dimensions (beyond the shared preamble) |
+|---|---|
+| `flows_by_application_1m` | `application`, `protocol` |
+| `flows_by_conversation_1m` | `srcAddr`, `dstAddr`, `application` |
+| `flows_by_exporter_iface_1m` | `exporterAddr`, `exporterName`, `inputSnmp`, `outputSnmp` |
+| `flows_by_geo_asn_1m` | `srcAs`, `dstAs`, `srcCountry`, `dstCountry` |
+
+Every rollup carries the same preamble — `tenant`, `organisation`, `timestamp`, `zone` — and the
+same measures: `bytes`, `packets`, `flowCount`, plus the directional split `bytesIn`/`bytesOut`
+and `packetsIn`/`packetsOut`. The undirected totals sit alongside the split deliberately: a flow
+with `direction = UNKNOWN` counts in neither `bytesIn` nor `bytesOut`, so a query that summed the
+split would quietly lose it. Use `bytes` unless you specifically want one direction.
+
+`timestamp` keeps the raw table's column name, truncated to the minute
+(`toStartOfMinute`), so a time filter ports between raw and rollup unchanged:
+
+```sql
+-- the same WHERE works against either table
+SELECT application, sum(bytes) AS bytes
+FROM riptide.flows_by_application_1m
+WHERE timestamp >= now() - INTERVAL 7 DAY
+GROUP BY application ORDER BY bytes DESC LIMIT 10;
+```
+
+Each rollup `X` is fed by a materialized view named `X_mv`. Query the table, never the `_mv`.
+
+### Retention
+
+Rollups keep **365 days** by default, against the raw table's 30. That is the point of them: the
+aggregates outlive the flows they came from, so long-range queries keep working after the raw
+rows expire. Retention is set at creation time (`TTL timestamp + INTERVAL <n> DAY`) — in
+provisioned mode via `onboard --ttl-days`, which applies to the raw table; adjust a rollup's TTL
+with `ALTER TABLE … MODIFY TTL` if you need something different.
+
+:::warning[Raw retention above 365 days inverts the invariant]
+
+`--ttl-days` sets only the **raw** table's TTL — the rollups stay at 365 unless altered. A raw
+retention above 365 therefore makes the rollups expire *before* the raw rows, silently defeating
+"aggregates outlive the flows": long-range queries lose the oldest aggregates while the raw data
+still exists. If you set `--ttl-days` above 365, raise the rollups to at least the same value:
+`ALTER TABLE <db>.<rollup> MODIFY TTL timestamp + INTERVAL <n> DAY` for each rollup.
+
+:::
+
+:::warning[Materialized views do not backfill]
+
+A rollup only covers traffic inserted **after** it was created. Adding the rollups to an existing
+deployment does not populate them from historical `flows` rows — they start empty and fill from
+that moment on. To backfill, `INSERT INTO … SELECT` from `flows` yourself, keeping the same
+grouping the view uses.
+
+:::
 
 ## Identity columns
 

--- a/docs/docs/configuration/clickhouse.md
+++ b/docs/docs/configuration/clickhouse.md
@@ -13,6 +13,7 @@ riptide.clickhouse.username=default
 #riptide.clickhouse.password=vault://secret/riptide/clickhouse#password
 riptide.clickhouse.database=riptide
 riptide.clickhouse.manage-schema=true
+#riptide.clickhouse.async-inserts=   # unset: follows manage-schema — see below
 ```
 
 ## Credentials
@@ -121,6 +122,25 @@ GROUP BY application ORDER BY bytes DESC LIMIT 10;
 ```
 
 Each rollup `X` is fed by a materialized view named `X_mv`. Query the table, never the `_mv`.
+
+### Insert coalescing (`async-inserts`)
+
+The collector inserts once per received packet, and every insert also feeds the four rollup
+views. Without coalescing, that many small inserts collapse throughput on modest hardware —
+measured on two cores: 206 inserts/s without the rollups, 56 with them, **607 with the rollups
+and server-side coalescing** (`async_insert`, acknowledged on buffer append).
+
+`riptide.clickhouse.async-inserts` controls it, and **unset follows `manage-schema`**:
+
+- **manage mode → on.** No write barrier exists, and flow transport is lossy UDP anyway — the
+  ~200 ms server-side buffer window changes nothing an operator relies on.
+- **provisioned mode → off.** The insert is acknowledged before the server evaluates it, so a
+  row the server later rejects is dropped **without the collector seeing an error** — including a
+  mis-tenanted row failing the CHECK barrier. Isolation still holds (the row never lands), but
+  the synchronous `469 VIOLATED_CONSTRAINT` signal is part of the provisioned-mode contract, so
+  coalescing stays off unless you opt in.
+
+Set the property explicitly to override either default.
 
 ### Retention
 

--- a/docs/docs/deploy/multi-tenancy.md
+++ b/docs/docs/deploy/multi-tenancy.md
@@ -108,27 +108,57 @@ checks `CREATE` privileges even when `IF NOT EXISTS` would no-op).
 | mode | minimum privileges for the admin credential |
 |---|---|
 | default (schema exists) | `CREATE USER`/`CREATE ROLE`/`CREATE QUOTA`/`CREATE ROW POLICY`, `ALTER USER`/`ALTER ROLE`, `DROP USER`/`DROP ROW POLICY` (offboard), `ALTER TABLE` on `<db>.flows`, and `INSERT`, `SELECT` on `<db>.flows` plus `SELECT` on `system.databases/tables/columns` **with grant option** (they are granted onward to the roles) |
-| `--create-schema` | the above, plus `CREATE DATABASE ON <db>.*` and `CREATE TABLE ON <db>.flows` |
+| `--create-schema` | the above, plus `CREATE DATABASE ON <db>.*`, `CREATE TABLE ON <db>.*` (the `flows` table and the rollup targets) and `CREATE VIEW ON <db>.*` (the rollups' materialized views) |
 
 `onboard` is safe to re-run: it reconciles the writer/reader **passwords** to the current secret, so
-rotating a secret and re-running updates ClickHouse (the users' `CONST` settings and row policy are
-preserved). To remove a tenant: `offboard --admin-url … --tenant acme --yes` (drops its users and
-row policy; the shared roles/constraints/quota stay).
+rotating a secret and re-running updates ClickHouse (the users' `CONST` settings are preserved; the
+row policies are **re-asserted** to match the recipe — a policy `TO` list widened by hand is
+reverted on the next run, so route extra grantees through provisioning, not manual DDL). To remove a tenant: `offboard --admin-url … --tenant acme --yes` (drops its users and
+its row policy from `flows` **and every rollup**; the shared roles/constraints/quota stay).
+
+### Adding rollups to an existing deployment
+
+A database provisioned before the rollups existed has a perfectly good `flows` table, so the
+schema check passes while the rollups are simply absent. `onboard` checks for them separately and
+refuses to run without `--create-schema`:
+
+```
+database 'riptide' is missing the 1-minute rollup tables or their materialized views — re-run
+with --create-schema to add them. …
+```
+
+Re-running with `--create-schema` adds them in place. This creates tables and materialized views
+only — **the `flows` table and its data are untouched**. The check covers each rollup's target
+*and* its view, so an interrupted bootstrap that left targets without views is detected rather
+than reading as healthy (which would leave the rollups silently empty).
+
+Because a materialized view does not backfill, rollups added this way cover traffic from creation
+onward. See [Rollups](../configuration/clickhouse.md#rollups) for the table layout and how to
+backfill if you need the history.
 
 ### What it provisions
 
 The recipe is **role-based**: the schema, the grants, the reader hardening, the CHECK barrier, and
-the quota are one-time objects, so per-tenant reduces to the scoped users + role grants + one literal
-row policy. `onboard` ensures the one-time objects on first run and adds the per-tenant part:
+the quota are one-time objects, so per-tenant reduces to the scoped users + role grants + one row
+policy per table (`flows` and each rollup, all sharing the tenant-literal predicate). `onboard`
+ensures the one-time objects on first run and adds the per-tenant part:
 
 ```sql
 -- Only with --create-schema, and only when the schema is actually missing (a default run emits
 -- no CREATE statement, so it needs no CREATE privileges). IF NOT EXISTS never replaces a table.
 CREATE DATABASE IF NOT EXISTS riptide;
 CREATE TABLE IF NOT EXISTS riptide.flows (…);  -- single-node MergeTree, TTL from --ttl-days (default 30)
+-- The 1-minute rollups: targets first, then the materialized views that feed them (a view cannot
+-- be created before its TO table). TTL is 365 days — the aggregates outlive the raw rows.
+CREATE TABLE IF NOT EXISTS riptide.flows_by_application_1m (…);          -- and three more
+CREATE MATERIALIZED VIEW IF NOT EXISTS riptide.flows_by_application_1m_mv
+  TO riptide.flows_by_application_1m AS SELECT … FROM riptide.flows AS f GROUP BY …;
 -- Once per cluster (idempotent): roles carry every per-tenant grant and the reader hardening.
 CREATE ROLE IF NOT EXISTS flow_writer;
 GRANT INSERT ON riptide.flows TO flow_writer;
+-- The writer also reads flows: a materialized view runs as the inserting user, so pushing a row
+-- into a rollup requires SELECT on the view's source table.
+GRANT SELECT ON riptide.flows TO flow_writer;
 CREATE ROLE IF NOT EXISTS flow_reader;
 GRANT SELECT ON riptide.flows TO flow_reader;
 GRANT SELECT ON system.databases TO flow_reader;
@@ -143,16 +173,35 @@ ALTER TABLE riptide.flows ADD CONSTRAINT IF NOT EXISTS org_pinned    CHECK organ
 -- One quota keyed by user gives every writer its own bucket (written_bytes — written_rows is not a metric).
 CREATE QUOTA IF NOT EXISTS flow_ingest FOR INTERVAL 1 hour MAX written_bytes = 50000000000
   KEYED BY user_name TO flow_writer;
+-- Every rollup gets the same treatment as flows, for both roles.
+GRANT INSERT ON riptide.flows_by_application_1m TO flow_writer;   -- and the other three
+GRANT SELECT ON riptide.flows_by_application_1m TO flow_reader;
 
--- Per tenant (the residual): two scoped users + role grants + one literal row policy.
+-- Per tenant (the residual): two scoped users + role grants + one row policy per table.
 CREATE USER IF NOT EXISTS writer_acme IDENTIFIED WITH sha256_password BY '…'
   SETTINGS SQL_tenant = 'acme' CONST, SQL_org = 'acme-eu' CONST;
 GRANT flow_writer TO writer_acme;
 CREATE USER IF NOT EXISTS bi_acme IDENTIFIED WITH sha256_password BY '…'
   SETTINGS SQL_tenant = 'acme' CONST, SQL_org = 'acme-eu' CONST;
 GRANT flow_reader TO bi_acme;
-CREATE ROW POLICY IF NOT EXISTS acme_iso ON riptide.flows FOR SELECT USING tenant = 'acme' TO bi_acme;
+-- The writer is named on the flows policy alongside the reader: a row policy is deny-by-default
+-- for anyone it does not name, and the writer must read flows for the rollup views to push. Its
+-- predicate is the same tenant the CHECK barrier already pins, so it grants no extra row.
+CREATE ROW POLICY OR REPLACE acme_iso ON riptide.flows
+  FOR SELECT USING tenant = 'acme' TO bi_acme, writer_acme;
+-- The rollup policies name the reader only — the writer reaches a rollup by INSERT through its
+-- materialized view, which no row policy filters.
+CREATE ROW POLICY OR REPLACE acme_iso ON riptide.flows_by_application_1m
+  FOR SELECT USING tenant = 'acme' TO bi_acme;                    -- and the other three
 ```
+
+:::note[Why `OR REPLACE` rather than `IF NOT EXISTS`]
+
+For the same reason `onboard` re-issues `ALTER USER` for passwords: a policy left over from an
+earlier run keeps its old `TO` list, so a re-run would not pick up a changed grantee. `OR REPLACE`
+makes the policy match the recipe every time.
+
+:::
 
 :::note
 
@@ -168,7 +217,9 @@ The hardened BI credential is a real boundary, not just a filter (proven by `Ten
 and, through the subcommand, `TenantOnboardingIT`):
 
 - **Reads stay in-tenant** — the row policy limits `bi_acme` to `tenant = 'acme'` rows, even
-  against a shared table holding every tenant.
+  against a shared table holding every tenant. The rollups carry the same policy, so a
+  pre-aggregated query is bounded exactly as the raw one is — a rollup is not a way around the
+  boundary.
 - **Cannot write** — the `flow_reader` role grants no `INSERT` and pins `readonly`, so a write is
   rejected (`ACCESS_DENIED`).
 - **Cannot change schema** — `allow_ddl = 0` rejects any DDL, so a compromised dashboard credential

--- a/src/main/java/org/riptide/config/ClickhouseConfig.java
+++ b/src/main/java/org/riptide/config/ClickhouseConfig.java
@@ -34,4 +34,26 @@ public final class ClickhouseConfig {
          * multi-tenant / provisioned mode.
          */
         private boolean manageSchema = true;
+
+        /**
+         * Server-side insert coalescing ({@code async_insert}). The pipeline inserts once per
+         * received packet, and each insert also feeds the rollup materialized views — without
+         * coalescing, that many small inserts collapse ingestion throughput on modest hardware
+         * (measured 206 → 56 inserts/s with the four rollups on two cores). With coalescing the
+         * server buffers and merges them (measured 607 inserts/s), at the price of asynchronous
+         * error reporting: the insert is acknowledged when buffered, so a row the server later
+         * rejects — notably a mis-tenanted row failing the multi-tenant CHECK barrier — is dropped
+         * without the collector seeing an error.
+         *
+         * <p>Unset (default) follows {@link #manageSchema}: on in manage mode (single-tenant,
+         * where the barrier does not exist and flow transport is lossy UDP anyway), off in
+         * provisioned mode (where the barrier's synchronous rejection is part of the isolation
+         * contract). Set explicitly to override either way.
+         */
+        private Boolean asyncInserts;
+
+        /** The effective setting: the explicit value if set, otherwise on exactly in manage mode. */
+        public boolean isAsyncInserts() {
+                return this.asyncInserts != null ? this.asyncInserts : this.manageSchema;
+        }
 }

--- a/src/main/java/org/riptide/provisioning/ProvisioningCommand.java
+++ b/src/main/java/org/riptide/provisioning/ProvisioningCommand.java
@@ -176,8 +176,10 @@ public final class ProvisioningCommand {
                   riptide offboard --admin-url URL [--admin-user U] [--admin-password REF] \\
                                    --tenant T [--database DB] --yes
                 secret REF: plain literal, env://VAR, or file:///path[#key]
-                --create-schema: bootstrap the database and flows table if absent (needs CREATE
-                                 privileges); without it, a missing schema fails before provisioning""");
+                --create-schema: bootstrap the database, flows table, and 1-minute rollup
+                                 tables/views if absent (needs CREATE privileges) — also the way
+                                 to add the rollups to a pre-rollup deployment; without it, a
+                                 missing schema fails before provisioning""");
     }
 
     /** Minimal {@code --key value} / {@code --flag} parser. {@code args[0]} is the subcommand. */

--- a/src/main/java/org/riptide/provisioning/ProvisioningDdl.java
+++ b/src/main/java/org/riptide/provisioning/ProvisioningDdl.java
@@ -17,9 +17,16 @@ import java.util.List;
  * <p>The model puts every identical-per-tenant part into one-time objects ({@link #ensureShared})
  * — the {@code flow_writer}/{@code flow_reader} roles carrying the grants and the reader hardening,
  * and a single quota keyed by user — so {@link #onboardTenant} reduces to the scoped users, two
- * role grants, and one literal row policy. The {@code flows} schema itself is a separate, opt-in
- * recipe ({@link #bootstrapSchema}, {@code onboard --create-schema}). All statements are idempotent
- * ({@code IF NOT EXISTS} / {@code ALTER ROLE SETTINGS}), verified on ClickHouse 25.3.
+ * role grants, and the row policies. The {@code flows} schema itself is a separate, opt-in recipe
+ * ({@link #bootstrapSchema}, {@code onboard --create-schema}), as are the 1-minute rollups
+ * ({@link #bootstrapRollups}). All statements are idempotent ({@code IF NOT EXISTS} /
+ * {@code OR REPLACE} / {@code ALTER ROLE SETTINGS}), verified on ClickHouse 25.3.
+ *
+ * <p>The rollups are provisioned as first-class tables: every grant and every row policy that
+ * covers {@code flows} covers each rollup target too. Both are driven off
+ * {@link FlowsSchema#rollupTableNames()}, so a rollup added to the schema is picked up here without
+ * a second edit — the failure mode being guarded against is a new rollup silently missing its
+ * tenant isolation.
  *
  * <p>Tenant/org names are validated ({@link TenantSpec}) to a safe charset; generated identifiers
  * are backtick-quoted and string literals are escaped, so neither can break out of the statement.
@@ -43,6 +50,21 @@ public final class ProvisioningDdl {
                 FlowsSchema.createFlowsTable(database, ttlDays));
     }
 
+    /**
+     * The opt-in rollup bootstrap: the 1-minute target tables and the materialized views feeding
+     * them. The additive columns come first because the rollups select {@code srcCountry},
+     * {@code dstCountry} and {@code exporterName} — on a pre-0.5 table those columns do not exist
+     * yet, and a materialized view referencing a missing column fails to create. Targets precede
+     * views for the same reason a view cannot be created before its {@code TO} table.
+     */
+    public static List<String> bootstrapRollups(final String database) {
+        final List<String> statements = new ArrayList<>();
+        statements.addAll(FlowsSchema.addAdditiveColumns(database));
+        statements.addAll(FlowsSchema.createRollupTables(database));
+        statements.addAll(FlowsSchema.createRollupViews(database));
+        return List.copyOf(statements);
+    }
+
     /** One-time shared objects: the two roles, the reader hardening, the CHECK barrier, the quota. */
     public static List<String> ensureShared(final String database, final long quotaBytes) {
         final String flows = FlowsSchema.qualifiedFlows(database);
@@ -54,6 +76,9 @@ public final class ProvisioningDdl {
         statements.addAll(List.of(
                 "CREATE ROLE IF NOT EXISTS flow_writer",
                 "GRANT INSERT ON " + flows + " TO flow_writer",
+                // The writer also reads flows: a materialized view runs as the inserting user, so
+                // pushing a row into a rollup target requires SELECT on the view's source table.
+                "GRANT SELECT ON " + flows + " TO flow_writer",
                 "CREATE ROLE IF NOT EXISTS flow_reader",
                 "GRANT SELECT ON " + flows + " TO flow_reader",
                 "GRANT SELECT ON system.databases TO flow_reader",
@@ -68,15 +93,32 @@ public final class ProvisioningDdl {
                         + " ADD CONSTRAINT IF NOT EXISTS org_pinned CHECK organisation = getSetting('SQL_org')",
                 "CREATE QUOTA IF NOT EXISTS flow_ingest FOR INTERVAL 1 hour MAX written_bytes = "
                         + quotaBytes + " KEYED BY user_name TO flow_writer"));
+        // The rollups get the same treatment as flows: the writer inserts (via the materialized
+        // views), the reader selects. Driven off rollupTableNames() so a new rollup cannot be
+        // added to the schema without inheriting its grants.
+        for (final String rollup : FlowsSchema.rollupTableNames()) {
+            final String table = FlowsSchema.qualifiedRollup(database, rollup);
+            statements.add("GRANT INSERT ON " + table + " TO flow_writer");
+            statements.add("GRANT SELECT ON " + table + " TO flow_reader");
+        }
         return List.copyOf(statements);
     }
 
     /**
-     * Per-tenant: the scoped writer/reader users, their role grants, and the literal row policy.
+     * Per-tenant: the scoped writer/reader users, their role grants, and one row policy per table.
      * Each user is created if absent and then has its password reconciled with {@code ALTER USER}
      * — so re-running after a secret rotation updates the credential (a plain
      * {@code CREATE … IF NOT EXISTS} would silently keep the old password). {@code ALTER USER}
      * preserves the user's {@code CONST} settings and its row-policy membership.
+     *
+     * <p>The writer is on the {@code flows} policy alongside the reader. A row policy on a table is
+     * deny-by-default for anyone it does not name, and the writer must read {@code flows} for the
+     * rollup views to push — omitting it would leave the materialized views silently pushing
+     * nothing. Its predicate is the same {@code tenant = '…'} the {@code tenant_pinned} constraint
+     * enforces on insert, so the policy grants the writer no row it could not already write.
+     *
+     * <p>The rollup policies name the reader only: the writer reaches a rollup by {@code INSERT}
+     * through its materialized view, which no row policy filters.
      */
     public static List<String> onboardTenant(final String database, final String tenant, final String organisation,
                                              final String writerPassword, final String readerPassword) {
@@ -86,7 +128,7 @@ public final class ProvisioningDdl {
         final String policy = ident(tenant + "_iso");
         final String pinned = " SETTINGS SQL_tenant = " + literal(tenant) + " CONST, SQL_org = "
                 + literal(organisation) + " CONST";
-        return List.of(
+        final List<String> statements = new ArrayList<>(List.of(
                 "CREATE USER IF NOT EXISTS " + writer + " IDENTIFIED WITH sha256_password BY "
                         + literal(writerPassword) + pinned,
                 "ALTER USER " + writer + " IDENTIFIED WITH sha256_password BY " + literal(writerPassword),
@@ -95,17 +137,39 @@ public final class ProvisioningDdl {
                         + literal(readerPassword) + pinned,
                 "ALTER USER " + reader + " IDENTIFIED WITH sha256_password BY " + literal(readerPassword),
                 "GRANT flow_reader TO " + reader,
-                "CREATE ROW POLICY IF NOT EXISTS " + policy + " ON " + flows
-                        + " FOR SELECT USING tenant = " + literal(tenant) + " TO " + reader);
+                rowPolicy(policy, flows, tenant, reader + ", " + writer)));
+        for (final String rollup : FlowsSchema.rollupTableNames()) {
+            statements.add(rowPolicy(policy, FlowsSchema.qualifiedRollup(database, rollup), tenant, reader));
+        }
+        return List.copyOf(statements);
     }
 
-    /** Per-tenant teardown: drop the row policy and the two users; shared objects stay. */
+    /**
+     * One tenant-isolating row policy. {@code OR REPLACE} rather than {@code IF NOT EXISTS} for the
+     * same reason {@link #onboardTenant} re-issues {@code ALTER USER}: a policy left over from an
+     * earlier run keeps its old {@code TO} list, so a re-run would not pick up a changed grantee.
+     */
+    private static String rowPolicy(final String policy, final String table, final String tenant, final String to) {
+        return "CREATE ROW POLICY OR REPLACE " + policy + " ON " + table
+                + " FOR SELECT USING tenant = " + literal(tenant) + " TO " + to;
+    }
+
+    /**
+     * Per-tenant teardown: drop the policy from {@code flows} and from every rollup, then the two
+     * users; shared objects stay. A policy left behind on a rollup would keep denying rows there
+     * after the tenant is gone.
+     */
     public static List<String> offboardTenant(final String database, final String tenant) {
-        final String flows = FlowsSchema.qualifiedFlows(database);
-        return List.of(
-                "DROP ROW POLICY IF EXISTS " + ident(tenant + "_iso") + " ON " + flows,
-                "DROP USER IF EXISTS " + ident("bi_" + tenant),
-                "DROP USER IF EXISTS " + ident("writer_" + tenant));
+        final String policy = ident(tenant + "_iso");
+        final List<String> statements = new ArrayList<>();
+        statements.add("DROP ROW POLICY IF EXISTS " + policy + " ON " + FlowsSchema.qualifiedFlows(database));
+        for (final String rollup : FlowsSchema.rollupTableNames()) {
+            statements.add("DROP ROW POLICY IF EXISTS " + policy + " ON "
+                    + FlowsSchema.qualifiedRollup(database, rollup));
+        }
+        statements.add("DROP USER IF EXISTS " + ident("bi_" + tenant));
+        statements.add("DROP USER IF EXISTS " + ident("writer_" + tenant));
+        return List.copyOf(statements);
     }
 
     /** Validate (safe charset, via the package's single check) and backtick-quote an identifier. */

--- a/src/main/java/org/riptide/provisioning/TenantProvisioner.java
+++ b/src/main/java/org/riptide/provisioning/TenantProvisioner.java
@@ -39,8 +39,9 @@ public final class TenantProvisioner {
      * Ensure the shared objects and this tenant's users/policy exist (idempotent). Returns the
      * riptide configuration stanza for the tenant's collector, referencing the same writer secret.
      *
-     * <p>A pre-flight check verifies the database and {@code flows} table exist <em>before any
-     * statement runs</em>. If they are missing, the run fails unless {@code createSchema} is set —
+     * <p>A pre-flight check verifies the database, the {@code flows} table and the rollups exist
+     * <em>before any statement runs</em>. If they are missing, the run fails unless
+     * {@code createSchema} is set —
      * a typo'd database name must fail loudly, not silently provision a phantom database with the
      * shared roles granted on it. The bootstrap statements are only <em>emitted</em> when actually
      * creating: ClickHouse checks the {@code CREATE} privileges even when {@code IF NOT EXISTS}
@@ -60,6 +61,21 @@ public final class TenantProvisioner {
                                 + " for typos (an admin-provisioned table is also accepted)", null);
             }
             statements.addAll(ProvisioningDdl.bootstrapSchema(spec.database(), ttlDays));
+        }
+        // Same opt-in gate for the rollups, checked separately: a database provisioned before the
+        // rollups existed has a perfectly good flows table and would otherwise pass the check above
+        // while silently lacking them. Short-circuited on bootstrap — a database we are creating
+        // right now cannot have rollups, so there is no point asking ClickHouse eight times.
+        if (bootstrap || !rollupsExist(spec.database())) {
+            if (!createSchema) {
+                throw new ProvisioningException(
+                        "database '" + spec.database() + "' is missing the 1-minute rollup tables or"
+                                + " their materialized views — re-run with --create-schema to add"
+                                + " them. This creates tables and materialized views only; the flows"
+                                + " table and its data are untouched, and the rollups cover traffic"
+                                + " from creation onward (a materialized view does not backfill)", null);
+            }
+            statements.addAll(ProvisioningDdl.bootstrapRollups(spec.database()));
         }
         statements.addAll(ProvisioningDdl.ensureShared(spec.database(), spec.quotaBytes()));
         statements.addAll(ProvisioningDdl.onboardTenant(
@@ -83,6 +99,17 @@ public final class TenantProvisioner {
     private boolean flowsTableExists(final String database) {
         return exists("EXISTS DATABASE " + ProvisioningDdl.ident(database))
                 && exists("EXISTS TABLE " + FlowsSchema.qualifiedFlows(database));
+    }
+
+    /**
+     * Whether every rollup target <em>and</em> its materialized view is present. Both halves are
+     * checked because they fail independently: an interrupted bootstrap can leave the target table
+     * created and the view not, which reports as a healthy-looking empty rollup.
+     */
+    private boolean rollupsExist(final String database) {
+        return FlowsSchema.rollupTableNames().stream()
+                .allMatch(rollup -> exists("EXISTS TABLE " + FlowsSchema.qualifiedRollup(database, rollup))
+                        && exists("EXISTS TABLE " + FlowsSchema.qualifiedRollupView(database, rollup)));
     }
 
     private boolean exists(final String sql) {

--- a/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
+++ b/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
@@ -127,6 +127,19 @@ public class ClickhouseRepository implements FlowRepository {
         // before the first insert would fail with an opaque error. Reuses the schema for register.
         final TableSchema schema = checkSchema();
 
+        if (this.config.isManageSchema()) {
+            // Rollups come after the flows check, not with the DDL above: their materialized views
+            // select from flows, so creating them against a stale or mis-provisioned table would
+            // fail with an error about the view rather than about the real problem. Targets before
+            // views — a view cannot be created before the table its TO clause names.
+            for (final String ddl : FlowsSchema.createRollupTables(this.config.getDatabase())) {
+                this.client.execute(ddl).get();
+            }
+            for (final String ddl : FlowsSchema.createRollupViews(this.config.getDatabase())) {
+                this.client.execute(ddl).get();
+            }
+        }
+
         this.client.register(ClickhouseFlow.class, schema);
     }
 

--- a/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
+++ b/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
@@ -81,14 +81,22 @@ public class ClickhouseRepository implements FlowRepository {
         this.username = resolvedUsername != null ? resolvedUsername : "default";
         this.password = resolvedPassword != null ? resolvedPassword : "";
 
-        this.client = new Client.Builder()
+        final var builder = new Client.Builder()
                 .addEndpoint(config.getEndpoint())
                 .setUsername(this.username)
                 .setPassword(this.password)
                 .setDefaultDatabase(config.getDatabase())
                 .compressClientRequest(true)
-                .compressServerResponse(true)
-                .build();
+                .compressServerResponse(true);
+        if (config.isAsyncInserts()) {
+            // Server-side coalescing for the per-packet inserts (see ClickhouseConfig#asyncInserts
+            // for the trade-off and measurements). wait_for_async_insert=0 acknowledges on buffer
+            // append — waiting for the flush would serialize the pipeline on the flush interval,
+            // which benchmarks slower than not coalescing at all (14 vs 56 inserts/s).
+            builder.serverSetting("async_insert", "1")
+                    .serverSetting("wait_for_async_insert", "0");
+        }
+        this.client = builder.build();
     }
 
     @Override

--- a/src/main/java/org/riptide/schema/FlowsSchema.java
+++ b/src/main/java/org/riptide/schema/FlowsSchema.java
@@ -13,6 +13,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * The one definition of riptide's ClickHouse flow schema — the {@code flows} table and the
@@ -37,11 +39,23 @@ import java.util.regex.Pattern;
  * always tracks the running version. It is used only by the collector's manage path — {@code
  * onboard} does not create it (in provisioned mode the reader role is not granted {@code SELECT} on
  * it, so it would be inert).
+ *
+ * <p>Alongside the raw table sit the <strong>1-minute rollups</strong>: {@code SummingMergeTree}
+ * targets fed by materialized views on {@code flows}. They are emitted as ordinary tables plus
+ * {@code …_mv} views so the provisioning path can create, grant, and row-policy them exactly like
+ * the raw table. A materialized view does not backfill, so a rollup covers traffic from its
+ * creation onward.
  */
 public final class FlowsSchema {
 
     /** The collector's manage-mode retention; also the {@code onboard --ttl-days} default. */
     public static final int DEFAULT_TTL_DAYS = 30;
+
+    /**
+     * Rollup retention, deliberately far longer than {@link #DEFAULT_TTL_DAYS}: the rollups exist so
+     * long-range queries survive the raw table's expiry, which only works if they outlive it.
+     */
+    public static final int DEFAULT_ROLLUP_TTL_DAYS = 365;
 
     /** Same charset as the provisioning boundary ({@code TenantSpec}): no quotes, backticks, spaces. */
     private static final Pattern SAFE_NAME = Pattern.compile("[A-Za-z0-9_-]+");
@@ -76,6 +90,93 @@ public final class FlowsSchema {
     /** The qualified {@code `<db>`.flows} name — the one home for its construction. */
     public static String qualifiedFlows(final String database) {
         return ident(database) + ".flows";
+    }
+
+    /** The qualified {@code `<db>`.<rollup>} target-table name. */
+    public static String qualifiedRollup(final String database, final String table) {
+        return ident(database) + "." + table;
+    }
+
+    /** The qualified {@code `<db>`.<rollup>_mv} materialized-view name. */
+    public static String qualifiedRollupView(final String database, final String table) {
+        return qualifiedRollup(database, table) + "_mv";
+    }
+
+    /**
+     * The rollup target-table names. Callers that must touch every rollup — {@code GRANT}, row
+     * policies, existence checks — iterate this rather than hard-coding a list that would silently
+     * miss a rollup added here later.
+     */
+    public static List<String> rollupTableNames() {
+        return ROLLUPS.stream().map(Rollup::table).toList();
+    }
+
+    /** As {@link #createRollupTables(String, int)} with the default rollup retention. */
+    public static List<String> createRollupTables(final String database) {
+        return createRollupTables(database, DEFAULT_ROLLUP_TTL_DAYS);
+    }
+
+    /** {@code CREATE TABLE IF NOT EXISTS} for every rollup target — pre-existing tables are left intact. */
+    public static List<String> createRollupTables(final String database, final int ttlDays) {
+        return ROLLUPS.stream().map(rollup -> rollupTable(database, rollup, ttlDays)).toList();
+    }
+
+    /**
+     * {@code CREATE MATERIALIZED VIEW IF NOT EXISTS … TO <target>} for every rollup. Must be emitted
+     * <em>after</em> {@link #createRollupTables} — a view whose {@code TO} target does not yet exist
+     * fails to create.
+     */
+    public static List<String> createRollupViews(final String database) {
+        return ROLLUPS.stream().map(rollup -> rollupView(database, rollup)).toList();
+    }
+
+    /**
+     * A rollup target table: every dimension in the sort key, every measure a {@code UInt64} the
+     * {@code SummingMergeTree} engine collapses on merge.
+     */
+    private static String rollupTable(final String database, final Rollup rollup, final int ttlDays) {
+        final List<Dimension> columns = allDimensions(rollup);
+        final StringBuilder ddl = new StringBuilder("CREATE TABLE IF NOT EXISTS ")
+                .append(qualifiedRollup(database, rollup.table()))
+                .append(" (\n");
+        for (final Dimension dimension : columns) {
+            ddl.append("    ").append(dimension.column()).append(' ').append(dimension.type()).append(",\n");
+        }
+        ddl.append(MEASURES.stream()
+                .map(measure -> "    " + measure.column() + " UInt64")
+                .collect(Collectors.joining(",\n")));
+        // Sorting by every dimension is what makes SummingMergeTree collapse correctly: rows agree
+        // on the full key or they are distinct facts.
+        ddl.append("\n) ENGINE = SummingMergeTree()\nORDER BY (")
+                .append(columns.stream().map(Dimension::column).collect(Collectors.joining(", ")))
+                .append(")\nPARTITION BY toYYYYMM(timestamp)\n")
+                .append("TTL timestamp + INTERVAL ").append(ttlDays).append(" DAY\n")
+                .append("SETTINGS index_granularity = 8192");
+        return ddl.toString();
+    }
+
+    /** The materialized view feeding one rollup target from {@code flows}. */
+    private static String rollupView(final String database, final Rollup rollup) {
+        final List<Dimension> columns = allDimensions(rollup);
+        final StringBuilder ddl = new StringBuilder("CREATE MATERIALIZED VIEW IF NOT EXISTS ")
+                .append(qualifiedRollupView(database, rollup.table()))
+                .append(" TO ").append(qualifiedRollup(database, rollup.table()))
+                .append(" AS\nSELECT\n");
+        ddl.append(columns.stream()
+                .map(dimension -> "    " + dimension.selectItem())
+                .collect(Collectors.joining(",\n")));
+        ddl.append(",\n").append(MEASURES.stream()
+                .map(measure -> "    " + measure.expression() + " AS " + measure.column())
+                .collect(Collectors.joining(",\n")));
+        ddl.append("\nFROM ").append(qualifiedFlows(database)).append(" AS ").append(SOURCE_ALIAS)
+                .append("\nGROUP BY ")
+                .append(columns.stream().map(Dimension::column).collect(Collectors.joining(", ")));
+        return ddl.toString();
+    }
+
+    /** The shared preamble followed by the rollup's own dimensions — the full sort key, in order. */
+    private static List<Dimension> allDimensions(final Rollup rollup) {
+        return Stream.concat(PREAMBLE.stream(), rollup.dimensions().stream()).toList();
     }
 
     /**
@@ -124,6 +225,88 @@ public final class FlowsSchema {
                             + " (letters, digits, underscore, hyphen)");
         }
         return "`" + name + "`";
+    }
+
+    /** The {@code flows} alias every rollup view's expressions qualify against. */
+    private static final String SOURCE_ALIAS = "f";
+
+    /**
+     * {@code application} is {@code Nullable(String)} on the raw table but a sort key on every
+     * rollup that carries it, so the null is folded to {@code ''} on the way in — a nullable sort
+     * key would make the {@code SummingMergeTree} collapse depend on null comparison.
+     */
+    private static final Dimension APPLICATION =
+            new Dimension("application", "LowCardinality(String)", "ifNull(f.application, '')");
+
+    /**
+     * Dimensions every rollup carries, ahead of its own. The tenant/organisation prefix mirrors the
+     * raw table's sort key so the same row policies apply, and {@code timestamp} keeps the raw
+     * table's column name so a time filter ports between raw and rollup unchanged — truncated to
+     * the minute, which is what makes the rollup a rollup.
+     */
+    private static final List<Dimension> PREAMBLE = List.of(
+            Dimension.of("tenant", "String"),
+            Dimension.of("organisation", "String"),
+            new Dimension("timestamp", "DateTime('UTC')", "toStartOfMinute(f.timestamp)"),
+            Dimension.of("zone", "String"));
+
+    /**
+     * The measures every rollup carries. Undirected totals sit alongside the ingress/egress split
+     * so a query that does not care about direction needs no reassembly, and one that does is not
+     * forced to re-derive it from the raw table.
+     */
+    private static final List<Measure> MEASURES = List.of(
+            new Measure("bytes", "sum(f.bytes)"),
+            new Measure("packets", "sum(f.packets)"),
+            new Measure("flowCount", "count()"),
+            new Measure("bytesIn", "sumIf(f.bytes, f.direction = 'INGRESS')"),
+            new Measure("bytesOut", "sumIf(f.bytes, f.direction = 'EGRESS')"),
+            new Measure("packetsIn", "sumIf(f.packets, f.direction = 'INGRESS')"),
+            new Measure("packetsOut", "sumIf(f.packets, f.direction = 'EGRESS')"));
+
+    /** The 1-minute rollups. Adding one here propagates to creation, grants, and row policies. */
+    private static final List<Rollup> ROLLUPS = List.of(
+            new Rollup("flows_by_application_1m", List.of(
+                    APPLICATION,
+                    Dimension.of("protocol", "UInt8"))),
+            new Rollup("flows_by_conversation_1m", List.of(
+                    Dimension.of("srcAddr", "IPv6"),
+                    Dimension.of("dstAddr", "IPv6"),
+                    APPLICATION)),
+            new Rollup("flows_by_exporter_iface_1m", List.of(
+                    Dimension.of("exporterAddr", "String"),
+                    Dimension.of("exporterName", "LowCardinality(String)"),
+                    Dimension.of("inputSnmp", "UInt32"),
+                    Dimension.of("outputSnmp", "UInt32"))),
+            new Rollup("flows_by_geo_asn_1m", List.of(
+                    Dimension.of("srcAs", "UInt64"),
+                    Dimension.of("dstAs", "UInt64"),
+                    Dimension.of("srcCountry", "LowCardinality(String)"),
+                    Dimension.of("dstCountry", "LowCardinality(String)"))));
+
+    /** One rollup: its target table name and the dimensions it adds to {@link #PREAMBLE}. */
+    private record Rollup(String table, List<Dimension> dimensions) {
+    }
+
+    /**
+     * A rollup column: its name and type in the target table, and the expression selecting it from
+     * {@code flows} in the view. Every expression is alias-qualified so the view never depends on
+     * name resolution against the source table.
+     */
+    private record Dimension(String column, String type, String expression) {
+
+        /** A dimension read straight through from the identically-named source column. */
+        static Dimension of(final String column, final String type) {
+            return new Dimension(column, type, SOURCE_ALIAS + "." + column);
+        }
+
+        String selectItem() {
+            return expression + " AS " + column;
+        }
+    }
+
+    /** An aggregate carried by every rollup: its target column and the aggregating expression. */
+    private record Measure(String column, String expression) {
     }
 
     // Placeholder tokens substituted with the qualified names / TTL. Plain replace() (not

--- a/src/test/java/org/riptide/provisioning/ProvisioningDdlTest.java
+++ b/src/test/java/org/riptide/provisioning/ProvisioningDdlTest.java
@@ -6,6 +6,7 @@
 package org.riptide.provisioning;
 
 import org.junit.jupiter.api.Test;
+import org.riptide.schema.FlowsSchema;
 
 import java.util.List;
 
@@ -92,7 +93,8 @@ class ProvisioningDdlTest {
     @Test
     void onboardTenantScopesUsersPolicyWithEscapedPassword() {
         final List<String> sql = ProvisioningDdl.onboardTenant("riptide", "acme", "acme-eu", "p'w", "r'w");
-        assertThat(sql).hasSize(7);
+        // The six user/grant statements, the flows policy, then one policy per rollup.
+        assertThat(sql).hasSize(7 + FlowsSchema.rollupTableNames().size());
         assertThat(sql.get(0))
                 .contains("CREATE USER IF NOT EXISTS `writer_acme`")
                 .contains("IDENTIFIED WITH sha256_password BY 'p\\'w'")
@@ -102,15 +104,86 @@ class ProvisioningDdlTest {
         assertThat(sql.get(2)).isEqualTo("GRANT flow_writer TO `writer_acme`");
         assertThat(sql.get(4)).isEqualTo("ALTER USER `bi_acme` IDENTIFIED WITH sha256_password BY 'r\\'w'");
         assertThat(sql.get(6))
-                .contains("CREATE ROW POLICY IF NOT EXISTS `acme_iso` ON `riptide`.flows")
+                .contains("CREATE ROW POLICY OR REPLACE `acme_iso` ON `riptide`.flows")
                 .contains("USING tenant = 'acme' TO `bi_acme`");
     }
 
     @Test
-    void offboardDropsPolicyThenUsers() {
-        assertThat(ProvisioningDdl.offboardTenant("riptide", "acme")).containsExactly(
-                "DROP ROW POLICY IF EXISTS `acme_iso` ON `riptide`.flows",
-                "DROP USER IF EXISTS `bi_acme`",
-                "DROP USER IF EXISTS `writer_acme`");
+    void bootstrapRollupsUpgradesAdditiveColumnsThenCreatesTargetsBeforeViews() {
+        // The rollups select the additive columns, and the views need their TO targets — so the
+        // ordering is load-bearing, not cosmetic.
+        final List<String> sql = ProvisioningDdl.bootstrapRollups("riptide");
+        final int additive = FlowsSchema.additiveColumnNames().size();
+        final int rollups = FlowsSchema.rollupTableNames().size();
+        assertThat(sql).hasSize(additive + rollups * 2);
+        assertThat(sql.subList(0, additive))
+                .allSatisfy(s -> assertThat(s).contains("ADD COLUMN IF NOT EXISTS"));
+        assertThat(sql.subList(additive, additive + rollups))
+                .allSatisfy(s -> assertThat(s).startsWith("CREATE TABLE IF NOT EXISTS"));
+        assertThat(sql.subList(additive + rollups, sql.size()))
+                .allSatisfy(s -> assertThat(s).startsWith("CREATE MATERIALIZED VIEW IF NOT EXISTS"));
+    }
+
+    @Test
+    void ensureSharedGrantsEveryRollupToBothRoles() {
+        final List<String> sql = ProvisioningDdl.ensureShared("riptide", 1L);
+        for (final String rollup : FlowsSchema.rollupTableNames()) {
+            final String table = FlowsSchema.qualifiedRollup("riptide", rollup);
+            assertThat(sql).contains("GRANT INSERT ON " + table + " TO flow_writer");
+            assertThat(sql).contains("GRANT SELECT ON " + table + " TO flow_reader");
+        }
+    }
+
+    @Test
+    void writerGetsSelectOnFlowsSoTheRollupViewsCanPush() {
+        // A materialized view runs as the inserting user: without SELECT on the source table the
+        // rollups would silently receive nothing.
+        assertThat(ProvisioningDdl.ensureShared("riptide", 1L))
+                .contains("GRANT SELECT ON `riptide`.flows TO flow_writer");
+    }
+
+    @Test
+    void rowPoliciesCoverFlowsAndEveryRollupWithOneSharedPredicate() {
+        final List<String> sql = ProvisioningDdl.onboardTenant("riptide", "acme", "org1", "w", "r");
+        final List<String> policies = sql.stream().filter(s -> s.contains("ROW POLICY")).toList();
+        assertThat(policies).hasSize(1 + FlowsSchema.rollupTableNames().size());
+        assertThat(policies).allSatisfy(policy -> assertThat(policy)
+                .startsWith("CREATE ROW POLICY OR REPLACE `acme_iso` ON ")
+                .contains("FOR SELECT USING tenant = 'acme'"));
+        // The writer is named on the flows policy (deny-by-default would otherwise starve the
+        // rollup views) but not on the rollups, which it only ever reaches by INSERT.
+        assertThat(policies.getFirst())
+                .contains("ON `riptide`.flows ")
+                .endsWith("TO `bi_acme`, `writer_acme`");
+        assertThat(policies.subList(1, policies.size()))
+                .allSatisfy(policy -> assertThat(policy).endsWith("TO `bi_acme`"));
+    }
+
+    @Test
+    void writerPolicyPredicateMatchesTheTenantPinnedConstraint() {
+        // The policy must not widen what the CHECK barrier already pins, or the writer could read
+        // rows it cannot write.
+        final String constraint = ProvisioningDdl.ensureShared("riptide", 1L).stream()
+                .filter(s -> s.contains("tenant_pinned")).findFirst().orElseThrow();
+        assertThat(constraint).contains("CHECK tenant = getSetting('SQL_tenant')");
+        final String policy = ProvisioningDdl.onboardTenant("riptide", "acme", "org1", "w", "r").stream()
+                .filter(s -> s.contains("ROW POLICY") && s.contains("`riptide`.flows "))
+                .findFirst().orElseThrow();
+        assertThat(policy).contains("USING tenant = 'acme'");
+        assertThat(ProvisioningDdl.onboardTenant("riptide", "acme", "org1", "w", "r"))
+                .anyMatch(s -> s.contains("SETTINGS SQL_tenant = 'acme' CONST"));
+    }
+
+    @Test
+    void offboardDropsThePolicyFromFlowsAndEveryRollup() {
+        // A policy left on a rollup would keep denying rows there after the tenant is gone.
+        final List<String> sql = ProvisioningDdl.offboardTenant("riptide", "acme");
+        assertThat(sql).contains("DROP ROW POLICY IF EXISTS `acme_iso` ON `riptide`.flows");
+        for (final String rollup : FlowsSchema.rollupTableNames()) {
+            assertThat(sql).contains("DROP ROW POLICY IF EXISTS `acme_iso` ON "
+                    + FlowsSchema.qualifiedRollup("riptide", rollup));
+        }
+        assertThat(sql.get(sql.size() - 2)).isEqualTo("DROP USER IF EXISTS `bi_acme`");
+        assertThat(sql.getLast()).isEqualTo("DROP USER IF EXISTS `writer_acme`");
     }
 }

--- a/src/test/java/org/riptide/repository/clickhouse/ClickhouseRepositoryIT.java
+++ b/src/test/java/org/riptide/repository/clickhouse/ClickhouseRepositoryIT.java
@@ -51,6 +51,8 @@ public class ClickhouseRepositoryIT {
         config.setEndpoint("http://" + CLICKHOUSE.getHost() + ":" + CLICKHOUSE.getMappedPort(8123));
         config.setUsername(SecretRef.of("riptide"));
         config.setPassword(SecretRef.of("riptide"));
+        // Read-after-write assertions need synchronous inserts; async has its own test below.
+        config.setAsyncInserts(false);
 
         repository = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), config, RESOLVERS);
         repository.start();
@@ -196,6 +198,31 @@ public class ClickhouseRepositoryIT {
     }
 
     @Test
+    void asyncInsertsDefaultOnInManageModeAndFeedTheRollups() throws Exception {
+        // Manage mode defaults async-inserts on (ClickhouseConfig#isAsyncInserts). The insert is
+        // acknowledged when buffered, so visibility is eventual — the flush is forced here to keep
+        // the test deterministic; production readers poll (dashboards), they do not read-after-write.
+        final var config = configFor("async_mode", true);
+        config.setAsyncInserts(null);
+        Assertions.assertThat(config.isAsyncInserts()).isTrue();
+
+        final var repo = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), config, RESOLVERS);
+        repo.start();
+        repo.persist(List.of(
+                testFlow(Instant.now().truncatedTo(ChronoUnit.MILLIS), 50001, 443, 300L),
+                testFlow(Instant.now().truncatedTo(ChronoUnit.MILLIS), 50002, 443, 700L)));
+
+        queryClient.execute("SYSTEM FLUSH ASYNC INSERT QUEUE").get();
+
+        Assertions.assertThat(queryClient.queryAll("SELECT sum(bytes) AS b FROM async_mode.flows")
+                .getFirst().getLong("b")).isEqualTo(1000L);
+        // The rollup views fire on the coalesced flush, not per client call — totals must conserve.
+        Assertions.assertThat(queryClient.queryAll(
+                        "SELECT sum(bytes) AS b FROM async_mode.flows_by_application_1m")
+                .getFirst().getLong("b")).isEqualTo(1000L);
+    }
+
+    @Test
     void columnCheckFailsFastWhenIdentityColumnMissing() throws Exception {
         final var database = "stale_schema";
         queryClient.execute("CREATE DATABASE IF NOT EXISTS " + database).get();
@@ -303,6 +330,8 @@ public class ClickhouseRepositoryIT {
         config.setPassword(SecretRef.of("riptide"));
         config.setDatabase(database);
         config.setManageSchema(manageSchema);
+        // These tests assert read-after-write; the coalesced path gets its own dedicated test.
+        config.setAsyncInserts(false);
         return config;
     }
 

--- a/src/test/java/org/riptide/repository/clickhouse/ClickhouseRepositoryIT.java
+++ b/src/test/java/org/riptide/repository/clickhouse/ClickhouseRepositoryIT.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.riptide.config.ClickhouseConfig;
 import org.riptide.flows.parser.data.Flow;
 import org.riptide.pipeline.EnrichedFlow;
+import org.riptide.schema.FlowsSchema;
 import org.riptide.secrets.SecretRef;
 import org.riptide.secrets.SecretResolvers;
 import org.testcontainers.containers.GenericContainer;
@@ -150,6 +151,51 @@ public class ClickhouseRepositoryIT {
     }
 
     @Test
+    void rollupsConserveTotalsAndKeepUndirectedTrafficVisible() throws Exception {
+        final var repo = new ClickhouseRepository(
+                new ClickhouseRepository$FlowMapperImpl(), configFor("rollups", true), RESOLVERS);
+        repo.start();
+
+        // Three flows in one minute bucket: one INGRESS, one EGRESS, one UNKNOWN. The UNKNOWN one
+        // is the point — it belongs to neither side of the split, so a rollup that only carried
+        // bytesIn/bytesOut would lose it entirely.
+        final var minute = Instant.now().truncatedTo(ChronoUnit.MINUTES).minus(5, ChronoUnit.MINUTES);
+        final var ingress = testFlow(minute.plusSeconds(5), 40001, 443, 100L);
+        final var egress = testFlow(minute.plusSeconds(20), 40002, 443, 200L);
+        egress.setDirection(Flow.Direction.EGRESS);
+        final var unknown = testFlow(minute.plusSeconds(40), 40003, 443, 800L);
+        unknown.setDirection(Flow.Direction.UNKNOWN);
+        repo.persist(List.of(ingress, egress, unknown));
+
+        final var rawBytes = queryClient.queryAll("SELECT sum(bytes) AS b FROM rollups.flows")
+                .getFirst().getLong("b");
+        Assertions.assertThat(rawBytes).isEqualTo(1100L);
+
+        // Every rollup must conserve the raw totals — no double counting, no dropped rows.
+        for (final String rollup : FlowsSchema.rollupTableNames()) {
+            final var totals = queryClient.queryAll(
+                    "SELECT sum(bytes) AS b, sum(packets) AS p, sum(flowCount) AS c FROM rollups." + rollup)
+                    .getFirst();
+            Assertions.assertThat(totals.getLong("b")).as("%s bytes", rollup).isEqualTo(1100L);
+            Assertions.assertThat(totals.getLong("p")).as("%s packets", rollup).isEqualTo(21L);
+            Assertions.assertThat(totals.getLong("c")).as("%s flow count", rollup).isEqualTo(3L);
+        }
+
+        // The directional split covers only the directed flows; the undirected total covers all.
+        final var split = queryClient.queryAll("SELECT sum(bytesIn) AS in, sum(bytesOut) AS out, "
+                + "sum(bytes) AS total FROM rollups.flows_by_application_1m").getFirst();
+        Assertions.assertThat(split.getLong("in")).isEqualTo(100L);
+        Assertions.assertThat(split.getLong("out")).isEqualTo(200L);
+        Assertions.assertThat(split.getLong("total")).isEqualTo(1100L);
+
+        // All three land in one bucket: toStartOfMinute really is truncating.
+        final var buckets = queryClient.queryAll(
+                "SELECT timestamp, sum(bytes) AS b FROM rollups.flows_by_application_1m GROUP BY timestamp");
+        Assertions.assertThat(buckets).hasSize(1);
+        Assertions.assertThat(buckets.getFirst().getLong("b")).isEqualTo(1100L);
+    }
+
+    @Test
     void columnCheckFailsFastWhenIdentityColumnMissing() throws Exception {
         final var database = "stale_schema";
         queryClient.execute("CREATE DATABASE IF NOT EXISTS " + database).get();
@@ -205,6 +251,13 @@ public class ClickhouseRepositoryIT {
         final var config = configFor(database, true);
         final var repo = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), config, RESOLVERS);
         repo.start();
+
+        // start() created the rollup views, and ClickHouse refuses to DROP a column a materialized
+        // view references (ALTER_OF_COLUMN_IS_FORBIDDEN) — drop the views first so the pre-geo
+        // simulation below can strip the columns. A real pre-geo database has neither.
+        for (final String rollup : FlowsSchema.rollupTableNames()) {
+            queryClient.execute("DROP VIEW IF EXISTS " + FlowsSchema.qualifiedRollupView(database, rollup)).get();
+        }
 
         // Simulate a pre-geo table: keep a persisted row, then drop the geo columns.
         repo.persist(List.of(testFlow(Instant.now().truncatedTo(ChronoUnit.MILLIS), 60001, 443, 100L)));

--- a/src/test/java/org/riptide/repository/clickhouse/TenantOnboardingIT.java
+++ b/src/test/java/org/riptide/repository/clickhouse/TenantOnboardingIT.java
@@ -10,6 +10,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.riptide.config.ClickhouseConfig;
 import org.riptide.provisioning.ProvisioningCommand;
+import org.riptide.schema.FlowsSchema;
 import org.riptide.secrets.SecretRef;
 import org.riptide.secrets.SecretResolvers;
 import org.testcontainers.containers.GenericContainer;
@@ -21,6 +22,7 @@ import org.testcontainers.utility.MountableFile;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.riptide.repository.clickhouse.ClickhouseItFlows.flow;
@@ -188,8 +190,64 @@ public class TenantOnboardingIT {
         }
     }
 
+    @Test
+    void onboardUpgradesAPreRollupPreGeoDatabaseInPlace() throws Exception {
+        // A database provisioned before the geo columns and the rollups existed: the flows table is
+        // perfectly good, so the schema check passes while the rollups are simply absent. This is
+        // the upgrade path for every deployment onboarded before this feature landed.
+        try (var admin = new Client.Builder()
+                .addEndpoint(endpoint()).setUsername("default").setPassword("").build()) {
+            admin.execute(FlowsSchema.createDatabase("legacy")).get();
+            admin.execute(FlowsSchema.createFlowsTable("legacy")).get();
+            for (final String column : FlowsSchema.additiveColumnNames()) {
+                admin.execute("ALTER TABLE legacy.flows DROP COLUMN " + column).get();
+            }
+
+            // Without --create-schema it must refuse, and say why in terms the operator can act on.
+            final var err = new ByteArrayOutputStream();
+            Assertions.assertThat(ProvisioningCommand.run(legacyOnboardArgs(false),
+                    discard(), new PrintStream(err, true, StandardCharsets.UTF_8))).isEqualTo(1);
+            Assertions.assertThat(err.toString(StandardCharsets.UTF_8))
+                    .contains("rollup")
+                    .contains("--create-schema");
+
+            Assertions.assertThat(ProvisioningCommand.run(legacyOnboardArgs(true), discard(), discard())).isZero();
+            for (final String rollup : FlowsSchema.rollupTableNames()) {
+                Assertions.assertThat(exists(admin, FlowsSchema.qualifiedRollup("legacy", rollup))).isTrue();
+                Assertions.assertThat(exists(admin, FlowsSchema.qualifiedRollupView("legacy", rollup))).isTrue();
+            }
+
+            // Half-provisioned is also detected: targets present, views dropped. An interrupted
+            // bootstrap must not read as healthy, or the rollups stay silently empty.
+            for (final String rollup : FlowsSchema.rollupTableNames()) {
+                admin.execute("DROP VIEW " + FlowsSchema.qualifiedRollupView("legacy", rollup)).get();
+            }
+            Assertions.assertThat(ProvisioningCommand.run(legacyOnboardArgs(false), discard(), discard()))
+                    .isEqualTo(1);
+            Assertions.assertThat(ProvisioningCommand.run(legacyOnboardArgs(true), discard(), discard()))
+                    .isZero();
+            for (final String rollup : FlowsSchema.rollupTableNames()) {
+                Assertions.assertThat(exists(admin, FlowsSchema.qualifiedRollupView("legacy", rollup))).isTrue();
+            }
+        }
+    }
+
     private static int onboard(final String tenant, final String org, final String writerPw, final String readerPw) {
         return ProvisioningCommand.run(onboardArgs(tenant, org, writerPw, readerPw), discard(), discard());
+    }
+
+    private static String[] legacyOnboardArgs(final boolean createSchema) {
+        final var args = new ArrayList<>(List.of(
+                "onboard", "--admin-url", endpoint(), "--database", "legacy",
+                "--tenant", "leg", "--org", "leg-eu", "--writer-secret", "wL", "--reader-secret", "rL"));
+        if (createSchema) {
+            args.add("--create-schema");
+        }
+        return args.toArray(String[]::new);
+    }
+
+    private static boolean exists(final Client admin, final String qualifiedName) {
+        return admin.queryAll("EXISTS TABLE " + qualifiedName).getFirst().getLong("result") == 1;
     }
 
     private static String[] onboardArgs(final String tenant, final String org, final String writerPw, final String readerPw) {

--- a/src/test/java/org/riptide/repository/clickhouse/TenantQueryIsolationIT.java
+++ b/src/test/java/org/riptide/repository/clickhouse/TenantQueryIsolationIT.java
@@ -189,6 +189,9 @@ public class TenantQueryIsolationIT {
         config.setUsername(SecretRef.of("default"));
         config.setDatabase(DATABASE);
         config.setManageSchema(true);
+        // The isolation assertions read the seeded rows back immediately; async coalescing is
+        // covered by its own test in ClickhouseRepositoryIT.
+        config.setAsyncInserts(false);
         return config;
     }
 

--- a/src/test/java/org/riptide/repository/clickhouse/TenantWriteBarrierIT.java
+++ b/src/test/java/org/riptide/repository/clickhouse/TenantWriteBarrierIT.java
@@ -89,10 +89,18 @@ public class TenantWriteBarrierIT {
         admin.execute("CREATE USER writer_acme IDENTIFIED WITH no_password "
                 + "SETTINGS SQL_tenant = 'acme' CONST, SQL_org = 'acme-eu' CONST").get();
         admin.execute("GRANT INSERT ON " + DATABASE + ".flows TO writer_acme").get();
+        // Writers also read flows (materialized views run as the inserting user), so they need
+        // SELECT and their own row policy — mirroring what onboard provisions.
+        admin.execute("GRANT SELECT ON " + DATABASE + ".flows TO writer_acme").get();
+        admin.execute("CREATE ROW POLICY acme_write ON " + DATABASE + ".flows "
+                + "FOR SELECT USING tenant = 'acme' TO writer_acme").get();
 
         admin.execute("CREATE USER writer_other IDENTIFIED WITH no_password "
                 + "SETTINGS SQL_tenant = 'other' CONST, SQL_org = 'other-eu' CONST").get();
         admin.execute("GRANT INSERT ON " + DATABASE + ".flows TO writer_other").get();
+        admin.execute("GRANT SELECT ON " + DATABASE + ".flows TO writer_other").get();
+        admin.execute("CREATE ROW POLICY other_write ON " + DATABASE + ".flows "
+                + "FOR SELECT USING tenant = 'other' TO writer_other").get();
 
         // Readonly reader for tenant acme, isolated to its own rows by a row policy.
         admin.execute("CREATE USER reader_acme IDENTIFIED WITH no_password").get();

--- a/src/test/java/org/riptide/repository/clickhouse/TimestampTimezoneIT.java
+++ b/src/test/java/org/riptide/repository/clickhouse/TimestampTimezoneIT.java
@@ -59,6 +59,8 @@ public class TimestampTimezoneIT {
             config.setEndpoint(endpoint);
             config.setUsername(SecretRef.of("riptide"));
             config.setPassword(SecretRef.of("riptide"));
+            // Read-after-write assertion; async coalescing has its own test in ClickhouseRepositoryIT.
+            config.setAsyncInserts(false);
 
             // Build the repository after the zone change so its client picks it up.
             final var repository = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), config, RESOLVERS);

--- a/src/test/java/org/riptide/schema/FlowsSchemaTest.java
+++ b/src/test/java/org/riptide/schema/FlowsSchemaTest.java
@@ -7,6 +7,8 @@ package org.riptide.schema;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -14,6 +16,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * The flow schema DDL is the single source shared by the collector's manage path and {@code
  * onboard}, so the load-bearing properties are that it is database-qualified (works on an unpinned
  * client), idempotent, and that the {@code samples} view still references the same qualified table.
+ *
+ * <p>The rollups add a second set: the dimension/measure split must line up exactly with the
+ * {@code SummingMergeTree} sort key, and their column names and time semantics must match the raw
+ * table closely enough that a query ports between the two.
  */
 class FlowsSchemaTest {
 
@@ -77,6 +83,100 @@ class FlowsSchemaTest {
     }
 
     @Test
+    void rollupTablesSummingEveryDimensionIntoTheSortKey() {
+        // SummingMergeTree collapses rows that agree on the sort key, summing the rest. That is
+        // only correct if the split is exact: every dimension in the key, every measure out of it.
+        final List<String> measures =
+                List.of("bytes", "packets", "flowCount", "bytesIn", "bytesOut", "packetsIn", "packetsOut");
+        for (final String ddl : FlowsSchema.createRollupTables("riptide")) {
+            assertThat(ddl).contains("ENGINE = SummingMergeTree()");
+            final String sortKey = between(ddl, "ORDER BY (", ")");
+            for (final String column : columnsOf(ddl)) {
+                if (measures.contains(column)) {
+                    assertThat(sortKey).as("measure %s must not be in the sort key", column)
+                            .doesNotContain(column);
+                } else {
+                    assertThat(sortKey).as("dimension %s must be in the sort key of %s", column, ddl)
+                            .contains(column);
+                }
+            }
+        }
+    }
+
+    @Test
+    void rollupViewsQualifyEverySourceReference() {
+        // Every expression is alias-qualified, so the view never depends on name resolution against
+        // the source table — an unqualified sum(bytes) would break the moment a column is added.
+        for (final String ddl : FlowsSchema.createRollupViews("riptide")) {
+            assertThat(ddl)
+                    .contains("FROM `riptide`.flows AS f")
+                    .contains("sum(f.bytes) AS bytes")
+                    .contains("sumIf(f.bytes, f.direction = 'INGRESS') AS bytesIn")
+                    .doesNotContain("sum(bytes)")
+                    .doesNotContain("sumIf(bytes");
+        }
+    }
+
+    @Test
+    void rollupsKeepUndirectedTotalsAlongsideTheDirectionSplit() {
+        // A query that does not care about direction should not have to add bytesIn + bytesOut.
+        assertThat(FlowsSchema.createRollupViews("riptide").getFirst())
+                .contains("sum(f.bytes) AS bytes")
+                .contains("sum(f.packets) AS packets")
+                .contains("count() AS flowCount");
+    }
+
+    @Test
+    void rollupTimeColumnMatchesTheRawTableSoTimeFilterPortsUnchanged() {
+        // Same column name as flows, truncated to the minute: a WHERE on timestamp moves between
+        // raw and rollup without rewriting.
+        assertThat(FlowsSchema.createRollupTables("riptide").getFirst())
+                .contains("timestamp DateTime('UTC')")
+                .contains("PARTITION BY toYYYYMM(timestamp)");
+        assertThat(FlowsSchema.createRollupViews("riptide").getFirst())
+                .contains("toStartOfMinute(f.timestamp) AS timestamp");
+    }
+
+    @Test
+    void rollupApplicationIsNonNullableBecauseItIsASortKey() {
+        // application is Nullable(String) on flows; folded to '' on the way in so the sort key —
+        // and therefore the SummingMergeTree collapse — never depends on null comparison.
+        assertThat(FlowsSchema.createRollupTables("riptide").getFirst())
+                .contains("application LowCardinality(String)");
+        assertThat(FlowsSchema.createRollupViews("riptide").getFirst())
+                .contains("ifNull(f.application, '') AS application");
+    }
+
+    @Test
+    void rollupDdlIsQualifiedIdempotentAndOrderedTargetsBeforeViews() {
+        assertThat(FlowsSchema.rollupTableNames()).containsExactly(
+                "flows_by_application_1m",
+                "flows_by_conversation_1m",
+                "flows_by_exporter_iface_1m",
+                "flows_by_geo_asn_1m");
+        assertThat(FlowsSchema.createRollupTables("acme_prod")).allSatisfy(ddl ->
+                assertThat(ddl).startsWith("CREATE TABLE IF NOT EXISTS `acme_prod`."));
+        assertThat(FlowsSchema.createRollupViews("acme_prod")).allSatisfy(ddl ->
+                assertThat(ddl).startsWith("CREATE MATERIALIZED VIEW IF NOT EXISTS `acme_prod`.")
+                        .contains(" TO `acme_prod`."));
+        assertThat(FlowsSchema.qualifiedRollup("acme_prod", "flows_by_application_1m"))
+                .isEqualTo("`acme_prod`.flows_by_application_1m");
+        assertThat(FlowsSchema.qualifiedRollupView("acme_prod", "flows_by_application_1m"))
+                .isEqualTo("`acme_prod`.flows_by_application_1m_mv");
+    }
+
+    @Test
+    void rollupTtlIsParameterizedAndOutlivesTheRawTable() {
+        assertThat(FlowsSchema.createRollupTables("riptide", 90).getFirst())
+                .contains("TTL timestamp + INTERVAL 90 DAY");
+        assertThat(FlowsSchema.createRollupTables("riptide").getFirst())
+                .contains("TTL timestamp + INTERVAL 365 DAY");
+        // The rollups exist so long-range queries survive the raw table's expiry — which only
+        // works while the rollup retention is the longer of the two.
+        assertThat(FlowsSchema.DEFAULT_ROLLUP_TTL_DAYS).isGreaterThan(FlowsSchema.DEFAULT_TTL_DAYS);
+    }
+
+    @Test
     void identRejectsUnsafeDatabaseNames() {
         // The collector's riptide.clickhouse.database binds without validation, so the quoting
         // site enforces the charset — a backtick must fail clearly, not emit malformed DDL.
@@ -87,5 +187,22 @@ class FlowsSchemaTest {
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> FlowsSchema.createSamplesView(""))
                 .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> FlowsSchema.createRollupTables("a b"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> FlowsSchema.createRollupViews("a'b"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    /** The column names of a CREATE TABLE body, in declaration order. */
+    private static List<String> columnsOf(final String ddl) {
+        return between(ddl, "(\n", "\n) ENGINE").lines()
+                .map(line -> line.strip().split(" ")[0])
+                .filter(name -> !name.isEmpty())
+                .toList();
+    }
+
+    private static String between(final String text, final String open, final String close) {
+        final int from = text.indexOf(open) + open.length();
+        return text.substring(from, text.indexOf(close, from));
     }
 }


### PR DESCRIPTION
Closes #308

Four `SummingMergeTree` rollups fed by materialized views on `flows` — `flows_by_application_1m`, `flows_by_conversation_1m`, `flows_by_exporter_iface_1m`, `flows_by_geo_asn_1m` — with the tenant/organisation/timestamp/zone preamble, undirected totals alongside the in/out split (so `direction = UNKNOWN` traffic is never lost), and 365-day retention against the raw table's 30.

Provisioning treats rollups as first-class: grants, row policies and offboard teardown all iterate `rollupTableNames()`. The writer role gains `SELECT` on `flows` + a place on its row policy (MVs run as the inserting user; policies are deny-by-default), predicate identical to `tenant_pinned`. Policies move to `OR REPLACE` so re-runs reconcile the `TO` list. `onboard --create-schema` is also the upgrade path for pre-rollup databases, with a target-**and**-view existence check so an interrupted bootstrap is detected.

## Provenance

This reconstructs an implementation lost from an uncommitted working tree (my `git reset --hard`, disclosed earlier). Recovery: CFR-decompiled the surviving `target/` bytecode. Verification of equivalence:
- the **original compiled test suite** passes against the reconstructed sources (732 unit tests, 0 failures)
- full ClickHouse IT tier green: `ClickhouseRepositoryIT` 10/10, `TenantWriteBarrierIT` 4/4, `TenantOnboardingIT` 7/7 (real ClickHouse 25.3 via Testcontainers)
- order-insensitive diff of decompiled-reconstruction vs decompiled-original: no semantic difference across all 10 Java files

Comments and the two docs pages are **re-authored, not recovered** — review them as new prose.

## Review (high) — run before this PR; notable outcomes

- **Caught & fixed:** my reconstruction had missed a body change in `geoColumnsPersistAndPreGeoTableUpgradesInPlace` (the original drops the rollup MVs before dropping geo columns; without it the IT fails with `ALTER_OF_COLUMN_IS_FORBIDDEN`). Found empirically, restored from bytecode.
- **Caught & fixed (docs):** two stale sentences contradicting the `OR REPLACE` policy behavior and the per-table policy fan-out; plus a new warning that `--ttl-days > 365` inverts the aggregates-outlive-raw invariant (rollup TTL stays 365 — a `max()` clamp is a possible code follow-up, left out to stay faithful to the recovered design).
- **Reported, not changed** (faithful to original): `SOURCE_ALIAS` half-applied; additive-column ALTERs emitted twice per `--create-schema` run (idempotent); no negative test that the writer cannot read other tenants' rows; rollup definitions have no staleness check (`IF NOT EXISTS`) unlike the samples view — first rollup schema change will need a migration story.
- **Refuted with evidence:** `AS in` alias concern (IT passes on 25.3), `OR REPLACE` privilege/version concerns (checked ClickHouse 23.8+ source), write-barrier under-provisioning (ITs pass).

Verification: `mvn verify` exit 0 (units + checkstyle/SpotBugs/Error Prone/coverage), `make docs` exit 0 (broken-link check on), full e2e tier green locally.