### PR TITLE
fix(dns): honor cached negative results in reverse lookups

### DIFF
--- a/src/main/java/org/riptide/dns/netty/NettyDnsResolver.java
+++ b/src/main/java/org/riptide/dns/netty/NettyDnsResolver.java
@@ -64,9 +64,9 @@ public class NettyDnsResolver implements DnsResolver, DisposableBean {
         if (inetAddress == null) return CompletableFuture.completedFuture(Optional.empty());
         final var reverseMapName = ReverseMap.fromAddress(inetAddress).toString();
         final var cachedEntry = reverseCache.getIfPresent(reverseMapName);
-        if (cachedEntry != null && cachedEntry.isPresent()) {
-            log.info("cache hit for: {}", reverseMapName);
-            return CompletableFuture.completedFuture(Optional.of(cachedEntry.get().getCleanedHostname()));
+        if (cachedEntry != null) {
+            log.debug("cache hit for: {}", reverseMapName);
+            return CompletableFuture.completedFuture(cachedEntry.map(DnsReverseCacheEntry::getCleanedHostname));
         }
         return performReverseLookup(reverseMapName);
     }

--- a/src/main/java/org/riptide/dns/netty/NettyDnsResolverWorker.java
+++ b/src/main/java/org/riptide/dns/netty/NettyDnsResolverWorker.java
@@ -69,7 +69,11 @@ class NettyDnsResolverWorker {
                             resultFuture.complete(Optional.empty());
                         }
                     } else {
-                        parent.reverseCache.put(reverseMapName, Optional.empty());
+                        // Only NXDOMAIN is a cacheable negative answer (RFC 2308); transient
+                        // failures like SERVFAIL must not suppress lookups for the TTL window.
+                        if (DnsResponseCode.NXDOMAIN.equals(dnsResponse.code())) {
+                            parent.reverseCache.put(reverseMapName, Optional.empty());
+                        }
                         resultFuture.complete(Optional.empty());
                     }
                 } finally {

--- a/src/test/java/org/riptide/dns/MockDnsServer.java
+++ b/src/test/java/org/riptide/dns/MockDnsServer.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.springframework.util.function.ThrowingFunction;
 import org.xbill.DNS.Flags;
 import org.xbill.DNS.Message;
+import org.xbill.DNS.Rcode;
 import org.xbill.DNS.Record;
 import org.xbill.DNS.Section;
 
@@ -72,8 +73,14 @@ public class MockDnsServer implements BeforeAllCallback, AfterAllCallback {
 
                     response.addRecord(request.getQuestion(), Section.QUESTION);
 
-                    for (Record record : this.callback.apply(request.getQuestion())) {
-                        response.addRecord(record, Section.ANSWER);
+                    final var records = this.callback.apply(request.getQuestion());
+                    if (records == null) {
+                        // null from the callback simulates a server-side failure
+                        response.getHeader().setRcode(Rcode.SERVFAIL);
+                    } else {
+                        for (Record record : records) {
+                            response.addRecord(record, Section.ANSWER);
+                        }
                     }
 
                     final var responseWire = response.toWire();

--- a/src/test/java/org/riptide/dns/netty/NettyDnsResolverTest.java
+++ b/src/test/java/org/riptide/dns/netty/NettyDnsResolverTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.dns.netty;
+
+import com.codahale.metrics.MetricRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.riptide.config.enricher.HostnamesConfig;
+import org.riptide.dns.MockDnsServer;
+import org.xbill.DNS.Record;
+import org.xbill.DNS.Type;
+
+import java.net.InetAddress;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NettyDnsResolverTest {
+
+    private static final Map<String, AtomicInteger> QUERY_COUNTS = new ConcurrentHashMap<>();
+
+    @RegisterExtension
+    static MockDnsServer dnsServer = new MockDnsServer(request -> {
+        QUERY_COUNTS.computeIfAbsent(request.getName().toString(), key -> new AtomicInteger()).incrementAndGet();
+        if (request.getType() == Type.PTR && request.getName().toString().equals("1.2.0.192.in-addr.arpa.")) {
+            return List.of(Record.fromString(request.getName(), request.getType(), request.getDClass(), 300, "one.example.com.", null));
+        }
+        if (request.getName().toString().equals("50.2.0.192.in-addr.arpa.")) {
+            return null; // SERVFAIL
+        }
+        return List.of();
+    });
+
+    private NettyDnsResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        final var config = new HostnamesConfig();
+        config.setNameservers(List.of("127.0.0.1:" + dnsServer.getPort()));
+        config.setMaximumDnsResolverThreads(1);
+        this.resolver = new NettyDnsResolver(new MetricRegistry(), config,
+                new DefaultDnsReverseCache(config), new DefaultDnsServerAddressProvider(config));
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        this.resolver.destroy();
+    }
+
+    @Test
+    void positiveResultIsCached() throws Exception {
+        final var address = InetAddress.getByName("192.0.2.1");
+
+        assertThat(this.resolver.reverseLookup(address).get(5, TimeUnit.SECONDS)).contains("one.example.com");
+        assertThat(this.resolver.reverseLookup(address).get(5, TimeUnit.SECONDS)).contains("one.example.com");
+
+        assertThat(QUERY_COUNTS.get("1.2.0.192.in-addr.arpa.")).hasValue(1);
+    }
+
+    @Test
+    void negativeResultIsCached() throws Exception {
+        final var address = InetAddress.getByName("192.0.2.99");
+
+        assertThat(this.resolver.reverseLookup(address).get(5, TimeUnit.SECONDS)).isEmpty();
+        assertThat(this.resolver.reverseLookup(address).get(5, TimeUnit.SECONDS)).isEmpty();
+
+        assertThat(QUERY_COUNTS.get("99.2.0.192.in-addr.arpa.")).hasValue(1);
+    }
+
+    @Test
+    void servfailIsNotCached() throws Exception {
+        final var address = InetAddress.getByName("192.0.2.50");
+
+        assertThat(this.resolver.reverseLookup(address).get(5, TimeUnit.SECONDS)).isEmpty();
+        assertThat(this.resolver.reverseLookup(address).get(5, TimeUnit.SECONDS)).isEmpty();
+
+        assertThat(QUERY_COUNTS.get("50.2.0.192.in-addr.arpa.")).hasValue(2);
+    }
+}


### PR DESCRIPTION
## Problem

`NettyDnsResolver.reverseLookup()` only accepted **positive** cache hits: the worker stores failed lookups as `Optional.empty()`, but the `cachedEntry.isPresent()` guard treated those as cache misses, so every flow with an unresolvable address re-queried DNS on every enrichment. Under synthetic flow load (random 10/8 addresses, all NXDOMAIN) this flooded the lab resolver with tens of thousands of uncacheable PTR queries per burst — diagnosed live against the homelab CoreDNS.

## Fix

- `reverseLookup()` returns the cached result for any cache entry, positive or negative.
- Since this activates the previously dead negative-cache path, the worker now caches only genuine negative answers — NXDOMAIN (and NOERROR/NODATA) — and **not** transient failures like SERVFAIL (RFC 2308), so a briefly overloaded resolver can't suppress resolution for the 60s TTL window.
- The per-hit `cache hit` log line drops to debug; negative hits make it hot-path.

## Tests

`NettyDnsResolverTest` (new) drives the real resolver against `MockDnsServer` (extended to simulate SERVFAIL) and counts wire queries: positive and NODATA results resolve exactly once; SERVFAIL is retried. The negative-cache test fails on `main`.

## Known residual gaps (pre-existing, out of scope)

- No in-flight deduplication: concurrent misses for the same key before the first response lands each fire a wire query (candidate: Caffeine `AsyncCache`).
- Query timeouts cache nothing, so an unresponsive (rather than NXDOMAIN-answering) resolver still gets re-queried per flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)