### PR TITLE
build(nix): automate mvnHash regeneration and surface it in CI

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -36,8 +36,30 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
       - name: Build the package
+        id: build
         run: |
           make nix
+      # A stale mvnHash after a pom change is the usual failure here. Surface the expected hash and
+      # the one-command fix in the job summary so it is a glance, not a log dig — see #324.
+      - name: Explain a hash mismatch
+        if: failure() && steps.build.outcome == 'failure'
+        run: |
+          got="$(make nix 2>&1 | grep -oE 'got:\s+sha256-[A-Za-z0-9+/=]+' | grep -oE 'sha256-[A-Za-z0-9+/=]+' | head -1 || true)"
+          {
+            echo "### Nix build failed"
+            if [ -n "${got}" ]; then
+              echo "The maven-deps hash in \`nix/package.nix\` is stale (a pom change moved it)."
+              echo ""
+              echo "Fix it with **\`make nix-hash\`**, or set \`mvnHash\` to:"
+              echo ""
+              echo "\`\`\`"
+              echo "${got}"
+              echo "\`\`\`"
+            else
+              echo "No hash mismatch detected — check the build log above for the real cause."
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+          exit 1
       - name: Run flake checks
         run: |
           make nix-check

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ help:
 	@echo "  packages-smoke: Install the packages in Debian and Rocky containers and smoke-test them (requires Docker)"
 	@echo "  nix:          Build the flake package from source (requires Nix)"
 	@echo "  nix-check:    Run the flake checks incl. the NixOS module eval (requires Nix)"
+	@echo "  nix-hash:     Regenerate nix/package.nix's mvnHash after a pom change (requires Nix)"
 	@echo "  coverage:     Run the unit test suite and render the JaCoCo coverage report"
 	@echo "  e2e:          Run integration and e2e tests (*IT, requires Docker) in addition to the unit suite"
 	@echo "  fuzz:         Coverage-guided fuzzing of the flow parsers (Jazzer); FUZZ_TIME=<seconds> per target"
@@ -151,6 +152,23 @@ nix: deps-nix
 .PHONY: nix-check
 nix-check: deps-nix
 	nix flake check --print-build-logs
+
+# Regenerate nix/package.nix's mvnHash after a pom change. Forces the fixed-output maven-deps
+# derivation to the fake-hash sentinel so the build reports the real hash, then writes it back.
+# Idempotent: run it whether or not the hash is stale. sed -i.bak works on both GNU and BSD sed.
+NIX_FAKE_HASH := sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+.PHONY: nix-hash
+nix-hash: deps-nix
+	@echo "Forcing the sentinel hash to read back the real one..."
+	@sed -i.bak -E 's|mvnHash = "sha256-[^"]*";|mvnHash = "$(NIX_FAKE_HASH)";|' nix/package.nix
+	@got=$$(nix build .#default --no-link 2>&1 | grep -oE 'sha256-[A-Za-z0-9+/=]{44}' | grep -v '$(NIX_FAKE_HASH)' | head -1); \
+	if [ -z "$$got" ]; then \
+		echo "No hash reported — the build did not fail on a mismatch. Restoring."; \
+		mv nix/package.nix.bak nix/package.nix; exit 1; \
+	fi; \
+	sed -i.bak2 -E "s|mvnHash = \"sha256-[^\"]*\";|mvnHash = \"$$got\";|" nix/package.nix; \
+	rm -f nix/package.nix.bak nix/package.nix.bak2; \
+	echo "mvnHash = $$got"
 
 .PHONY: release
 release:

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -46,8 +46,9 @@ maven.buildMavenPackage {
   # git-commit-id plugin reads .git, which is not part of the store source.
   mvnParameters = "-Dmaven.gitcommitid.skip=true";
 
-  # Verified for the pinned nixpkgs rev (spike A.1). Regenerate with lib.fakeHash
-  # whenever pom dependencies change; the nix CI job fails the PR if it drifts.
+  # Fixed-output hash of the maven dependency set. Regenerate with `make nix-hash` whenever the
+  # pom changes; the nix CI job fails the PR if it drifts and prints the expected hash in its
+  # job summary.
   mvnHash = "sha256-jNOhE9uMFwLq1VUaEwLauNlVYSECMjPZewvulPJrkIE=";
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
Closes #324

Three PRs in a row (#310, #318, #323) needed a hand-copied `mvnHash` after a pom change. This removes the toil without losing the loud-fail safety property:

- **`make nix-hash`** — forces the fake-hash sentinel, reads the real hash back from the build's mismatch, writes it into `nix/package.nix`. Idempotent (run it stale or not), GNU/BSD-sed safe.
- **CI surfacing** — the `nix` job now prints the expected hash and `make nix-hash` into the step summary on failure, so it's visible without opening the log.
- Comment in `nix/package.nix` updated to point at `make nix-hash` (was the dangling "regenerate with lib.fakeHash" with no tooling behind it).

**Validation:** no local Nix here, so the target itself is CI-proven (consistent with e2e/fuzz). This PR touches `nix/**`, so the `nix` job runs — with the current (correct) hash unchanged, it exercises the happy path and the new step's YAML. The failure-surfacing branch only fires on an actual stale hash; its logic is plain shell. `make lint-actions` passes; the target parses (`make -n nix-hash`).

Rejected alternative (in the commit + issue): auto-committing the hash from CI — Dependabot's restricted token can't push back, and it adds a `contents: write` surface for little gain.