### PR TITLE
fix(snmp): timeout-aware ifTable fallback and per-endpoint back-off

### DIFF
--- a/src/main/java/org/riptide/snmp/CachingSnmpService.java
+++ b/src/main/java/org/riptide/snmp/CachingSnmpService.java
@@ -37,6 +37,10 @@ public class CachingSnmpService implements SnmpService {
     // one walk per TTL, not one per flow. Separate cache because Guava has no per-entry TTL.
     private final Cache<Tuple<InetSocketAddress, Integer>, Boolean> missCache;
 
+    // Endpoint-level back-off: misses are per-ifIndex, but a walk timeout condemns the whole
+    // endpoint — without this, a dead exporter costs one walk per distinct ifIndex per TTL (#337).
+    private final Cache<InetSocketAddress, Boolean> deadEndpointCache;
+
     public CachingSnmpService(final SnmpService delegate, final SnmpCacheConfig cacheConfig) {
         this.delegate = Objects.requireNonNull(delegate);
         this.cacheConfig = Objects.requireNonNull(cacheConfig);
@@ -49,31 +53,51 @@ public class CachingSnmpService implements SnmpService {
                 // a rogue exporter spraying distinct ifIndexes must not grow the heap
                 .maximumSize(10_000)
                 .build();
+        deadEndpointCache = CacheBuilder.newBuilder()
+                .expireAfterWrite(Duration.ofMillis(cacheConfig.getDeadEndpointRetentionMs()))
+                .build();
     }
 
     /** Config hot-reload hook: changed nodes may mean changed endpoints or credentials. */
     public void invalidateAll() {
         this.ifIndexCache.invalidateAll();
         this.missCache.invalidateAll();
+        this.deadEndpointCache.invalidateAll();
     }
 
     @Override
     public Optional<IfInfo> getIfInfo(final SnmpEndpoint snmpEndpoint, final int ifIndex) {
-        final var key = Tuple.of(snmpEndpoint.getInetSocketAddress(), ifIndex);
+        final var address = snmpEndpoint.getInetSocketAddress();
+        if (this.deadEndpointCache.getIfPresent(address) != null) {
+            return Optional.empty();
+        }
+        final var key = Tuple.of(address, ifIndex);
         if (this.missCache.getIfPresent(key) != null) {
             return Optional.empty();
         }
         final Optional<IfInfo> ifInfo;
         try {
-            ifInfo = ifIndexCache.get(key, () -> this.delegate.getIfInfo(snmpEndpoint, ifIndex));
+            ifInfo = ifIndexCache.get(key, () -> {
+                final var lookup = this.delegate.lookupIfInfo(snmpEndpoint, ifIndex);
+                if (lookup.endpointTimedOut()) {
+                    this.deadEndpointCache.put(address, Boolean.TRUE);
+                    log.warn("SNMP endpoint {} does not answer, backing off for {} ms",
+                            snmpEndpoint, this.cacheConfig.getDeadEndpointRetentionMs());
+                }
+                return lookup.ifInfo();
+            });
         } catch (ExecutionException e) {
-            // the delegate degrades all failures to Optional.empty and never throws
+            // the delegate degrades all failures to empty lookups and never throws
             throw new IllegalStateException(e);
         }
         if (ifInfo.isEmpty()) {
             ifIndexCache.invalidate(key);
-            missCache.put(key, Boolean.TRUE);
-            log.warn("Cannot determine interface info for ifIndex {} for endpoint {}", ifIndex, snmpEndpoint);
+            // dead endpoints got the single back-off WARN above; the per-ifIndex diagnostic
+            // is only meaningful when the agent actually answered
+            if (this.deadEndpointCache.getIfPresent(address) == null) {
+                missCache.put(key, Boolean.TRUE);
+                log.warn("Cannot determine interface info for ifIndex {} for endpoint {}", ifIndex, snmpEndpoint);
+            }
         }
         return ifInfo;
     }

--- a/src/main/java/org/riptide/snmp/DefaultSnmpService.java
+++ b/src/main/java/org/riptide/snmp/DefaultSnmpService.java
@@ -24,14 +24,20 @@ public class DefaultSnmpService implements SnmpService {
 
     @Override
     public Optional<IfInfo> getIfInfo(final SnmpEndpoint snmpEndpoint, final int ifIndex) {
+        return lookupIfInfo(snmpEndpoint, ifIndex).ifInfo();
+    }
+
+    @Override
+    public IfInfoLookup lookupIfInfo(final SnmpEndpoint snmpEndpoint, final int ifIndex) {
         try {
-            final var value = SnmpUtils.getIfInfoMap(snmpEndpoint, this.secretResolvers).get(ifIndex);
-            return Optional.ofNullable(value);
+            final var walk = SnmpUtils.getIfInfoMap(snmpEndpoint, this.secretResolvers);
+            return new IfInfoLookup(Optional.ofNullable(walk.rows().get(ifIndex)),
+                    walk.outcome() == SnmpUtils.WalkOutcome.TIMEOUT);
         } catch (IOException | IllegalArgumentException e) {
             // IllegalArgumentException: an unresolvable secret reference must degrade to an
             // unenriched flow, never fail the pipeline and drop the batch.
             log.warn("Error fetching value from {} at index {}: {}", snmpEndpoint, ifIndex, e.getMessage());
-            return Optional.empty();
+            return new IfInfoLookup(Optional.empty(), false);
         }
     }
 }

--- a/src/main/java/org/riptide/snmp/SnmpCacheConfig.java
+++ b/src/main/java/org/riptide/snmp/SnmpCacheConfig.java
@@ -28,4 +28,12 @@ public class SnmpCacheConfig {
      * table walk per TTL instead of one per flow. 0 disables negative caching.
      */
     private long negativeRetentionMs = 60_000;
+
+    /**
+     * Back-off TTL for endpoints whose walk timed out: the whole endpoint is considered
+     * dead and no walks are issued for any of its ifIndexes until the TTL expires, so an
+     * unreachable exporter costs one walk per TTL regardless of how many ifIndexes its
+     * flows reference. Cleared by config hot-reload. 0 disables the endpoint back-off.
+     */
+    private long deadEndpointRetentionMs = 60_000;
 }

--- a/src/main/java/org/riptide/snmp/SnmpService.java
+++ b/src/main/java/org/riptide/snmp/SnmpService.java
@@ -9,4 +9,16 @@ import java.util.Optional;
 
 public interface SnmpService {
     Optional<IfInfo> getIfInfo(SnmpEndpoint snmpEndpoint, int ifIndex);
+
+    /**
+     * Like {@link #getIfInfo}, additionally reporting whether the endpoint failed to answer at
+     * all (walk timeout) — the caching layer uses this to back off per endpoint, not per
+     * ifIndex.
+     */
+    default IfInfoLookup lookupIfInfo(SnmpEndpoint snmpEndpoint, int ifIndex) {
+        return new IfInfoLookup(getIfInfo(snmpEndpoint, ifIndex), false);
+    }
+
+    record IfInfoLookup(Optional<IfInfo> ifInfo, boolean endpointTimedOut) {
+    }
 }

--- a/src/main/java/org/riptide/snmp/SnmpUtils.java
+++ b/src/main/java/org/riptide/snmp/SnmpUtils.java
@@ -36,8 +36,15 @@ public final class SnmpUtils {
     private SnmpUtils() {
     }
 
-    private static Map<Integer, IfInfo> walkColumns(final Snmp snmp, final Target<?> target, final SnmpEndpoint snmpEndpoint,
-                                                    final OID[] columns, final Function<List<VariableBinding>, IfInfo> row) {
+    enum WalkOutcome {
+        OK, TIMEOUT, ERROR
+    }
+
+    public record WalkResult(Map<Integer, IfInfo> rows, WalkOutcome outcome) {
+    }
+
+    private static WalkResult walkColumns(final Snmp snmp, final Target<?> target, final SnmpEndpoint snmpEndpoint,
+                                          final OID[] columns, final Function<List<VariableBinding>, IfInfo> row) {
         final TableUtils tableUtils = new TableUtils(snmp, new DefaultPDUFactory());
         final List<TableEvent> tableEvents = tableUtils.getTable(target, columns, null, null);
 
@@ -47,7 +54,12 @@ public final class SnmpUtils {
             if (tableEvent.isError()) {
                 // The SNMP4J target must not be logged: its toString() carries the credential (#335)
                 log.warn("Error querying {} for {}: {}", columns[0], snmpEndpoint, tableEvent.getErrorMessage());
-                return new TreeMap<>();
+                // rows collected before the error are discarded: an incomplete table must not
+                // be cached as if it were complete
+                final var outcome = tableEvent.getStatus() == TableEvent.STATUS_TIMEOUT
+                        ? WalkOutcome.TIMEOUT
+                        : WalkOutcome.ERROR;
+                return new WalkResult(new TreeMap<>(), outcome);
             }
             if (tableEvent.getIndex() == null || tableEvent.getColumns() == null) {
                 continue;
@@ -61,7 +73,7 @@ public final class SnmpUtils {
             }
         }
 
-        return interfaces;
+        return new WalkResult(interfaces, WalkOutcome.OK);
     }
 
     private static IfInfo ifXRow(final List<VariableBinding> columns) {
@@ -94,17 +106,30 @@ public final class SnmpUtils {
 
     /**
      * Walks the exporter's interface table: ifXTable (ifName/ifHighSpeed/ifAlias) first,
-     * falling back to the legacy ifTable (ifDescr only).
+     * falling back to the legacy ifTable (ifDescr only) — unless the first walk timed out.
      */
-    public static Map<Integer, IfInfo> getIfInfoMap(final SnmpEndpoint snmpEndpoint, final SecretResolvers secretResolvers) throws IOException {
+    public static WalkResult getIfInfoMap(final SnmpEndpoint snmpEndpoint, final SecretResolvers secretResolvers) throws IOException {
         final SnmpBuilder snmpBuilder = snmpEndpoint.getSnmpDefinition().getSnmpVersion().getSnmpBuilder();
         try (Snmp snmp = snmpBuilder.build()) {
             final Target<?> target = snmpEndpoint.getSnmpDefinition().getSnmpVersion().getTarget(snmp, snmpBuilder, snmpEndpoint, secretResolvers);
-            final var interfaces = walkColumns(snmp, target, snmpEndpoint, new OID[]{IFX_NAME, IFX_HIGH_SPEED, IFX_ALIAS}, SnmpUtils::ifXRow);
-            if (interfaces.isEmpty()) {
+            final var ifXTable = walkColumns(snmp, target, snmpEndpoint, new OID[]{IFX_NAME, IFX_HIGH_SPEED, IFX_ALIAS}, SnmpUtils::ifXRow);
+            if (shouldFallback(ifXTable)) {
                 return walkColumns(snmp, target, snmpEndpoint, new OID[]{IF_DESCR}, SnmpUtils::ifRow);
             }
-            return interfaces;
+            return ifXTable;
         }
+    }
+
+    /**
+     * The fallback exists for agents that lack ifXTable: v2c/v3 agents answer clean-empty (OK),
+     * v1 agents answer with a noSuchName error (ERROR). A TIMEOUT means the agent does not
+     * answer at all — the fallback walk would only time out again (#337).
+     */
+    static boolean shouldFallback(final WalkResult ifXTableResult) {
+        return switch (ifXTableResult.outcome()) {
+            case TIMEOUT -> false;
+            case ERROR -> true;
+            case OK -> ifXTableResult.rows().isEmpty();
+        };
     }
 }

--- a/src/test/java/org/riptide/snmp/SnmpTest.java
+++ b/src/test/java/org/riptide/snmp/SnmpTest.java
@@ -121,7 +121,7 @@ public class SnmpTest {
         currentAgent.registerIfXTable();
 
         final SnmpEndpoint snmpEndpoint = communityV2c(new IPAddressString("127.0.0.1"), port, TestSnmpAgent.COMMUNITY);
-        final Map<Integer, IfInfo> ifMap = SnmpUtils.getIfInfoMap(snmpEndpoint, SECRET_RESOLVERS);
+        final Map<Integer, IfInfo> ifMap = SnmpUtils.getIfInfoMap(snmpEndpoint, SECRET_RESOLVERS).rows();
 
         assertThat(ifMap.get(1).name()).isEqualTo("eth0-x");
         assertThat(ifMap.get(1).alias()).isEqualTo("My ethernet interface");
@@ -140,7 +140,7 @@ public class SnmpTest {
         currentAgent.registerIfXTable();
 
         final SnmpEndpoint snmpEndpoint = noAuthNoPriv(new IPAddressString("127.0.0.1"), port, TestSnmpAgent.NOAUTHNOPRIV_USERNAME);
-        final Map<Integer, IfInfo> ifMap = SnmpUtils.getIfInfoMap(snmpEndpoint, SECRET_RESOLVERS);
+        final Map<Integer, IfInfo> ifMap = SnmpUtils.getIfInfoMap(snmpEndpoint, SECRET_RESOLVERS).rows();
 
         assertThat(ifMap.get(1).name()).isEqualTo("eth0-x");
         assertThat(ifMap.get(1).alias()).isEqualTo("My ethernet interface");
@@ -158,7 +158,7 @@ public class SnmpTest {
         currentAgent.registerIfTable();
 
         final SnmpEndpoint snmpEndpoint = noAuthNoPriv(new IPAddressString("127.0.0.1"), port, TestSnmpAgent.NOAUTHNOPRIV_USERNAME);
-        final Map<Integer, IfInfo> ifMap = SnmpUtils.getIfInfoMap(snmpEndpoint, SECRET_RESOLVERS);
+        final Map<Integer, IfInfo> ifMap = SnmpUtils.getIfInfoMap(snmpEndpoint, SECRET_RESOLVERS).rows();
 
         assertThat(ifMap.get(1).name()).isEqualTo("eth0");
         assertThat(ifMap.get(1).alias()).isNull();
@@ -175,7 +175,7 @@ public class SnmpTest {
         currentAgent.registerIfXTable();
 
         final SnmpEndpoint snmpEndpoint = authNoPriv(new IPAddressString("127.0.0.1"), port, TestSnmpAgent.AUTHNOPRIV_USERNAME, TargetBuilder.AuthProtocol.sha1, TestSnmpAgent.AUTHNOPRIV_AUTH_PASSHRASE);
-        final Map<Integer, IfInfo> ifMap = SnmpUtils.getIfInfoMap(snmpEndpoint, SECRET_RESOLVERS);
+        final Map<Integer, IfInfo> ifMap = SnmpUtils.getIfInfoMap(snmpEndpoint, SECRET_RESOLVERS).rows();
 
         assertThat(ifMap.get(1).name()).isEqualTo("eth0-x");
         assertThat(ifMap.get(1).alias()).isEqualTo("My ethernet interface");
@@ -194,7 +194,7 @@ public class SnmpTest {
         currentAgent.registerIfXTable();
 
         final SnmpEndpoint snmpEndpoint = authPriv(new IPAddressString("127.0.0.1"), port, TestSnmpAgent.AUTHPRIV_USERNAME, TargetBuilder.AuthProtocol.sha1, TestSnmpAgent.AUTHPRIV_AUTH_PASSHRASE, TargetBuilder.PrivProtocol.aes128, TestSnmpAgent.AUTHPRIV_PRIV_PASSHRASE);
-        final Map<Integer, IfInfo> ifMap = SnmpUtils.getIfInfoMap(snmpEndpoint, SECRET_RESOLVERS);
+        final Map<Integer, IfInfo> ifMap = SnmpUtils.getIfInfoMap(snmpEndpoint, SECRET_RESOLVERS).rows();
 
         assertThat(ifMap.get(1).name()).isEqualTo("eth0-x");
         assertThat(ifMap.get(1).alias()).isEqualTo("My ethernet interface");
@@ -223,7 +223,7 @@ public class SnmpTest {
         appender.start();
         logger.addAppender(appender);
         try {
-            Assertions.assertThat(SnmpUtils.getIfInfoMap(snmpEndpoint, SECRET_RESOLVERS)).isEmpty();
+            Assertions.assertThat(SnmpUtils.getIfInfoMap(snmpEndpoint, SECRET_RESOLVERS).rows()).isEmpty();
 
             // The leak lives in argument rendering, so assert on the formatted messages
             Assertions.assertThat(appender.list)
@@ -239,6 +239,40 @@ public class SnmpTest {
         } finally {
             logger.detachAppender(appender);
         }
+    }
+
+    @Test
+    public void timedOutWalkSkipsTheIfTableFallback() throws Exception {
+        // no agent listening: the ifXTable walk times out; the ifTable fallback would only time
+        // out again, so exactly one walk (and one WARN) must happen (#337)
+        final SnmpEndpoint snmpEndpoint = communityV2c(new IPAddressString("127.0.0.1"), getNextPort(), TestSnmpAgent.COMMUNITY);
+        snmpEndpoint.getSnmpDefinition().setTimeout(50);
+
+        final var logger = (Logger) LoggerFactory.getLogger(SnmpUtils.class);
+        final var appender = new ListAppender<ILoggingEvent>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            final var walk = SnmpUtils.getIfInfoMap(snmpEndpoint, SECRET_RESOLVERS);
+
+            assertThat(walk.outcome()).isEqualTo(SnmpUtils.WalkOutcome.TIMEOUT);
+            Assertions.assertThat(walk.rows()).isEmpty();
+            Assertions.assertThat(appender.list)
+                    .filteredOn(event -> event.getFormattedMessage().contains("Error querying"))
+                    .hasSize(1);
+        } finally {
+            logger.detachAppender(appender);
+        }
+    }
+
+    @Test
+    public void fallbackRunsOnErrorAndEmptyButNotOnTimeout() {
+        // v1 agents lacking ifXTable answer noSuchName (ERROR) — the fallback exists for them
+        assertThat(SnmpUtils.shouldFallback(new SnmpUtils.WalkResult(Map.of(), SnmpUtils.WalkOutcome.ERROR))).isTrue();
+        // v2c/v3 agents lacking ifXTable answer clean-empty
+        assertThat(SnmpUtils.shouldFallback(new SnmpUtils.WalkResult(Map.of(), SnmpUtils.WalkOutcome.OK))).isTrue();
+        assertThat(SnmpUtils.shouldFallback(new SnmpUtils.WalkResult(Map.of(1, new IfInfo("eth0", null, null)), SnmpUtils.WalkOutcome.OK))).isFalse();
+        assertThat(SnmpUtils.shouldFallback(new SnmpUtils.WalkResult(Map.of(), SnmpUtils.WalkOutcome.TIMEOUT))).isFalse();
     }
 
     @Test

--- a/src/test/java/org/riptide/snmp/SnmpTest.java
+++ b/src/test/java/org/riptide/snmp/SnmpTest.java
@@ -289,8 +289,10 @@ public class SnmpTest {
         final int port = getNextPort();
         final SnmpCacheConfig snmpCacheConfig = new SnmpCacheConfig();
         snmpCacheConfig.setRetentionMs(600000);
-        // negative caching off: this test exercises miss -> recovery without waiting for the TTL
+        // negative caching and endpoint back-off: this test exercises miss -> recovery
+        // without waiting for either TTL (the first lookup targets a not-yet-started agent)
         snmpCacheConfig.setNegativeRetentionMs(0);
+        snmpCacheConfig.setDeadEndpointRetentionMs(0);
 
         final SnmpService snmpCache = new CachingSnmpService(new DefaultSnmpService(SECRET_RESOLVERS), snmpCacheConfig);
         final SnmpEndpoint snmpEndpoint = communityV2c(new IPAddressString("127.0.0.1"), port, TestSnmpAgent.COMMUNITY);
@@ -313,6 +315,53 @@ public class SnmpTest {
         assertThat(snmpCache.getIfInfo(snmpEndpoint, 1).get().name()).isEqualTo("eth0");
         assertThat(snmpCache.getIfInfo(snmpEndpoint, 2)).isInstanceOf(Optional.class).isPresent();
         assertThat(snmpCache.getIfInfo(snmpEndpoint, 2).get().name()).isEqualTo("lo0");
+    }
+
+    @Test
+    public void deadEndpointsShortCircuitAcrossIfIndexes() {
+        final SnmpCacheConfig snmpCacheConfig = new SnmpCacheConfig();
+
+        final AtomicInteger delegateCalls = new AtomicInteger();
+        final SnmpService timingOut = new SnmpService() {
+            @Override
+            public Optional<IfInfo> getIfInfo(final SnmpEndpoint endpoint, final int ifIndex) {
+                return lookupIfInfo(endpoint, ifIndex).ifInfo();
+            }
+
+            @Override
+            public IfInfoLookup lookupIfInfo(final SnmpEndpoint endpoint, final int ifIndex) {
+                delegateCalls.incrementAndGet();
+                return new IfInfoLookup(Optional.empty(), true);
+            }
+        };
+        final CachingSnmpService snmpCache = new CachingSnmpService(timingOut, snmpCacheConfig);
+        final SnmpEndpoint snmpEndpoint = communityV2c(new IPAddressString("127.0.0.1"), getNextPort(), TestSnmpAgent.COMMUNITY);
+
+        final var logger = (Logger) LoggerFactory.getLogger(CachingSnmpService.class);
+        final var appender = new ListAppender<ILoggingEvent>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            // one timed-out walk condemns the endpoint: other ifIndexes must not walk again
+            assertThat(snmpCache.getIfInfo(snmpEndpoint, 1)).isInstanceOf(Optional.class).isEmpty();
+            assertThat(snmpCache.getIfInfo(snmpEndpoint, 2)).isInstanceOf(Optional.class).isEmpty();
+            assertThat(snmpCache.getIfInfo(snmpEndpoint, 3)).isInstanceOf(Optional.class).isEmpty();
+            assertThat(delegateCalls.get()).isEqualTo(1);
+
+            // one WARN marks the endpoint dead; the per-ifIndex diagnostic stays silent
+            Assertions.assertThat(appender.list)
+                    .filteredOn(event -> event.getFormattedMessage().contains("does not answer"))
+                    .hasSize(1);
+            Assertions.assertThat(appender.list)
+                    .noneMatch(event -> event.getFormattedMessage().contains("Cannot determine interface info"));
+
+            // hot-reload clears the dead marking: the next lookup walks again
+            snmpCache.invalidateAll();
+            assertThat(snmpCache.getIfInfo(snmpEndpoint, 1)).isInstanceOf(Optional.class).isEmpty();
+            assertThat(delegateCalls.get()).isEqualTo(2);
+        } finally {
+            logger.detachAppender(appender);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Implements the decisions from #337 (see the issue for the full analysis).

**Walk contract** (`41da49b`): `walkColumns` returns `WalkResult { rows, OK | TIMEOUT | ERROR }` instead of conflating errored and empty walks. `getIfInfoMap` skips the ifTable fallback **only on TIMEOUT** — an agent that does not answer will not answer twice. Non-timeout errors still fall back: **v1 agents lacking ifXTable answer `noSuchName`** and are the population the fallback exists for; v2c/v3 agents lacking ifXTable answer clean-empty and fall back as before. Partial rows from a mid-walk error stay discarded. The outcome reaches the caching layer via a new `SnmpService.lookupIfInfo` default method (backward-compatible with functional-interface stubs).

**Endpoint back-off** (`8536bfa`): the miss cache is per `(address, ifIndex)`, so a dead exporter with N distinct ifIndexes in its flows previously paid N × 2 s of walks per 60 s window, each blocking a commonPool thread, with 3 WARNs per miss. A timed-out walk now condemns the whole endpoint for `riptide.snmp.cache.deadEndpointRetentionMs` (default 60 s, 0 disables); all lookups short-circuit for the window; config hot-reload (`invalidateAll`) clears the marking. One WARN when condemning; the per-ifIndex diagnostic only fires for agents that answered.

## Tests

12/12 `SnmpTest`: timeout → single walk, single WARN, `TIMEOUT` outcome; `shouldFallback` matrix pinning the v1-ERROR and clean-empty branches; dead endpoint short-circuits across ifIndexes with log assertions and hot-reload recovery; `testSnmpCache` disables the back-off (its first lookup targets a stopped agent) exactly as it already disabled negative caching. `mvn verify` green.

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)