### PR TITLE
build(docs): bump fast-uri to 3.1.4 (GHSA-v2hh-gcrm-f6hx)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9426,9 +9426,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Closes #327 — Dependabot alert #11 (high).

`fast-uri` 3.1.3 → 3.1.4 in `docs/package-lock.json`, transitive via `ajv` (`^3.0.1`, so an in-range lockfile-only bump — no `package.json` change). It's a docs-site build dependency, not in the shipped application, but it's high severity so cleared now rather than waiting on the weekly Dependabot run.

Diff is 3 lines (version, resolved URL, integrity). `make docs` builds clean on the updated lock (`npm ci` + Docusaurus build, exit 0).