### PR TITLE
fix(parser): convert into primitive flow fields; preserve fuzz corpus on timeout

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -62,8 +62,12 @@ jobs:
           make fuzz
       # A crash writes its reproducer under src/test/resources/.../<target>Inputs/. Upload it (and
       # the corpus) so a maintainer can replay it locally, then commit it to lock in the regression.
+      # cancelled() is included because a pathological input that hangs rather than crashes trips the
+      # job timeout, which is a cancellation, not a failure: without it that run uploads nothing and
+      # the discovered corpus is lost with the runner. cancelled() also lets this step run during the
+      # timeout's grace period at all.
       - name: Upload crash reproducers
-        if: failure()
+        if: ${{ failure() || cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fuzz-crash-${{ matrix.target }}

--- a/src/main/java/org/riptide/flows/parser/ie/values/ValueConversionService.java
+++ b/src/main/java/org/riptide/flows/parser/ie/values/ValueConversionService.java
@@ -49,15 +49,20 @@ public class ValueConversionService {
         validate();
     }
 
+    /**
+     * Visitors are keyed by their boxed target class, so a primitive field type must be boxed before
+     * lookup. apply() and validate() both go through here: when they disagreed, validate() accepted a
+     * primitive-typed field at construction while apply() looked it up raw, missed, and threw an NPE
+     * for every such value.
+     */
+    private static Class<?> boxed(final Class<?> type) {
+        return type.isPrimitive() ? PRIMITIVE_TYPE_MAP.get(type) : type;
+    }
+
     private void validate() {
         final var requiredTypes = Stream.of(targetType.getDeclaredFields())
                 .map(Field::getType)
-                .map(it -> {
-                    if (it.isPrimitive()) {
-                        return PRIMITIVE_TYPE_MAP.get(it);
-                    }
-                    return it;
-                })
+                .map(ValueConversionService::boxed)
                 .distinct()
                 .toList();
         for (Class<?> fieldType : requiredTypes) {
@@ -76,14 +81,17 @@ public class ValueConversionService {
             final var key = source.getName();
             final var field = fieldMap.get(key);
             if (field != null) {
-                final var converterVisitor = visitors.get(field.getType());
+                final var converterVisitor = visitors.get(boxed(field.getType()));
                 final var convertedValue = source.accept(converterVisitor);
                 if (convertedValue != null) {
                     field.set(targetFlow, convertedValue);
                 }
             }
         } catch (Exception ex) {
-            log.error("🤡🦄💩: {}", ex.getMessage(), ex);
+            // One unconvertible value must not drop the whole flow, so swallow and move on. Logged at
+            // debug because this runs once per value on the untrusted-input path: a malformed packet
+            // could otherwise flood the log at a higher level (which is exactly what masked this bug).
+            log.debug("Could not convert value {} into {}: {}", source.getName(), targetType, ex.getMessage(), ex);
         }
 
     }

--- a/src/test/java/org/riptide/flows/parser/ie/values/ValueConversionServiceTest.java
+++ b/src/test/java/org/riptide/flows/parser/ie/values/ValueConversionServiceTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.parser.ie.values;
+
+import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.Test;
+import org.riptide.flows.parser.ie.Value;
+import org.riptide.flows.parser.ie.values.visitor.BooleanVisitor;
+import org.riptide.flows.parser.ie.values.visitor.DoubleVisitor;
+import org.riptide.flows.parser.ie.values.visitor.DurationVisitor;
+import org.riptide.flows.parser.ie.values.visitor.InetAddressVisitor;
+import org.riptide.flows.parser.ie.values.visitor.InstantVisitor;
+import org.riptide.flows.parser.ie.values.visitor.IntegerVisitor;
+import org.riptide.flows.parser.ie.values.visitor.LongVisitor;
+import org.riptide.flows.parser.ie.values.visitor.StringVisitor;
+import org.riptide.flows.parser.ie.values.visitor.UnsignedLongVisitor;
+import org.riptide.flows.parser.ie.values.visitor.ValueVisitor;
+import org.riptide.flows.parser.ipfix.IpfixRawFlow;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ValueConversionServiceTest {
+
+    // The full production visitor set: validate() requires a fitting visitor for every field type on
+    // the target, so a trimmed list would fail construction before the conversion under test runs.
+    private static final List<ValueVisitor<?>> VISITORS = List.of(
+            new BooleanVisitor(),
+            new DoubleVisitor(),
+            new DurationVisitor(),
+            new InetAddressVisitor(),
+            new InstantVisitor(),
+            new IntegerVisitor(),
+            new LongVisitor(),
+            new StringVisitor(),
+            new UnsignedLongVisitor());
+
+    /**
+     * recordCount is a primitive {@code int} field. Visitors are keyed by their boxed target class, so
+     * apply() must box the field type before looking one up. When it did not, every primitive-typed
+     * field threw an NPE that was swallowed and logged per value, leaving the field unset.
+     */
+    @Test
+    void convertsIntoPrimitiveField() throws Exception {
+        final var service = new ValueConversionService(IpfixRawFlow.class, VISITORS);
+        final var flow = new IpfixRawFlow();
+
+        final Value<?> recordCount = UnsignedValue.parserWith32Bit("recordCount", null, null)
+                .parse(null, Unpooled.buffer(4).writeInt(7));
+        service.apply(recordCount, flow);
+
+        assertEquals(7, flow.recordCount);
+    }
+
+    /** A boxed field converted through the same path, to show both sides of the boxing behave. */
+    @Test
+    void convertsIntoBoxedField() throws Exception {
+        final var service = new ValueConversionService(IpfixRawFlow.class, VISITORS);
+        final var flow = new IpfixRawFlow();
+
+        final Value<?> octetTotalCount = UnsignedValue.parserWith64Bit("octetTotalCount", null, null)
+                .parse(null, Unpooled.buffer(8).writeLong(42));
+        service.apply(octetTotalCount, flow);
+
+        assertEquals(42L, flow.octetTotalCount);
+    }
+}


### PR DESCRIPTION
Follow-up to the IPFIX fuzz hang investigated after #354. Refs #351.

## 1 — Primitive-field conversion (root cause of the hang)

`ValueConversionService` keys visitors by their **boxed** class. The two methods disagreed on boxing:

- `validate()` boxed a primitive field type *before* checking a visitor existed → construction passed
- `apply()` looked the visitor up with the **raw** type → `visitors.get(int.class)` missed a map keyed by `Integer.class`, returned null, and `source.accept(null)` threw

So every primitive-typed field — `IpfixRawFlow.recordCount` (`int`), `sequenceNumber`/`observationDomainId` (`long`), and the NetFlow 9 equivalents — could *never* convert. The NPE was swallowed and the field silently left at its default.

Fixed by routing both methods through a shared `boxed()` helper so they can't drift again, and looking up the boxed type in `apply()`.

**Regression test** (`ValueConversionServiceTest`) converts into both a primitive and a boxed field. Verified it fails against the pre-fix lookup:

```
convertsIntoPrimitiveField:56 expected: <7> but was: <0>
```

## 2 — Logging policy (what turned the bug into a hang)

The catch stays — one unconvertible value must not drop the whole flow — but the diagnostics were the hazard. On the untrusted-input path a malformed packet drove that catch **once per value**, at `error` with a full stack trace. The nightly IPFIX job buried a real finding under a **~24M line** log flood and tripped its own timeout.

Downgraded to `debug`, and replaced the placeholder `🤡🦄💩` message with one that names the value and target type.

## 3 — Fuzz workflow: preserve corpus on timeout (separate commit)

The reproducer upload ran on `if: failure()`. A pathological input that **hangs** rather than crashes trips the 30-minute job timeout, which is a *cancellation*, not a failure — so that run uploaded nothing and the discovered corpus was lost with the runner. Exactly what happened here: a timed-out nightly with no artifact to debug.

Now gated on `failure() || cancelled()`. Naming `cancelled()` also lets the step run at all during the timeout's grace period.

## Verification

`make jar` — **795 tests, 0 failures** (was 793; +2 from the new test), including SpotBugs/checkstyle/Error Prone. `actionlint`/`zizmor` run in the `lint-actions` CI job.