### PR TITLE
perf(clickhouse): restructure samples() view for 5-15x faster queries

### DIFF
--- a/docs/docs/configuration/clickhouse.md
+++ b/docs/docs/configuration/clickhouse.md
@@ -55,10 +55,11 @@ what ClickHouse accepts under backtick quoting; rename such a database or use va
 
   :::warning[Hand-created `samples` views need re-creating]
 
-  The `samples` bucket split was corrected in #270 (older definitions under-report traffic by up
-  to the flow's bucket count). Manage-mode collectors heal on restart, but a `samples` view an
-  admin created by hand — e.g. in a provisioned deployment — keeps the old formula until it is
-  re-created from the current definition.
+  The `samples` definition evolves: the bucket split was corrected in #270 (older definitions
+  under-report traffic by up to the flow's bucket count), and the view body was restructured in
+  #346 (older definitions are 5–15× slower on every query). Manage-mode collectors heal on
+  restart, but a `samples` view an admin created by hand — e.g. in a provisioned deployment —
+  keeps the old definition until it is re-created from the current one.
 
   :::
 - **`false` (provisioned / multi-tenant)** — the collector creates nothing. It validates that the
@@ -168,6 +169,74 @@ that moment on. To backfill, `INSERT INTO … SELECT` from `flows` yourself, kee
 grouping the view uses.
 
 :::
