### PR TITLE
chore(security): remediate Scorecard findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,15 @@ updates:
       prefix: "ci"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "docker" # keeps the digest-pinned base image of the main Dockerfile current
+    directory: "/"
+    target-branch: "main"
+    labels:
+      - "dependency update"
+    commit-message:
+      prefix: "build"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "docker" # nfpm pin used by `make packages` (Dockerfile.nfpm)
     directory: "/deployment/package"
     target-branch: "main"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,12 +5,13 @@ name: CodeQL
 run-name: CodeQL security and quality analysis
 on:
   workflow_dispatch:
+  # No paths-ignore: Scorecard's SAST check counts commits CodeQL analyzed, and a docs-only
+  # commit slipping through unscanned dings every subsequent scan. The java analysis of an
+  # unchanged tree costs ~2 minutes — cheaper than the standing alert.
   push:
     branches: [ 'main' ]
-    paths-ignore: [ 'docs/**' ]
   pull_request:
     branches: [ 'main' ]
-    paths-ignore: [ 'docs/**' ]
   schedule:
     - cron: '31 5 * * 1' # weekly, Monday morning
 

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -11,7 +11,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 # Only the newest main commit needs to be :rc — cancel the ones it overtook.
 concurrency:
@@ -24,6 +23,9 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     timeout-minutes: 45
+    permissions:
+      contents: read    # job-level block replaces the top-level one — checkout still needs this
+      packages: write   # push the :rc image to GHCR
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM eclipse-temurin:25-alpine
+# Digest-pinned (Scorecard PinnedDependencies); Dependabot's docker ecosystem keeps it current.
+FROM eclipse-temurin:25-alpine@sha256:5ecfde8e5ecde5954ea3721155b345ef56c1d579b940c761318ad4c05959a151
 
 ARG VERSION
 ARG GIT_SHORT_HASH

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -48,7 +48,7 @@ maven.buildMavenPackage {
 
   # Verified for the pinned nixpkgs rev (spike A.1). Regenerate with lib.fakeHash
   # whenever pom dependencies change; the nix CI job fails the PR if it drifts.
-  mvnHash = "sha256-hMSxT2fTaSCW+xI1p02gfFZoHXmDJ4L937WwL6iOo4o=";
+  mvnHash = "sha256-gSdcxPZFTv8U7crHzCBeBMWSW+6FIdDu6GEs+1+cB7E=";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,20 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- Transitive-CVE pins (Scorecard/osv-scanner findings). Neither library is on a
+                 reachable path — riptide has no STOMP endpoint (GHSA-vhch-2wf3-m8rp) and Jackson
+                 only rides in with Spring (GHSA-5jmj-h7xm-6q6v) — pinned to the patched versions
+                 anyway. Drop each pin once the managing parent/netty-all catches up. -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.21.5</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-stomp</artifactId>
+                <version>4.2.16.Final</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Closes #317 — Phase 1 of the code-scanning plan.

| Alert | Fix | Verified |
|---|---|---|
| #120 known vulnerabilities | `jackson-databind` → 2.21.5, `netty-codec-stomp` → 4.2.16.Final via `dependencyManagement` | `dependency:tree` shows both patched versions; `mvn verify` exit 0 |
| #115 unpinned base image | `eclipse-temurin:25-alpine@sha256:5ecfde8e…` + Dependabot docker ecosystem for `/` so the digest stays current | digest taken from the live registry tag |
| #114 top-level `packages: write` | moved to job level in `publish-rc.yml`; top level is `contents: read` | `make lint-actions` exit 0 |
| #119 SAST coverage 12/13 | dropped `docs/**` `paths-ignore` from CodeQL | every commit now analyzed |

Exploitability context for #120: the Netty advisory is a DoS in the **STOMP** decoder — riptide has no STOMP surface; the Jackson bypass needs `@JsonIgnoreProperties`-guarded deserialization of attacker JSON — Jackson only rides in with Spring. Pinned anyway; the pins are documented to be dropped when netty-all/Spring Boot catch up.

Alerts #112/#113/#116 are dismissed separately as won't-fix with reasons (single-maintainer constraints; release upload needs `contents: write`).