### PR TITLE
fix(dns): harden reverse-DNS caching for chained answers

### DIFF
--- a/src/main/java/org/riptide/config/enricher/HostnamesConfig.java
+++ b/src/main/java/org/riptide/config/enricher/HostnamesConfig.java
@@ -18,6 +18,7 @@ import java.util.List;
 public class HostnamesConfig {
     private boolean enabled = true;
     private long defaultCacheTtl = Duration.ofMinutes(1).toSeconds();
+    private long maximumCacheTtl = Duration.ofDays(1).toSeconds();
     private Long maximumCacheSize;
     private long queryTimeoutMillis = Duration.ofSeconds(5).toMillis();
     private int resolverThreads = 5;

--- a/src/main/java/org/riptide/dns/netty/DefaultDnsReverseCache.java
+++ b/src/main/java/org/riptide/dns/netty/DefaultDnsReverseCache.java
@@ -25,7 +25,9 @@ public class DefaultDnsReverseCache {
                     @Override
                     public long expireAfterCreate(String key, Optional<DnsReverseCacheEntry> value, long currentTime) {
                         return value.map(it -> {
-                            return Duration.ofSeconds(it.getRecord().timeToLive()).toNanos(); // use the TTL from the DNS record
+                            // min TTL across the answer's records, bounded by configuration
+                            final var ttlSeconds = Math.min(it.getEffectiveTtlSeconds(), config.getMaximumCacheTtl());
+                            return Duration.ofSeconds(ttlSeconds).toNanos();
                         }).orElse(Duration.ofSeconds(config.getDefaultCacheTtl()).toNanos());
                     }
 

--- a/src/main/java/org/riptide/dns/netty/DnsReverseCacheEntry.java
+++ b/src/main/java/org/riptide/dns/netty/DnsReverseCacheEntry.java
@@ -19,4 +19,6 @@ public class DnsReverseCacheEntry {
     private final DnsPtrRecord record;
     @NonNull
     private final String cleanedHostname;
+    /** Minimum TTL across the answer's records; a chained answer expires with its shortest link. */
+    private final long effectiveTtlSeconds;
 }

--- a/src/main/java/org/riptide/dns/netty/NettyDnsResolverWorker.java
+++ b/src/main/java/org/riptide/dns/netty/NettyDnsResolverWorker.java
@@ -20,6 +20,7 @@ import io.netty.util.concurrent.Future;
 import lombok.extern.slf4j.Slf4j;
 
 import java.net.InetSocketAddress;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -57,15 +58,7 @@ class NettyDnsResolverWorker {
                 try {
                     final var dnsResponse = envelope.content();
                     if (DnsResponseCode.NOERROR.equals(dnsResponse.code())) {
-                        // RFC 2317 classless delegation answers lead with a CNAME; the PTR may
-                        // sit anywhere in the chain, and only PTR records decode as DnsPtrRecord.
-                        DnsPtrRecord ptrRecord = null;
-                        for (int i = 0; i < dnsResponse.count(DnsSection.ANSWER); i++) {
-                            if (dnsResponse.recordAt(DnsSection.ANSWER, i) instanceof DnsPtrRecord ptr) {
-                                ptrRecord = ptr;
-                                break;
-                            }
-                        }
+                        final var ptrRecord = findChainedPtr(dnsResponse, reverseMapName);
                         if (ptrRecord != null) {
                             log.debug("Result received for {}: {}", reverseMapName, ptrRecord);
                             final var cacheEntry = new DnsReverseCacheEntry(reverseMapName, ptrRecord,
@@ -105,6 +98,46 @@ class NettyDnsResolverWorker {
             return ex.getCause(); // TODO MVR decide if you want to go all the way down to the actual root cause
         }
         return ex;
+    }
+
+    /**
+     * Finds the PTR record answering {@code qname}. RFC 2317 classless delegation answers lead
+     * with a CNAME onto a sub-zone; netty leaves CNAME RDATA as a raw slice whose compression
+     * pointers reference the whole datagram, so the chain target cannot be decoded reliably.
+     * Acceptance therefore uses owner names only: the PTR must be owned by the queried name, or
+     * — when a CNAME owned by the queried name is present — by a name at or under the queried
+     * name's parent domain (RFC 2317 delegations stay within the parent zone).
+     */
+    private static DnsPtrRecord findChainedPtr(final DnsResponse response, final String qname) {
+        final int answerCount = response.count(DnsSection.ANSWER);
+        final var canonicalQname = canonical(qname);
+
+        boolean chained = false;
+        for (int i = 0; i < answerCount; i++) {
+            final DnsRecord record = response.recordAt(DnsSection.ANSWER, i);
+            if (DnsRecordType.CNAME.equals(record.type()) && canonical(record.name()).equals(canonicalQname)) {
+                chained = true;
+                break;
+            }
+        }
+
+        final var parentDomain = canonicalQname.substring(canonicalQname.indexOf('.') + 1);
+        for (int i = 0; i < answerCount; i++) {
+            if (response.recordAt(DnsSection.ANSWER, i) instanceof DnsPtrRecord ptr) {
+                final var owner = canonical(ptr.name());
+                if (owner.equals(canonicalQname)
+                        || (chained && (owner.equals(parentDomain) || owner.endsWith("." + parentDomain)))) {
+                    return ptr;
+                }
+                log.warn("Ignoring PTR with unrelated owner {} in answer for {}", ptr.name(), qname);
+            }
+        }
+        return null;
+    }
+
+    private static String canonical(final String name) {
+        final var lower = name.toLowerCase(Locale.ROOT);
+        return lower.endsWith(".") ? lower : lower + ".";
     }
 
     /**

--- a/src/main/java/org/riptide/dns/netty/NettyDnsResolverWorker.java
+++ b/src/main/java/org/riptide/dns/netty/NettyDnsResolverWorker.java
@@ -68,7 +68,8 @@ class NettyDnsResolverWorker {
                         }
                         if (ptrRecord != null) {
                             log.debug("Result received for {}: {}", reverseMapName, ptrRecord);
-                            final var cacheEntry = new DnsReverseCacheEntry(reverseMapName, ptrRecord, cleanHostname(ptrRecord.hostname()));
+                            final var cacheEntry = new DnsReverseCacheEntry(reverseMapName, ptrRecord,
+                                    cleanHostname(ptrRecord.hostname()), minAnswerTtl(dnsResponse));
                             parent.reverseCache.put(reverseMapName, Optional.of(cacheEntry));
                             resultFuture.complete(Optional.of(cacheEntry.getCleanedHostname()));
                         } else {
@@ -104,6 +105,20 @@ class NettyDnsResolverWorker {
             return ex.getCause(); // TODO MVR decide if you want to go all the way down to the actual root cause
         }
         return ex;
+    }
+
+    /**
+     * Minimum TTL across all ANSWER records. A chained answer must not outlive its shortest
+     * link (the delegation CNAME's TTL governs, RFC 1034); the floor of 1s keeps TTL-0 answers
+     * from being re-queried once per flow.
+     */
+    private static long minAnswerTtl(final DnsResponse response) {
+        long ttlSeconds = Long.MAX_VALUE;
+        final int answerCount = response.count(DnsSection.ANSWER);
+        for (int i = 0; i < answerCount; i++) {
+            ttlSeconds = Math.min(ttlSeconds, response.<DnsRecord>recordAt(DnsSection.ANSWER, i).timeToLive());
+        }
+        return Math.max(ttlSeconds, 1);
     }
 
     private static String cleanHostname(String hostname) {

--- a/src/test/java/org/riptide/dns/netty/NettyDnsResolverTest.java
+++ b/src/test/java/org/riptide/dns/netty/NettyDnsResolverTest.java
@@ -18,6 +18,7 @@ import org.xbill.DNS.Record;
 import org.xbill.DNS.Type;
 
 import java.net.InetAddress;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -45,6 +46,18 @@ class NettyDnsResolverTest {
                     Record.fromString(request.getName(), Type.CNAME, request.getDClass(), 300, "25.0/27.2.0.192.in-addr.arpa.", null),
                     Record.fromString(Name.fromString("25.0/27.2.0.192.in-addr.arpa."), Type.PTR, DClass.IN, 300, "classless.example.com.", null));
         }
+        if (request.getType() == Type.PTR && request.getName().toString().equals("26.2.0.192.in-addr.arpa.")) {
+            // short-lived delegation CNAME, long-lived PTR: the CNAME TTL must govern caching
+            return List.of(
+                    Record.fromString(request.getName(), Type.CNAME, request.getDClass(), 60, "26.0/27.2.0.192.in-addr.arpa.", null),
+                    Record.fromString(Name.fromString("26.0/27.2.0.192.in-addr.arpa."), Type.PTR, DClass.IN, 86400, "shortlease.example.com.", null));
+        }
+        if (request.getType() == Type.PTR && request.getName().toString().equals("27.2.0.192.in-addr.arpa.")) {
+            return List.of(Record.fromString(request.getName(), Type.PTR, request.getDClass(), 0, "zero.example.com.", null));
+        }
+        if (request.getType() == Type.PTR && request.getName().toString().equals("28.2.0.192.in-addr.arpa.")) {
+            return List.of(Record.fromString(request.getName(), Type.PTR, request.getDClass(), 999999, "clamped.example.com.", null));
+        }
         if (request.getType() == Type.PTR && request.getName().toString().equals("60.2.0.192.in-addr.arpa.")) {
             // CNAME without the chased PTR, as a non-recursive server would answer
             return List.of(
@@ -54,14 +67,22 @@ class NettyDnsResolverTest {
     });
 
     private NettyDnsResolver resolver;
+    private DefaultDnsReverseCache reverseCache;
 
     @BeforeEach
     void setUp() {
         final var config = new HostnamesConfig();
         config.setNameservers(List.of("127.0.0.1:" + dnsServer.getPort()));
         config.setMaximumDnsResolverThreads(1);
+        config.setMaximumCacheTtl(120L);
+        this.reverseCache = new DefaultDnsReverseCache(config);
         this.resolver = new NettyDnsResolver(new MetricRegistry(), config,
-                new DefaultDnsReverseCache(config), new DefaultDnsServerAddressProvider(config));
+                this.reverseCache, new DefaultDnsServerAddressProvider(config));
+    }
+
+    private Duration expiresAfter(String reverseMapName) {
+        return this.reverseCache.delegate.policy().expireVariably().orElseThrow()
+                .getExpiresAfter(reverseMapName).orElseThrow();
     }
 
     @AfterEach
@@ -97,6 +118,36 @@ class NettyDnsResolverTest {
         assertThat(this.resolver.reverseLookup(address).get(5, TimeUnit.SECONDS)).contains("classless.example.com");
 
         assertThat(QUERY_COUNTS.get("25.2.0.192.in-addr.arpa.")).hasValue(1);
+    }
+
+    @Test
+    void chainedAnswerExpiresWithItsShortestTtl() throws Exception {
+        final var address = InetAddress.getByName("192.0.2.26");
+
+        assertThat(this.resolver.reverseLookup(address).get(5, TimeUnit.SECONDS)).contains("shortlease.example.com");
+
+        assertThat(expiresAfter("26.2.0.192.in-addr.arpa."))
+                .isBetween(Duration.ofSeconds(55), Duration.ofSeconds(60));
+    }
+
+    @Test
+    void zeroTtlIsFlooredToOneSecond() throws Exception {
+        final var address = InetAddress.getByName("192.0.2.27");
+
+        assertThat(this.resolver.reverseLookup(address).get(5, TimeUnit.SECONDS)).contains("zero.example.com");
+
+        assertThat(expiresAfter("27.2.0.192.in-addr.arpa."))
+                .isBetween(Duration.ofMillis(1), Duration.ofSeconds(1));
+    }
+
+    @Test
+    void oversizedTtlIsClampedToMaximumCacheTtl() throws Exception {
+        final var address = InetAddress.getByName("192.0.2.28");
+
+        assertThat(this.resolver.reverseLookup(address).get(5, TimeUnit.SECONDS)).contains("clamped.example.com");
+
+        assertThat(expiresAfter("28.2.0.192.in-addr.arpa."))
+                .isBetween(Duration.ofSeconds(115), Duration.ofSeconds(120));
     }
 
     @Test

--- a/src/test/java/org/riptide/dns/netty/NettyDnsResolverTest.java
+++ b/src/test/java/org/riptide/dns/netty/NettyDnsResolverTest.java
@@ -58,6 +58,21 @@ class NettyDnsResolverTest {
         if (request.getType() == Type.PTR && request.getName().toString().equals("28.2.0.192.in-addr.arpa.")) {
             return List.of(Record.fromString(request.getName(), Type.PTR, request.getDClass(), 999999, "clamped.example.com.", null));
         }
+        if (request.getType() == Type.PTR && request.getName().toString().equals("29.2.0.192.in-addr.arpa.")) {
+            // genuine chain, but the PTR's owner is outside the queried name's parent domain
+            return List.of(
+                    Record.fromString(request.getName(), Type.CNAME, request.getDClass(), 300, "29.0/27.2.0.192.in-addr.arpa.", null),
+                    Record.fromString(Name.fromString("9.9.9.9.in-addr.arpa."), Type.PTR, DClass.IN, 300, "offchain.example.com.", null));
+        }
+        if (request.getType() == Type.PTR && request.getName().toString().equals("30.2.0.192.in-addr.arpa.")) {
+            // stray PTR under the parent domain but with no CNAME owned by the queried name
+            return List.of(
+                    Record.fromString(Name.fromString("1.2.0.192.in-addr.arpa."), Type.PTR, DClass.IN, 300, "stray.example.com.", null));
+        }
+        if (request.getType() == Type.PTR && request.getName().toString().equals("31.2.0.192.in-addr.arpa.")) {
+            return List.of(
+                    Record.fromString(Name.fromString("31.2.0.192.IN-ADDR.ARPA."), Type.PTR, DClass.IN, 300, "mixedcase.example.com.", null));
+        }
         if (request.getType() == Type.PTR && request.getName().toString().equals("60.2.0.192.in-addr.arpa.")) {
             // CNAME without the chased PTR, as a non-recursive server would answer
             return List.of(
@@ -148,6 +163,30 @@ class NettyDnsResolverTest {
 
         assertThat(expiresAfter("28.2.0.192.in-addr.arpa."))
                 .isBetween(Duration.ofSeconds(115), Duration.ofSeconds(120));
+    }
+
+    @Test
+    void offChainPtrIsRejectedAndCachedEmpty() throws Exception {
+        final var address = InetAddress.getByName("192.0.2.29");
+
+        assertThat(this.resolver.reverseLookup(address).get(5, TimeUnit.SECONDS)).isEmpty();
+        assertThat(this.resolver.reverseLookup(address).get(5, TimeUnit.SECONDS)).isEmpty();
+
+        assertThat(QUERY_COUNTS.get("29.2.0.192.in-addr.arpa.")).hasValue(1);
+    }
+
+    @Test
+    void strayPtrWithoutChainIsRejected() throws Exception {
+        final var address = InetAddress.getByName("192.0.2.30");
+
+        assertThat(this.resolver.reverseLookup(address).get(5, TimeUnit.SECONDS)).isEmpty();
+    }
+
+    @Test
+    void mixedCaseOwnerIsAccepted() throws Exception {
+        final var address = InetAddress.getByName("192.0.2.31");
+
+        assertThat(this.resolver.reverseLookup(address).get(5, TimeUnit.SECONDS)).contains("mixedcase.example.com");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Follow-up hardening from the adversarial review of #341, as decided in #342.

**Cache TTL** (`9f1a364`): positive entries now expire after the **minimum TTL across all ANSWER records** — a chained answer can't outlive its delegation CNAME — floored at 1 s (TTL-0 answers must not re-query per flow) and clamped by a new `riptide.enricher.hostnames.maximumCacheTtl` setting (default 86400 s). The TTL travels as `effectiveTtlSeconds` in `DnsReverseCacheEntry`; expiry no longer reads the raw PTR record.

**PTR acceptance** (`d7502e2`): the ANSWER scan is now `findChainedPtr`, accepting a PTR only when its owner equals the queried name, or — with a CNAME owned by the queried name present — when the owner sits at/under the queried name's parent domain (RFC 2317 delegations cannot leave it). Case-insensitive, dot-boundary-safe suffix matching. Rejected records log WARN and degrade to the negatively-cached empty result. **CNAME RDATA is deliberately never decoded** — netty leaves it as a raw slice whose compression pointers reference the whole datagram, so chain-target decoding is unreliable by construction (see #342 for the full analysis and the accepted residual gap).

## Tests

Six new cases in `NettyDnsResolverTest` (11 total, all green): chained answer expires with its shortest TTL, TTL-0 floor, `maximumCacheTtl` clamp (expiry asserted via Caffeine `expireVariably().getExpiresAfter` — no sleeps), off-chain PTR rejected + negatively cached, stray PTR without a chain rejected, mixed-case owner accepted. `mvn verify` green.

Closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)