### PR TITLE
build(docs): bump react and react-dom together to 19.2.8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,6 +59,12 @@ updates:
       docusaurus:
         patterns:
           - "@docusaurus/*"
+      # react and react-dom must move together — Docusaurus fails the build if their versions
+      # differ, so a split bump (one PR each) leaves both PRs red. Group them into one.
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
     ignore:
       # TS 7 removed baseUrl, which @docusaurus/tsconfig still sets; blocked
       # until the Docusaurus toolchain supports TypeScript 7 (see PR #171).

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -13,8 +13,8 @@
         "@docusaurus/preset-classic": "3.10.2",
         "@mdx-js/react": "^3.1.1",
         "prism-react-renderer": "^2.4.1",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4"
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "3.10.2",
@@ -16501,24 +16501,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-fast-compare": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,8 +15,8 @@
     "@docusaurus/preset-classic": "3.10.2",
     "@mdx-js/react": "^3.1.1",
     "prism-react-renderer": "^2.4.1",
-    "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.10.2",


### PR DESCRIPTION
Supersedes #320 and #321.

Dependabot split the 19.2.7 → 19.2.8 bump into two PRs (react in #320, react-dom in #321), but Docusaurus fails the build unless `react` and `react-dom` are the **exact** same version — so each was red alone ("Incompatible React versions"). This bumps both in one commit.

Also adds a `react` group to `.github/dependabot.yml` so the next react/react-dom bump comes as one PR, not a red pair — same reason the `@docusaurus/*` group already exists.

`make docs` builds clean; `dependabot.yml` parses.