### PR TITLE
fix(build): compile tests and honour FUZZ_TIME in make fuzz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,13 +91,15 @@ e2e: deps-jar deps-oci
 # mode (the seed corpus replays as ordinary tests in `make jar`) into fuzzing mode. FUZZ_TIME is
 # the per-target budget in seconds; FUZZ_TARGET narrows to one harness (the nightly matrix passes
 # it per job); the corpus persists in .cifuzz-corpus so coverage compounds.
+# test-compile is part of the invocation because deps-jar only checks tool versions: on a fresh
+# checkout (i.e. CI) surefire:test alone has no target/test-classes to select a harness from.
 FUZZ_TIME   ?= 120
 FUZZ_TARGET ?= *FuzzTest
 .PHONY: fuzz
 fuzz: deps-jar
-	JAZZER_FUZZ=1 mvn $(BUILD_OPTS) --batch-mode surefire:test \
-		-Dtest='org.riptide.flows.fuzz.$(FUZZ_TARGET)' -DfailIfNoSpecifiedTests=false \
-		-Djazzer.max_total_time=$(FUZZ_TIME)
+	JAZZER_FUZZ=1 mvn $(BUILD_OPTS) --batch-mode test-compile surefire:test \
+		-Dtest='org.riptide.flows.fuzz.$(FUZZ_TARGET)' \
+		-Djazzer.max_duration=$(FUZZ_TIME)s
 
 .PHONY: deps-lint-actions
 deps-lint-actions:


### PR DESCRIPTION
The nightly [Fuzz workflow](https://github.com/Riptide-Labs/riptide/actions/workflows/fuzz.yml) has failed on every run since it landed. The workflow itself is fine — the bug is in the `make fuzz` target it calls.

## Two defects

**1. Nothing compiles the tests.** `fuzz: deps-jar`, and `deps-jar` only echoes tool versions. So `mvn surefire:test` selected harnesses from a `target/test-classes` that does not exist on a fresh checkout:

```
[ERROR] No tests matching pattern "org.riptide.flows.fuzz.Netflow5ParserFuzzTest" were executed!
make: *** [fuzz] Error 1
```

Reproduced identically in a clean worktree. It passes locally only because `target/` is already populated. Fixed by running `test-compile` in the same invocation.

**2. `FUZZ_TIME` was silently ignored.** Jazzer does not read `jazzer.max_total_time`, so every target ran the 5-minute `@FuzzTest` default — a run with `FUZZ_TIME=15` fuzzed for `Done 29709570 runs in 301 second(s)`. Disassembling jazzer 0.30.0's `Opt` gives the real name:

> `max_duration` — "Sets the maximum fuzzing duration (e.g. '30s', '2m', '1h'). For JUnit tests, overrides `@FuzzTest(maxDuration)`"

Also drops `-DfailIfNoSpecifiedTests=false`. Surefire 3.x spells that property `surefire.failIfNoSpecifiedTests`, and that typo is the only reason CI reported anything — spelled correctly it would have let the nightly go green while fuzzing nothing. Without it, a bad matrix entry fails loudly.

## Verification

Clean worktree at the previous HEAD reproduced the CI failure exactly. After the fix, `FUZZ_TIME=20`:

```
Done 1889114 runs in 21 second(s)
[INFO] Tests run: 56, Failures: 0, Errors: 0, Skipped: 0 -- in org.riptide.flows.fuzz.Netflow5ParserFuzzTest
[INFO] BUILD SUCCESS
```

and the corpus lands in `.cifuzz-corpus/org.riptide.flows.fuzz.Netflow5ParserFuzzTest`, the path the workflow's cache step keys on.

Only `Netflow5ParserFuzzTest` was exercised end to end; the other three matrix names match existing files, and with the escape hatch gone any mismatch now fails the job rather than passing quietly. I'll dispatch a short manual run of all four targets after merge to confirm.