### PR TITLE
fix(dns): resolve PTR through RFC 2317 CNAME chains in reverse lookups

### DIFF
--- a/src/main/java/org/riptide/dns/netty/NettyDnsResolverWorker.java
+++ b/src/main/java/org/riptide/dns/netty/NettyDnsResolverWorker.java
@@ -46,7 +46,7 @@ class NettyDnsResolverWorker {
         final var dnsQuestion = new DefaultDnsQuestion(reverseMapName, DnsRecordType.PTR, DnsRecord.CLASS_IN);
         Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> queryFuture = resolver.query(dnsQuestion);
         queryFuture.addListener((responseFuture) -> {
-            log.info("DNS Reverse lookup for {}", reverseMapName);
+            log.debug("DNS Reverse lookup for {}", reverseMapName);
             try {
                 final var envelope = (AddressedEnvelope<DnsResponse, InetSocketAddress>) responseFuture.get();
                 if (envelope == null) {
@@ -67,7 +67,7 @@ class NettyDnsResolverWorker {
                             }
                         }
                         if (ptrRecord != null) {
-                            log.warn("Result received for {}: {}", reverseMapName, ptrRecord);
+                            log.debug("Result received for {}: {}", reverseMapName, ptrRecord);
                             final var cacheEntry = new DnsReverseCacheEntry(reverseMapName, ptrRecord, cleanHostname(ptrRecord.hostname()));
                             parent.reverseCache.put(reverseMapName, Optional.of(cacheEntry));
                             resultFuture.complete(Optional.of(cacheEntry.getCleanedHostname()));

--- a/src/main/java/org/riptide/dns/netty/NettyDnsResolverWorker.java
+++ b/src/main/java/org/riptide/dns/netty/NettyDnsResolverWorker.java
@@ -57,7 +57,15 @@ class NettyDnsResolverWorker {
                 try {
                     final var dnsResponse = envelope.content();
                     if (DnsResponseCode.NOERROR.equals(dnsResponse.code())) {
-                        final DnsPtrRecord ptrRecord = dnsResponse.recordAt(DnsSection.ANSWER);
+                        // RFC 2317 classless delegation answers lead with a CNAME; the PTR may
+                        // sit anywhere in the chain, and only PTR records decode as DnsPtrRecord.
+                        DnsPtrRecord ptrRecord = null;
+                        for (int i = 0; i < dnsResponse.count(DnsSection.ANSWER); i++) {
+                            if (dnsResponse.recordAt(DnsSection.ANSWER, i) instanceof DnsPtrRecord ptr) {
+                                ptrRecord = ptr;
+                                break;
+                            }
+                        }
                         if (ptrRecord != null) {
                             log.warn("Result received for {}: {}", reverseMapName, ptrRecord);
                             final var cacheEntry = new DnsReverseCacheEntry(reverseMapName, ptrRecord, cleanHostname(ptrRecord.hostname()));

--- a/src/test/java/org/riptide/dns/netty/NettyDnsResolverTest.java
+++ b/src/test/java/org/riptide/dns/netty/NettyDnsResolverTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.riptide.config.enricher.HostnamesConfig;
 import org.riptide.dns.MockDnsServer;
+import org.xbill.DNS.DClass;
+import org.xbill.DNS.Name;
 import org.xbill.DNS.Record;
 import org.xbill.DNS.Type;
 
@@ -36,6 +38,17 @@ class NettyDnsResolverTest {
         }
         if (request.getName().toString().equals("50.2.0.192.in-addr.arpa.")) {
             return null; // SERVFAIL
+        }
+        if (request.getType() == Type.PTR && request.getName().toString().equals("25.2.0.192.in-addr.arpa.")) {
+            // RFC 2317 classless delegation: CNAME onto the /27 sub-zone, PTR on the target
+            return List.of(
+                    Record.fromString(request.getName(), Type.CNAME, request.getDClass(), 300, "25.0/27.2.0.192.in-addr.arpa.", null),
+                    Record.fromString(Name.fromString("25.0/27.2.0.192.in-addr.arpa."), Type.PTR, DClass.IN, 300, "classless.example.com.", null));
+        }
+        if (request.getType() == Type.PTR && request.getName().toString().equals("60.2.0.192.in-addr.arpa.")) {
+            // CNAME without the chased PTR, as a non-recursive server would answer
+            return List.of(
+                    Record.fromString(request.getName(), Type.CNAME, request.getDClass(), 300, "60.32/27.2.0.192.in-addr.arpa.", null));
         }
         return List.of();
     });
@@ -74,6 +87,26 @@ class NettyDnsResolverTest {
         assertThat(this.resolver.reverseLookup(address).get(5, TimeUnit.SECONDS)).isEmpty();
 
         assertThat(QUERY_COUNTS.get("99.2.0.192.in-addr.arpa.")).hasValue(1);
+    }
+
+    @Test
+    void rfc2317CnameChainedPtrIsResolvedAndCached() throws Exception {
+        final var address = InetAddress.getByName("192.0.2.25");
+
+        assertThat(this.resolver.reverseLookup(address).get(5, TimeUnit.SECONDS)).contains("classless.example.com");
+        assertThat(this.resolver.reverseLookup(address).get(5, TimeUnit.SECONDS)).contains("classless.example.com");
+
+        assertThat(QUERY_COUNTS.get("25.2.0.192.in-addr.arpa.")).hasValue(1);
+    }
+
+    @Test
+    void cnameOnlyAnswerIsEmptyAndCached() throws Exception {
+        final var address = InetAddress.getByName("192.0.2.60");
+
+        assertThat(this.resolver.reverseLookup(address).get(5, TimeUnit.SECONDS)).isEmpty();
+        assertThat(this.resolver.reverseLookup(address).get(5, TimeUnit.SECONDS)).isEmpty();
+
+        assertThat(QUERY_COUNTS.get("60.2.0.192.in-addr.arpa.")).hasValue(1);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Reverse lookups whose answers use RFC 2317 classless delegation (CNAME → PTR chain) crashed `NettyDnsResolverWorker` with `ClassCastException` — the code cast the *first* ANSWER record to `DnsPtrRecord`, and the exception path cached nothing, so hot addresses re-queried on every flow (observed on edge-01: 738 errors in 20 min, 545 for `anycast.pebkac.dn42` alone).

- Scan the ANSWER section for the first record of type PTR instead of casting record 0; leading CNAMEs are skipped.
- NOERROR answers without any PTR (e.g. an unchased CNAME from a non-recursive upstream) fall into the existing empty branch and are negatively cached for `defaultCacheTtl` — ending the re-query loop. Chasing CNAME targets is a deliberate non-goal: riptide queries recursive resolvers, which chase server-side.
- Per-lookup `INFO`/`WARN` hot-path logs demoted to `debug` (separate commit).

## Tests

- `rfc2317CnameChainedPtrIsResolvedAndCached` — CNAME→PTR chain resolves and is served from cache on the second lookup (1 upstream query).
- `cnameOnlyAnswerIsEmptyAndCached` — CNAME-only answer yields empty, negatively cached.
- `mvn verify` green (SpotBugs/checkstyle/Error Prone).

## Notes for reviewers

- Behavior change worth a release-note line: RFC 2317 answers previously counted as circuit-breaker failures (`lookupsFailed`); they now count as successes — the old failures were spurious.
- Adversarial review found two non-blocking follow-ups (chain-aware min-TTL caching, PTR owner-name validation) — tracked separately.

Fixes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)