### PR TITLE
fix(deps): bump all Netty modules to 4.2.16.Final via netty.version

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -49,7 +49,7 @@ maven.buildMavenPackage {
   # Fixed-output hash of the maven dependency set. Regenerate with `make nix-hash` whenever the
   # pom changes; the nix CI job fails the PR if it drifts and prints the expected hash in its
   # job summary.
-  mvnHash = "sha256-k617eYQ/aWBGSSFkUI78XPkbNR0VYd/dCiBv+RC0B/w=";
+  mvnHash = "sha256-ulBcUQcXEHkoIHJiRBXzOg6qFpmGGMgGQqP2kblx9hY=";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,10 @@
         <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
-        <netty-all.version>4.2.16.Final</netty-all.version>
+        <!-- Overrides Spring Boot's managed netty.version (4.2.15.Final), which governs every
+             io.netty:netty-* module and otherwise leaves them a patch behind netty-all. 4.2.16.Final
+             patches the Netty advisories in Scorecard alert #120 (GHSA-hpcc-26xq-25fv and 15 more). -->
+        <netty.version>4.2.16.Final</netty.version>
         <org-eclipse-persistence-moxy.version>5.0.1</org-eclipse-persistence-moxy.version>
         <resilience4j.version>2.4.0</resilience4j.version>
         <snmp4j.version>3.12.2</snmp4j.version>
@@ -56,19 +59,14 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- Transitive-CVE pins (Scorecard/osv-scanner findings). Neither library is on a
-                 reachable path — riptide has no STOMP endpoint (GHSA-vhch-2wf3-m8rp) and Jackson
-                 only rides in with Spring (GHSA-5jmj-h7xm-6q6v) — pinned to the patched versions
-                 anyway. Drop each pin once the managing parent/netty-all catches up. -->
+            <!-- Transitive-CVE pin (Scorecard/osv-scanner finding): Jackson is not on a reachable
+                 path — it only rides in with Spring (GHSA-5jmj-h7xm-6q6v) — pinned to the patched
+                 version anyway. Drop once the managing parent catches up. Netty (including the
+                 former netty-codec-stomp pin) is handled by the netty.version override above. -->
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
                 <version>2.22.1</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-codec-stomp</artifactId>
-                <version>4.2.16.Final</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -97,7 +95,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>${netty-all.version}</version>
+            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Closes #358. Resolves Scorecard alert [#120](https://github.com/Riptide-Labs/riptide/security/code-scanning/120) (16 Netty advisories).

## Why it was real, not stale

`pom.xml` set `netty-all.version=4.2.16.Final` and pinned `netty-codec-stomp`, but Spring Boot 4.1.0 manages `netty.version = 4.2.15.Final` — and **that** property governs every `io.netty:netty-*` module, overriding what `netty-all` drags in. Result: the functional modules shipped a patch behind, inside the vulnerable range of all 16 advisories:

| Artifact | Before | After |
|---|---|---|
| `netty-all`, `netty-codec-stomp` | 4.2.16.Final | 4.2.16.Final |
| `netty-codec`, `-handler`, `-transport`, `-buffer`, `-codec-compression`, `-http/http2/http3`, `-haproxy`, `-xml`, `-handler-ssl-ocsp` | **4.2.15.Final** ✗ | 4.2.16.Final ✓ |

`netty-transport`, `-codec`, `-handler`, `-buffer`, `-codec-compression` are on the hot path for the UDP/TCP flow listeners. The earlier remediation (#318) only touched `netty-all` + `netty-codec-stomp`, missing the Spring-managed modules.

## The change

Override the Spring-managed property instead of pinning individual artifacts, so one line lifts every module; point `netty-all` at the same property; drop the now-redundant `netty-codec-stomp` pin (per that pom comment's own "drop once the parent catches up").

## Verification

- `mvn dependency:tree` — every netty module resolves to **4.2.16.Final**, 0 below (stomp included, via the property, with its pin removed)
- `make jar` — **792 tests, 0 failures**, including SpotBugs/checkstyle/Error Prone

Once merged, the next Scorecard run should clear alert #120.