### PR TITLE
release: merge v0.6.5 version commits back to main

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.riptide.flows</groupId>
     <artifactId>riptide-flows</artifactId>
-    <version>0.6.5</version>
+    <version>0.6.6-SNAPSHOT</version>
     <name>riptide-flows</name>
     <description>NetFlow analysis engine</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.riptide.flows</groupId>
     <artifactId>riptide-flows</artifactId>
-    <version>0.6.5-SNAPSHOT</version>
+    <version>0.6.5</version>
     <name>riptide-flows</name>
     <description>NetFlow analysis engine</description>
 


### PR DESCRIPTION
Merges the `make release` version commits for **v0.6.5** back into `main`:

- `release: Riptide version 0.6.5` (the tagged commit)
- `release: Set new snapshot version 0.6.6-SNAPSHOT`

`main` resumes at `0.6.6-SNAPSHOT`. The `v0.6.5` tag is already pushed and driving [`release.yml`](https://github.com/Riptide-Labs/riptide/actions/runs/30049580843); this PR only reconciles `main`. Standard post-release merge-back per [RELEASING.md](https://github.com/Riptide-Labs/riptide/blob/main/RELEASING.md).