### PR TITLE
chore(dashboards): remove third-party vendor name from dashboards and docs

### DIFF
--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-host-investigation.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-host-investigation.json
@@ -1,11 +1,11 @@
 {
   "uid": "riptide-host-investigation",
-  "title": "Riptide - Host Investigation (Kentik-style)",
+  "title": "Riptide - Host Investigation",
   "tags": [
     "riptide",
     "netflow",
     "security",
-    "kentik"
+    "host-investigation"
   ],
   "timezone": "browser",
   "schemaVersion": 39,
@@ -175,7 +175,7 @@
     {
       "type": "timeseries",
       "title": "Traffic to / from $host",
-      "description": "The IP details page's Traffic tab and the forensics walkthrough's 'bidirectional mode': inbound vs outbound volume for one host. https://kb.kentik.com/docs/core-details-pages",
+      "description": "Bidirectional volume: inbound vs outbound traffic for one host.",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
         "uid": "${datasource}"
@@ -217,7 +217,7 @@
     {
       "type": "timeseries",
       "title": "Unique peers",
-      "description": "Kentik's primary distributed-source/scanning signal (alert details 'unique source IPs'; attack-hunting walkthrough). A jump in inbound peers = scan/DDoS; outbound = the host scanning or beaconing. https://kb.kentik.com/docs/alert-details",
+      "description": "Unique-peers signal for distributed sources and scanning. A jump in inbound peers = scan/DDoS; outbound = the host scanning or beaconing.",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
         "uid": "${datasource}"
@@ -259,7 +259,7 @@
     {
       "type": "timeseries",
       "title": "TCP flag profile",
-      "description": "Scan signature per the Data Explorer TCP-flags dimension: SYN-only flows (connection attempts that never established) vs flows that saw an ACK. A SYN-only surge inbound is a port scan; outbound, the host probing others. https://kb.kentik.com/docs/data-explorer",
+      "description": "Scan signature via TCP flags: SYN-only flows (connection attempts that never established) vs flows that saw an ACK. A SYN-only surge inbound is a port scan; outbound, the host probing others.",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
         "uid": "${datasource}"
@@ -301,7 +301,7 @@
     {
       "type": "table",
       "title": "Top peers",
-      "description": "The traffic-patterns pivot: who this host talks to, labeled with hostname, geo and AS (enrichment columns), with per-direction volume and how many distinct services were touched \u2014 many ports against one peer = probing (forensics walkthrough). https://kb.kentik.com/docs/core-details-pages",
+      "description": "Traffic patterns: who this host talks to, labeled with hostname, geo and AS (enrichment columns), with per-direction volume and how many distinct services were touched \u2014 many ports against one peer = probing.",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
         "uid": "${datasource}"
@@ -343,7 +343,7 @@
     {
       "type": "table",
       "title": "Top services",
-      "description": "The source-services alert tab: which protocols/ports carry this host's traffic, and how many peers share each \u2014 single-port concentration across many peers is the DDoS/abuse fingerprint. https://kb.kentik.com/docs/alert-details",
+      "description": "Source services: which protocols/ports carry this host's traffic, and how many peers share each \u2014 single-port concentration across many peers is the DDoS/abuse fingerprint.",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
         "uid": "${datasource}"
@@ -385,7 +385,7 @@
     {
       "type": "table",
       "title": "Packet size distribution",
-      "description": "The packet-size alert tab: uniform small packets across high flow counts betray floods and botnets; legitimate traffic spreads. https://kb.kentik.com/docs/alert-details",
+      "description": "Packet-size signal: uniform small packets across high flow counts betray floods and botnets; legitimate traffic spreads.",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
         "uid": "${datasource}"
@@ -427,7 +427,7 @@
     {
       "type": "table",
       "title": "Peer countries",
-      "description": "The source-countries alert tab, via riptide's GeoIP columns: countries ranked by unique peers and volume \u2014 geo anomalies flag distributed attacks. https://kb.kentik.com/docs/alert-details",
+      "description": "Source countries, via riptide's GeoIP columns: countries ranked by unique peers and volume \u2014 geo anomalies flag distributed attacks.",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
         "uid": "${datasource}"
@@ -469,7 +469,7 @@
     {
       "type": "table",
       "title": "Peer ASes",
-      "description": "The top-ASes table from Botnet & Threat Analysis, minus the threat feed: which networks this host exchanges traffic with. https://kb.kentik.com/docs/botnet-threat-analysis",
+      "description": "Top ASes: which networks this host exchanges traffic with.",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
         "uid": "${datasource}"

--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-traffic-paths.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-traffic-paths.json
@@ -1,10 +1,10 @@
 {
-  "uid": "riptide-kentik-sankey",
-  "title": "Riptide - Kentik-style Traffic Paths (Sankey)",
+  "uid": "riptide-traffic-paths",
+  "title": "Riptide - Traffic Paths (Sankey)",
   "tags": [
     "riptide",
     "netflow",
-    "kentik"
+    "traffic-paths"
   ],
   "timezone": "browser",
   "schemaVersion": 39,
@@ -176,7 +176,7 @@
     {
       "type": "netsage-sankey-panel",
       "title": "Peering: Source AS - Ingress - Egress - Destination AS",
-      "description": "Replicates Kentik's Discover Peers Sankey and the 'cost per customer' chain (customer \u2192 ingress interface \u2192 egress interface \u2192 adjacent ASN). https://kb.kentik.com/docs/discover-peers",
+      "description": "Peering analysis: the cost-per-customer chain (customer \u2192 ingress interface \u2192 egress interface \u2192 adjacent ASN).",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
         "uid": "${datasource}"
@@ -206,7 +206,7 @@
     {
       "type": "netsage-sankey-panel",
       "title": "Situational awareness: Source Country - Source AS - Exporter - Destination host - Service",
-      "description": "Replicates Kentik's DDoS situational-awareness chain (Source Country \u2192 Source ASN \u2192 Destination IP \u2192 Destination Protocol), with the observing exporter as the middle column. https://www.kentik.com/blog/insight-delivered-the-power-of-sankey-diagrams/",
+      "description": "DDoS situational awareness: Source Country \u2192 Source ASN \u2192 Destination IP \u2192 Destination Protocol, with the observing exporter as the middle column.",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
         "uid": "${datasource}"
@@ -236,7 +236,7 @@
     {
       "type": "netsage-sankey-panel",
       "title": "Geo termination: Exporter - Destination AS - Destination Country - Destination City",
-      "description": "Replicates Kentik's geo-planning chain (Dest Country \u2192 Dest Region \u2192 Dest City); riptide carries country and city, led by the observing exporter and destination AS. https://www.kentik.com/blog/insight-delivered-the-power-of-sankey-diagrams/",
+      "description": "Geo capacity planning: Dest Country \u2192 Dest Region \u2192 Dest City; riptide carries country and city, led by the observing exporter and destination AS.",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
         "uid": "${datasource}"
@@ -266,7 +266,7 @@
     {
       "type": "netsage-sankey-panel",
       "title": "Origination/termination: Source City - Source Locality - Exporter - Destination Locality - Destination City",
-      "description": "Replicates the Data Explorer example chain (Source City \u2192 Source Traffic Origination \u2192 Destination Traffic Termination \u2192 Destination City), with riptide's locality as the origination/termination analog and the exporter at the waist. https://kb.kentik.com/docs/chart-visualization-types",
+      "description": "Origination/termination flow: Source City \u2192 Source Traffic Origination \u2192 Destination Traffic Termination \u2192 Destination City, with riptide's locality as the origination/termination analog and the exporter at the waist.",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
         "uid": "${datasource}"
@@ -296,7 +296,7 @@
     {
       "type": "netsage-sankey-panel",
       "title": "Ultimate Exit: Ingress - Egress - Destination AS",
-      "description": "Replicates Kentik's Ultimate Exit Sankey (Entry Site \u2192 Exit Site \u2192 Destination AS), mapped to riptide's ingress/egress interfaces. https://kb.kentik.com/docs/using-ultimate-exit",
+      "description": "Entry-to-exit paths: Entry Site \u2192 Exit Site \u2192 Destination AS, mapped to riptide's ingress/egress interfaces.",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
         "uid": "${datasource}"

--- a/docs/docs/deploy/docker-compose.md
+++ b/docs/docs/deploy/docker-compose.md
@@ -28,7 +28,7 @@ Grafana (admin/admin) ships two provisioned dashboards backed by the `flows` tab
 
 - **Riptide - Top 10**: stacked top-10 rate panels (AS, hosts, applications, services, protocols,
   exporters, interfaces) plus a source-AS statistics table with a 95th-percentile column.
-- **Riptide - Traffic Paths (Sankey)**: Kentik-style path diagrams (source AS → ingress
+- **Riptide - Traffic Paths (Sankey)**: path diagrams (source AS → ingress
   interface → application → destination AS, and more), weighted by bytes over the selected range.
 
 The JSON sources live in `deployment/clickhouse/container-fs/grafana/provisioning/dashboards/`.


### PR DESCRIPTION
Closes #314

- Dashboard titles: `Riptide - Traffic Paths (Sankey)` and `Riptide - Host Investigation` (vendor qualifier dropped)
- File + uid rename: the vendor-named dashboard file → `riptide-traffic-paths.json` (no cross-references existed; the compose docs already use the plain title). Note the uid change gives the provisioned dashboard a new identity in Grafana — old bookmarks re-open via the dashboard list.
- 13 panel descriptions rewritten to describe the analytical signal on its own terms (unique-peers, TCP-flag scan signature, packet-size, geo/ASN chains, …) instead of citing the vendor's docs
- Tags: `kentik` → `traffic-paths` / `host-investigation`
- One line in `docker-compose.md`

`grep -ri kentik` over the tree: zero matches; both JSONs parse.

GitHub metadata (PR titles/bodies, one issue comment) is being edited in place separately — commit messages on `main` are a follow-up decision.
