### PR TITLE
docs: state the tests-with-the-change policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ In short:
 - [Run & debug](https://riptide.space/docs/develop/run-and-debug) — local stack, pcap replay, nl6
 - [Testing](https://riptide.space/docs/develop/testing) — unit / e2e / full-mode tiers
 - [Pull requests](https://riptide.space/docs/develop/pull-requests) — CI quality gates,
-  **DCO sign-off (`git commit -s`)**, Conventional Commits
+  **tests land with the change**, **DCO sign-off (`git commit -s`)**, Conventional Commits
 
 ## Working from an issue
 

--- a/docs/docs/develop/pull-requests.md
+++ b/docs/docs/develop/pull-requests.md
@@ -21,6 +21,15 @@ Every PR must pass, all wired through `make` in CI:
 
 Run the Maven-side gates locally before pushing: `make` (= `mvn verify`).
 
+## Tests are part of the change
+
+**New functionality lands with tests, and a bug fix lands with a test that fails without it.**
+A PR that adds behaviour without covering it — or fixes a bug without a regression test — will be
+asked to add one before merge. The coverage floor above is a backstop, not the policy: it catches
+a shortfall in aggregate but does not excuse an untested feature. Match the tier to the change —
+a unit test for pure logic, an `*IT` against real ClickHouse for the repository layer, an e2e/nl6
+case for the ingestion path, a fuzz seed for a parser edge case.
+
 ## Commits
 
 - **Conventional Commits**: `<type>[scope]: <description>` — `feat`, `fix`, `docs`,


### PR DESCRIPTION
Adds an explicit "tests land with the change" section to the pull-requests doc, and a pointer in CONTRIBUTING.

The repo already operates this way (the coverage floor is a backstop, not the policy) — this documents it so the OpenSSF Best Practices `test_policy` criterion has a URL to cite. With this, the passing tier is satisfied bar the two self-attestation ticks (`know_secure_design`, `know_common_errors`).

Docs-only; no code or gates touched.

Closes #333