### PR TITLE
release: merge v0.6.4 version commits back to main

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.riptide.flows</groupId>
     <artifactId>riptide-flows</artifactId>
-    <version>0.6.4</version>
+    <version>0.6.5-SNAPSHOT</version>
     <name>riptide-flows</name>
     <description>NetFlow analysis engine</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.riptide.flows</groupId>
     <artifactId>riptide-flows</artifactId>
-    <version>0.6.4-SNAPSHOT</version>
+    <version>0.6.4</version>
     <name>riptide-flows</name>
     <description>NetFlow analysis engine</description>
 


### PR DESCRIPTION
Merges the `make release` version commits for **v0.6.4** back into `main`:

- `release: Riptide version 0.6.4` (the tagged commit)
- `release: Set new snapshot version 0.6.5-SNAPSHOT`

`main` resumes at `0.6.5-SNAPSHOT`. The `v0.6.4` tag has already been pushed and is driving [`release.yml`](https://github.com/Riptide-Labs/riptide/actions/runs/30045949393); this PR only reconciles `main`'s history and pom version. Standard post-release merge-back, per [RELEASING.md](https://github.com/Riptide-Labs/riptide/blob/main/RELEASING.md).