+
+## Query performance
+
+The `samples(ival)` view expands each flow into per-bucket rows, attributing bytes and packets to
+each bucket **proportionally to the time the flow spent in it** (assuming an even rate across the
+flow's `deltaSwitched`…`lastSwitched` interval). Summing over buckets always returns the flow's
+exact totals. This is the same `time-proportional` load scheme SiLK's `rwcount` defaults to; no
+other ClickHouse flow store offers it — the usual alternative (bucketing each flow entirely into
+its start minute) spikes long flows into single buckets. The precision has a query-time cost:
+every query over `samples()` processes roughly *flows × buckets-per-flow* rows. Three habits keep
+that cost small:
+
+**Use the rollups when buckets are a minute or coarser.** A `samples(ival = 60)` query and a
+[rollup](#rollups) query differ in attribution (proportional vs. start-minute) but usually not in
+what a dashboard shows — and the rollup reads thousands of rows instead of exploding millions.
+Reach for `samples()` when you need sub-minute buckets or exact proportional attribution.
+
+**Bound the flow interval *and* the raw record time, and keep top-N mapping on raw keys.** Inside
+the view the bucketed `timestamp` shadows the raw column, so neither `WHERE timestamp …` nor
+bounds on `deltaSwitched`/`lastSwitched` can use the table's partition or primary index — the
+interval columns are in neither key, so those bounds only filter rows before the explosion (still
+worthwhile). The raw, indexed column stays addressable through the view as `flow.timestamp`:
+bound it too, widened by the longest flow duration you expect, and the query prunes partitions
+like a direct table read:
+
+```sql
+-- top-10 source AS as bps series, {from}/{to}/{ival} filled in by the caller
+WITH top AS (
+    SELECT srcAs FROM riptide.flows
+    WHERE timestamp >= {from} AND timestamp <= {to}
+      AND lastSwitched >= {from} AND deltaSwitched <= {to}
+    GROUP BY srcAs ORDER BY sum(bytes) DESC LIMIT 10
+)
+SELECT time, if(asn IS NULL, 'Other', toString(asn)) AS series, b   -- labels: hundreds of rows
+FROM (
+    SELECT timestamp AS time,
+           if(srcAs IN top, toNullable(srcAs), NULL) AS asn,        -- raw-key mapping: millions of rows
+           sum(bytes) * 8 / {ival} AS b
+    FROM riptide.samples(ival = {ival})
+    WHERE timestamp >= {from} AND timestamp <= {to}
+      AND lastSwitched >= {from} AND deltaSwitched <= {to}          -- pre-explosion row filter
+      AND flow.timestamp >= {from} - INTERVAL 1 HOUR                -- partition/index pruning on the
+      AND flow.timestamp <= {to} + INTERVAL 1 HOUR                  -- raw column, widened by max flow duration
+    GROUP BY time, asn
+) ORDER BY time;
+```
+
+`NULL` is the 'Other' sentinel because it lies outside the value space: unknown AS arrives as
+`srcAs = 0`, which is a real series (often the largest) and must not be folded into 'Other'.
+
+**Render labels after aggregating, not per row.** The inner `GROUP BY` above runs over the
+exploded rows — millions of them — so group on raw binary columns (addresses, AS numbers,
+tuples) and build display strings (`IPv6NumToString`, `concat`, hostname fallbacks) in the outer
+select, which sees only a few hundred aggregated rows. For high-cardinality keys like
+conversations this alone is worth ~1.5×; formatted-string group keys also force ClickHouse's
+slowest aggregation path.
+
+:::note
+
+The bundled top-10 dashboards predate this guidance and still render their series labels per
+exploded row; rewriting them to this pattern is follow-up work tracked in #346.
+
+:::
+
+The view needs a ClickHouse with the new query analyzer (24.8+ recommended, where it is the
+default). The view does not emit zero rows for empty buckets — use
+`ORDER BY time WITH FILL STEP {ival}` (or Grafana's null-as-zero option) when a panel needs
+gap filling.
 
 ## Identity columns
 

--- a/src/main/java/org/riptide/schema/FlowsSchema.java
+++ b/src/main/java/org/riptide/schema/FlowsSchema.java
@@ -426,29 +426,13 @@ public final class FlowsSchema {
     private static final String SAMPLES_VIEW = """
         CREATE OR REPLACE VIEW @@samples@@ AS
         WITH
-            toInt64({ival:Int64} * 1e9) AS interval_ns,
+            toInt64({ival:Int64} * 1000000000) AS interval_ns,
 
-            -- Find first and last absolute bucket numbers. Integer division is load-bearing:
-            -- Float64 '/' cannot represent nanosecond epochs exactly (ULP ~256ns), which would
-            -- absorb the boundary shift below. greatest() clamps corrupt flows with
-            -- lastSwitched < deltaSwitched to one bucket — unclamped, bucket_count wraps and
-            -- range() throws, poisoning every query over the view. The 1ns shift moves a flow
-            -- ending exactly on a bucket boundary into the preceding bucket instead of emitting
-            -- a spurious zero-contribution bucket.
-            toUInt64(intDiv(toUnixTimestamp64Nano(deltaSwitched), interval_ns)) as first_bucket,
-            toUInt64(intDiv(toUnixTimestamp64Nano(greatest(lastSwitched, deltaSwitched))
-                            - if(age('ns', deltaSwitched, lastSwitched) > 0, 1, 0),
-                            interval_ns)) as last_bucket,
-
-            last_bucket - first_bucket + 1 as bucket_count,
-
-            -- Calculate total duration in nanoseconds
-            age('ns', deltaSwitched, lastSwitched) as flow_duration,
-
-            -- Generate buckets from the first bucket onward
-            range(toUInt32(bucket_count)) AS buckets,
-
-            -- Determine the fraction of the interval used in each case
+            -- Determine the fraction of the interval used in each case. Computed from the
+            -- per-flow scalars the inner subquery materialized: as plain WITH aliases over the
+            -- base columns these expressions re-expand per reference through the ARRAY JOIN,
+            -- which made every query over the view 5-15x slower (issue #346) — keep the scalar
+            -- math in the subquery and only shallow arithmetic here.
             CASE
                 -- Only one bucket
                 WHEN bucket_count = 1
@@ -456,11 +440,11 @@ public final class FlowsSchema {
 
                 -- First bucket: Portion from start time to the next bucket boundary
                 WHEN bucket = 0
-                    THEN ((interval_ns * (first_bucket + 1)) - toUnixTimestamp64Nano(deltaSwitched)) / interval_ns
+                    THEN ((interval_ns * (first_bucket + 1)) - delta_ns) / interval_ns
 
                 -- Last bucket: Portion from the start of the last bucket to end time
                 WHEN bucket = bucket_count - 1
-                    THEN (toUnixTimestamp64Nano(lastSwitched) - (interval_ns * last_bucket)) / interval_ns
+                    THEN (last_ns - (interval_ns * last_bucket)) / interval_ns
 
                 -- Full buckets in between
                 ELSE 1.0
@@ -475,15 +459,46 @@ public final class FlowsSchema {
             if(bucket_count = 1, 1., bucket_fraction * interval_ns / flow_duration) AS bucket_share
 
         SELECT
-            flow.*,
+            -- EXCEPT hides the helper scalars below. The raw timestamp/bytes/packets stay
+            -- addressable under their flow.-qualified names (and appear so in SELECT *) — that is
+            -- pre-existing analyzer behavior, and flow.timestamp is exactly what a partition-
+            -- pruning time bound must reference (see the query-performance docs).
+            flow.* EXCEPT (delta_ns, last_ns, first_bucket, last_bucket, bucket_count, flow_duration),
 
             fromUnixTimestamp64Nano((first_bucket + bucket) * interval_ns) AS timestamp,
 
-            bytes * bucket_share as bytes,
-            packets * bucket_share as packets
+            bytes * bucket_share AS bytes,
+            packets * bucket_share AS packets
 
-        FROM @@flows@@ AS flow
-        ARRAY JOIN buckets AS bucket
-        ORDER BY timestamp;
+        FROM (
+            SELECT
+                *,
+
+                toUnixTimestamp64Nano(deltaSwitched) AS delta_ns,
+                toUnixTimestamp64Nano(lastSwitched) AS last_ns,
+
+                -- Find first and last absolute bucket numbers. Integer division is load-bearing:
+                -- Float64 '/' cannot represent nanosecond epochs exactly (ULP ~256ns), which would
+                -- absorb the boundary shift below. greatest() clamps corrupt flows with
+                -- lastSwitched < deltaSwitched to one bucket — unclamped, bucket_count wraps and
+                -- range() throws, poisoning every query over the view. The 1ns shift moves a flow
+                -- ending exactly on a bucket boundary into the preceding bucket instead of emitting
+                -- a spurious zero-contribution bucket.
+                toUInt64(intDiv(delta_ns, interval_ns)) AS first_bucket,
+                toUInt64(intDiv(greatest(last_ns, delta_ns) - if(last_ns > delta_ns, 1, 0),
+                                interval_ns)) AS last_bucket,
+
+                last_bucket - first_bucket + 1 AS bucket_count,
+
+                -- Total duration in nanoseconds; negative for corrupt flows, which never divide
+                -- by it (they clamp to bucket_count = 1 above).
+                last_ns - delta_ns AS flow_duration
+
+            FROM @@flows@@
+        ) AS flow
+        -- No ORDER BY: callers that need an order state it themselves. Aggregating consumers get
+        -- the sort eliminated by the optimizer either way, but a bare SELECT would pay a full sort
+        -- of the exploded set (~rows x buckets) for an ordering nothing relies on.
+        ARRAY JOIN range(toUInt32(bucket_count)) AS bucket;
     """;
 }

--- a/src/test/java/org/riptide/repository/clickhouse/ClickhouseRepositoryIT.java
+++ b/src/test/java/org/riptide/repository/clickhouse/ClickhouseRepositoryIT.java
@@ -23,7 +23,9 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.net.InetAddress;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 /**
  * First real-ClickHouse test of the repository: schema creation on a fresh
@@ -270,6 +272,49 @@ public class ClickhouseRepositoryIT {
                 "SELECT sum(bytes) AS b, sum(packets) AS p FROM " + database + ".samples(ival = 60)");
         Assertions.assertThat(totals.getFirst().getDouble("b")).isCloseTo(6000.0, Assertions.within(0.01));
         Assertions.assertThat(totals.getFirst().getDouble("p")).isCloseTo(90.0, Assertions.within(0.01));
+    }
+
+    @Test
+    void samplesViewClampsDegenerateFlowsAndHidesHelperColumns() throws Exception {
+        final var database = "samples_guard";
+        final var repo = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), configFor(database, true), RESOLVERS);
+        repo.start();
+
+        // The two degenerate cases the view's guards exist for: a zero-duration flow (the
+        // bucket_count = 1 branch is its division guard) and a corrupt flow with
+        // lastSwitched < deltaSwitched (the greatest() clamp — unclamped, bucket_count wraps and
+        // range() throws, poisoning every query over the view). Each must land in exactly one
+        // bucket with its full totals.
+        final var minute = Instant.now().truncatedTo(ChronoUnit.MINUTES).minus(10, ChronoUnit.MINUTES);
+        repo.persist(List.of(
+                testFlow(minute.plusSeconds(15), minute.plusSeconds(15), 40011, 443, 500L, 5L),
+                testFlow(minute.plusSeconds(75), minute.plusSeconds(70), 40012, 443, 700L, 7L)));
+
+        final var totals = queryClient.queryAll(
+                "SELECT count() AS n, sum(bytes) AS b, sum(packets) AS p FROM " + database + ".samples(ival = 60)");
+        Assertions.assertThat(totals.getFirst().getLong("n")).isEqualTo(2L);
+        Assertions.assertThat(totals.getFirst().getDouble("b")).isCloseTo(1200.0, Assertions.within(0.01));
+        Assertions.assertThat(totals.getFirst().getDouble("p")).isCloseTo(12.0, Assertions.within(0.01));
+
+        // The view's output contract, derived rather than enumerated: every flows column in
+        // order — with the shadowed trio surfacing under flow.-qualified names — followed by the
+        // bucketed timestamp/bytes/packets. Comparing the full DESCRIBE catches a leaked helper
+        // scalar whatever its name (an enumerated negative list would stay green after a rename),
+        // and equally catches an EXCEPT entry accidentally hiding a real flows column.
+        final var shadowed = Set.of("timestamp", "bytes", "packets");
+        final var expected = new ArrayList<String>();
+        queryClient.queryAll("SELECT name FROM system.columns WHERE database = '" + database
+                        + "' AND table = 'flows' ORDER BY position")
+                .forEach(row -> {
+                    final var name = row.getString("name");
+                    expected.add(shadowed.contains(name) ? "flow." + name : name);
+                });
+        expected.addAll(List.of("timestamp", "bytes", "packets"));
+        final var actual = queryClient.queryAll(
+                        "DESCRIBE (SELECT * FROM " + database + ".samples(ival = 60))").stream()
+                .map(row -> row.getString("name"))
+                .toList();
+        Assertions.assertThat(actual).containsExactlyElementsOf(expected);
     }
 
     @Test

--- a/src/test/java/org/riptide/schema/FlowsSchemaTest.java
+++ b/src/test/java/org/riptide/schema/FlowsSchemaTest.java
@@ -58,7 +58,10 @@ class FlowsSchemaTest {
     void createSamplesViewQualifiesBothViewAndSourceTable() {
         final String ddl = FlowsSchema.createSamplesView("riptide");
         assertThat(ddl.strip()).startsWith("CREATE OR REPLACE VIEW `riptide`.samples AS");
-        assertThat(ddl).contains("FROM `riptide`.flows AS flow");
+        // One pattern spanning FROM through the alias: the qualified flows table must be what the
+        // scalar-projecting subquery aliased AS flow reads — two independent contains() would
+        // also pass with the fragments in unrelated clauses.
+        assertThat(ddl).containsPattern("FROM `riptide`\\.flows\\s*\\)\\s*AS flow");
         // The view parameter is a literal placeholder bound at SELECT time, not at CREATE time.
         assertThat(ddl).contains("{ival:Int64}");
     }
@@ -69,7 +72,7 @@ class FlowsSchemaTest {
                 .contains("CREATE TABLE IF NOT EXISTS `acme_prod`.flows (");
         assertThat(FlowsSchema.createSamplesView("acme_prod"))
                 .contains("VIEW `acme_prod`.samples AS")
-                .contains("FROM `acme_prod`.flows AS flow");
+                .containsPattern("FROM `acme_prod`\\.flows\\s*\\)\\s*AS flow");
         assertThat(FlowsSchema.qualifiedFlows("acme_prod")).isEqualTo("`acme_prod`.flows");
     }
 


### PR DESCRIPTION
Closes #346.

## What

Restructures the `samples(ival)` view body: the per-flow scalars (`delta_ns`, `last_ns`, `first_bucket`, `last_bucket`, `bucket_count`, `flow_duration`) are materialized once in an inner subquery **before** the ARRAY JOIN explosion, with only shallow arithmetic left in the outer select. The contract is unchanged — same parameter, same output columns (`flow.* EXCEPT` hides the helpers), same #270-corrected proportional attribution, boundary shift, and degenerate-flow guards.

Also: the internal `ORDER BY` is dropped (optimizer-eliminated for aggregating consumers anyway; a full sort of the exploded set for a bare SELECT otherwise), and `age('ns', …)` is replaced by direct nanosecond subtraction on the materialized scalars — verified exactly equivalent (sign, zero, sub-second, pre-1970, types, bit-identical division results), which drops the view's `~24.5` minimum for that function.

## Why

Investigating #346 showed the reported 13–24× gap is **not** measure-column width through the explosion (the optimizer prunes unused columns before ARRAY JOIN on ≥ 24.8: plan step `DROP unused columns before ARRAY JOIN`). The dominant cost is the old view body itself: WITH aliases re-expand per reference through the explosion, so the epoch/bucket math ran many times per exploded row.

Benchmarks (ClickHouse 26.6, riptide's verbatim DDL, deterministic 1,024,000-flow corpus, 600 s window, 2 s buckets, medians of 5 after warmup, byte-identical results across all forms):

| Top-10 series query | old view | this PR | inline hand-tuned SQL |
|---|---|---|---|
| applications, dashboard idiom | 757 ms | **116 ms (6.5×)** | — |
| conversations, dashboard idiom | 1,840 ms | **342 ms (5.4×)** | — |
| conversations, two-phase raw-key shape | 1,465 ms | **238 ms** | 127 ms |

The unmodified bundled dashboards get the 5–6.5× immediately; rewriting them in the two-phase raw-key shape (another ~1.4× on high-cardinality dimensions, plus partition pruning at retention scale) is follow-up work, as is seeding the #57 benchmark suite with these queries as fixtures.

The measure-projected variants proposed in #346 (`samples_bytes(ival)`, `samples(ival, measure)`) are deliberately **not** implemented: the problem they solve no longer exists on supported versions, and `Identifier` view parameters are undocumented upstream. Details in the issue comment.

## Verification

- DDL validated on ClickHouse 24.8 and 25.3 (IT pin): view output schema identical to the old view (column-list hash equal), per-bucket/per-series checksums over the 1M corpus identical, #270 case exact (2000/4000 split, 2 buckets), zero-duration and corrupt-flow guards conserve totals.
- `age('ns')` → subtraction equivalence verified on 24.8/25.3 incl. edge cases; full old-vs-new row-level `EXCEPT` diff returns 0 rows.
- New IT asserts the degenerate-flow guards and the view's column contract **derived** from `DESCRIBE` vs the flows schema (catches any leaked helper or an EXCEPT entry hiding a real column, regardless of naming).
- `make jar` (full `mvn verify` incl. SpotBugs/checkstyle) and `make docs` green; `ClickhouseRepositoryIT` 12/12, `FlowsSchemaTest` 14/14.

Known pre-existing quirk (documented, not changed): `SELECT *` through the view also emits the raw shadowed trio under `flow.`-qualified names (`flow.timestamp` etc.) — analyzer behavior, identical before and after this PR; `flow.timestamp` is in fact the escape hatch for partition-pruning time bounds and the docs now say so. Not addressed: overflow of `ival ≥ ~9.2e9` seconds now wraps instead of saturating — a ~292-year bucket interval is treated as out of scope.

## Docs

New "Query performance" section in `configuration/clickhouse.md`: rollup routing for ≥ 1 min buckets, flow-interval bounds **plus** `flow.timestamp` bounds for partition pruning through the view, raw-key top-N mapping with a NULL sentinel (AS 0 is real traffic and must not fold into 'Other'), label rendering after aggregation, and a note that the bundled dashboards predate this guidance. The hand-created-view warning now covers #346: provisioned deployments keep the slow definition until the view is re-created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)