### PR TITLE
build(release): cycle-proof release-branch flow in docs and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,8 +182,11 @@ release:
 	@echo -n "Check release branch:        "
 	@if [ "$(GIT_BRANCH)" != "release" ]; then echo "Releases are made from the release branch, your branch is $(GIT_BRANCH)."; exit 1; fi
 	@echo "$(OK)"
+	@echo -n "Check upstream configured    "
+	@if ! git rev-parse --abbrev-ref @{u} >/dev/null 2>&1; then echo "No upstream for the release branch — run: git push -u origin release"; exit 1; fi
+	@echo "$(OK)"
 	@echo -n "Check release branch in sync "
-	@if [ "$$(git rev-parse HEAD)" != "$$(git rev-parse @{u})" ]; then echo "Release branch not in sync with remote origin."; exit 1; fi
+	@if [ "$$(git rev-parse HEAD)" != "$$(git rev-parse @{u})" ]; then echo "Release branch not in sync with its upstream."; exit 1; fi
 	@echo "$(OK)"
 	@echo -n "Check uncommited changes     "
 	@if git status --porcelain | grep -q .; then echo "There are uncommited changes in your repository."; exit 1; fi

--- a/README.md
+++ b/README.md
@@ -114,7 +114,9 @@ You can also bind mount your configuration to `/app/application.properties`.
 # 📦 Make a release
 
 ```
-git checkout -b release
+git checkout main && git pull
+git checkout -B release
+git push -u origin release
 make release RELEASE_VERSION=1.0.0
 ```
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,13 +14,17 @@ anything else patch.
 other change. Example for 1.0.0:
 
 ```bash
-git checkout -b release
+git checkout main && git pull
+git checkout -B release
+git push -u origin release
 make release RELEASE_VERSION=1.0.0
 ```
 
-`make release` refuses to run unless you are on the `release` branch, in sync
-with origin, with a clean tree and a version tag that does not exist yet. It
-then:
+`checkout -B` starts the branch fresh from up-to-date `main` even when a local
+`release` from the previous cycle is still around. `make release` refuses to
+run unless you are on the `release` branch, in sync with its upstream (hence
+the `git push -u` above), with a clean tree and a version tag that does not
+exist yet. It then:
 
 1. sets the release version in `pom.xml`
 2. commits it and creates the annotated tag `v1.0.0`
@@ -35,7 +39,11 @@ git push origin HEAD
 git push origin v1.0.0
 ```
 
-Open a PR to merge `release` into `main` and squash-merge it as usual.
+Open a PR to merge `release` into `main` and squash-merge it as usual. The
+branch is deleted automatically on merge; the next release recreates it fresh
+off `main`. An abandoned attempt (PR closed without merging) leaves a stale
+`origin/release` behind — delete it before starting over:
+`git push origin --delete release`.
 
 **The tag push is what releases.** Everything below happens in
 [`release.yml`](.github/workflows/release.yml) with no further input.


### PR DESCRIPTION
Follow-up to the v0.6.3 release cycle: the `release` branch is ephemeral now (auto-deleted on merge-back; the `protect-release-branch` ruleset that kept it alive and blocked deletion is removed), and this PR makes the documented flow and the tooling match that reality. Applies all seven findings from the pre-PR code review.

- **RELEASING.md + README quick-start**: start the branch with `git checkout main && git pull && git checkout -B release` — the old `checkout -b` fails on the second cycle against the surviving local branch, and nothing pinned the starting point to up-to-date `main`. Both copies of the procedure now agree and include the required `git push -u origin release`.
- **Makefile**: `make release` now distinguishes a missing upstream from a diverged one. Previously an upstream-less branch hit the sync check's empty `git rev-parse @{u}` substitution and reported the misleading "not in sync with remote origin"; it now fails fast with the actual fix (`run: git push -u origin release`). Verified by running the target on an upstream-less `release` branch.
- **RELEASING.md**: documents the abandoned-attempt case (a stale `origin/release` from an unmerged PR is not auto-deleted — delete it before starting over) and drops the overstated wording around what the sync check compares.

🤖 Generated with [Claude Code](https://claude.com/claude-code)