### PR TITLE
feat(deployment): add collection-health Grafana dashboard

### DIFF
--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-collection-health.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-collection-health.json
@@ -1,0 +1,713 @@
+{
+  "title": "Riptide - Collection Health",
+  "uid": "riptide-collection-health",
+  "description": "Is flow collection healthy right now — is every exporter delivering? Status wall for the operator running the Riptide collector: verdict on top, per-exporter activity below, inventory with drill-down at the bottom. All panels read ingest time (receivedAt), not flow switch time, so they measure the collection pipeline rather than the traffic.",
+  "tags": ["riptide", "netflow", "collection-health", "audience:noc"],
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "schemaVersion": 39,
+  "refresh": "1m",
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "links": [
+    {
+      "title": "Operations runbook (health endpoints, ports, troubleshooting)",
+      "type": "link",
+      "url": "https://github.com/Riptide-Labs/riptide-flows/blob/main/docs/docs/deploy/operations.md",
+      "targetBlank": true,
+      "icon": "doc"
+    },
+    {
+      "title": "Riptide dashboards",
+      "type": "dashboards",
+      "tags": ["riptide"],
+      "asDropdown": true,
+      "includeVars": true,
+      "keepTime": true
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "label": "Datasource",
+        "type": "datasource",
+        "query": "grafana-clickhouse-datasource",
+        "current": {},
+        "refresh": 1
+      },
+      {
+        "name": "database",
+        "label": "Database",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${datasource}"
+        },
+        "query": {
+          "editorType": "sql",
+          "format": 1,
+          "queryType": "table",
+          "rawSql": "SELECT DISTINCT database FROM system.tables WHERE name = 'flows'"
+        },
+        "definition": "SELECT DISTINCT database FROM system.tables WHERE name = 'flows'",
+        "refresh": 1,
+        "sort": 1,
+        "current": {}
+      },
+      {
+        "name": "bucket",
+        "label": "Bucket (s)",
+        "type": "custom",
+        "query": "60,300,900",
+        "current": {
+          "selected": true,
+          "text": "300",
+          "value": "300"
+        },
+        "options": [
+          { "selected": false, "text": "60", "value": "60" },
+          { "selected": true, "text": "300", "value": "300" },
+          { "selected": false, "text": "900", "value": "900" }
+        ]
+      },
+      {
+        "name": "tenant",
+        "label": "Tenant",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${datasource}"
+        },
+        "query": {
+          "editorType": "sql",
+          "format": 1,
+          "queryType": "table",
+          "rawSql": "SELECT DISTINCT tenant FROM ${database}.flows ORDER BY tenant"
+        },
+        "definition": "SELECT DISTINCT tenant FROM ${database}.flows ORDER BY tenant",
+        "refresh": 1,
+        "includeAll": true,
+        "multi": true,
+        "sort": 1,
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        }
+      },
+      {
+        "name": "zone",
+        "label": "Zone",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${datasource}"
+        },
+        "query": {
+          "editorType": "sql",
+          "format": 1,
+          "queryType": "table",
+          "rawSql": "SELECT DISTINCT zone FROM ${database}.flows ORDER BY zone"
+        },
+        "definition": "SELECT DISTINCT zone FROM ${database}.flows ORDER BY zone",
+        "refresh": 1,
+        "includeAll": true,
+        "multi": true,
+        "sort": 1,
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Exporters reporting — last 15 min",
+      "description": "Distinct exporters that delivered at least one flow record in the last 15 minutes, independent of the selected time range. Normal: matches the number of devices configured to export to this collector. NONE (red) means the collector is receiving nothing — check the collector first: is the container up, is /readyz returning 200, is UDP 9999 reachable? See the operations runbook linked in the dashboard header.",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${datasource}"
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": { "text": "NONE", "color": "red", "index": 0 }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "graphMode": "none",
+        "colorMode": "value",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "${datasource}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "queryType": "table",
+          "rawSql": "SELECT uniqExact(exporterAddr) AS \"Exporters reporting\"\nFROM ${database}.flows\nWHERE timestamp >= now() - INTERVAL 1 DAY AND receivedAt >= now() - INTERVAL 15 MINUTE AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone)",
+          "refId": "A",
+          "meta": { "timezone": "UTC" }
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Silent exporters — seen in range, quiet 15 min",
+      "description": "Exporters that delivered flows inside the selected time range but nothing in its final 15 minutes (relative to the range end, so panning into the past judges that window, not now). Normal: 0 (green). Any other value (red) means a device stopped exporting or its packets stopped arriving — check the exporter device and the network path to the collector before suspecting the collector itself, since the other exporters are still getting through. On a quiet network with genuinely idle exporters, widen the mental threshold accordingly; ranges shorter than 15 minutes make this panel meaningless.",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${datasource}"
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "graphMode": "none",
+        "colorMode": "value",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "${datasource}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "queryType": "table",
+          "rawSql": "SELECT countIf(lastSeen < $__toTime - INTERVAL 15 MINUTE) AS \"Silent exporters\"\nFROM (\n  SELECT exporterAddr, max(receivedAt) AS lastSeen\n  FROM ${database}.flows\n  WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone)\n  GROUP BY exporterAddr\n)",
+          "refId": "A",
+          "meta": { "timezone": "UTC" }
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Flow record rate — last 5 min",
+      "description": "Flow records received per second, averaged over the last 5 minutes, independent of the selected time range. Normal: steady and roughly proportional to network activity; compare against the 'Flow records by exporter' panel below for what steady looks like here. STALLED (red) means zero records arrived in 5 minutes — treat it like 'Exporters reporting = NONE' and start with the collector's /readyz and the UDP listener port.",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${datasource}"
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "decimals": 1,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": { "text": "STALLED", "color": "red", "index": 0 }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "graphMode": "area",
+        "colorMode": "value",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "${datasource}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "queryType": "table",
+          "rawSql": "SELECT count() / 300 AS \"Flow record rate\"\nFROM ${database}.flows\nWHERE timestamp >= now() - INTERVAL 1 DAY AND receivedAt >= now() - INTERVAL 5 MINUTE AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone)",
+          "refId": "A",
+          "meta": { "timezone": "UTC" }
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Collection lag p95 — last 15 min",
+      "description": "95th percentile of the delay between a flow ending on the exporter (lastSwitched) and the record arriving at the collector (receivedAt), over the last 15 minutes. Normal: seconds to about a minute, dominated by the exporter's active/inactive timeout settings. Amber above 1 minute, red above 5: sustained high lag means export batching delay, a congested path to the collector, or exporter clock skew (the collector records the skew it corrects in the clockCorrection column).",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${datasource}"
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 1,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 60 },
+              { "color": "red", "value": 300 }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "graphMode": "none",
+        "colorMode": "value",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "${datasource}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "queryType": "table",
+          "rawSql": "SELECT if(count() > 0, quantile(0.95)(dateDiff('millisecond', lastSwitched, receivedAt)) / 1000, NULL) AS \"Collection lag p95\"\nFROM ${database}.flows\nWHERE timestamp >= now() - INTERVAL 1 DAY AND receivedAt >= now() - INTERVAL 15 MINUTE AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone)",
+          "refId": "A",
+          "meta": { "timezone": "UTC" }
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "state-timeline",
+      "title": "Exporter activity — who was delivering, when",
+      "description": "One row per exporter (named where the exporter has a name, address otherwise), green while at least one flow record arrived in the bucket, red where the exporter went quiet while others kept delivering. Normal: unbroken green rows. A red gap on one row is that exporter or its path; red across all rows at once is the collector. Caveats: intervals before an exporter's first record in the range also render red, and if every exporter is silent simultaneously the interval is missing entirely (no rows) — the stat panels above catch that case.",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${datasource}"
+      },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 4 },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 70,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "1": { "text": "Receiving", "color": "green", "index": 0 }
+              }
+            },
+            {
+              "type": "special",
+              "options": {
+                "match": "null",
+                "result": { "text": "Silent", "color": "red", "index": 1 }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "mergeValues": true,
+        "showValue": "never",
+        "alignValue": "center",
+        "rowHeight": 0.85,
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "${datasource}"
+          },
+          "editorType": "sql",
+          "format": 0,
+          "queryType": "table",
+          "rawSql": "SELECT toStartOfInterval(receivedAt, toIntervalSecond($bucket)) AS time,\n       if(exporterName != '', exporterName, exporterAddr) AS exporter,\n       1 AS state\nFROM ${database}.flows\nWHERE $__timeFilter(receivedAt) AND timestamp >= $__fromTime - INTERVAL 1 DAY AND timestamp <= $__toTime + INTERVAL 1 DAY AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone)\nGROUP BY time, exporter\nORDER BY time",
+          "refId": "A",
+          "meta": { "timezone": "UTC" }
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Flow records by exporter",
+      "description": "Flow records received per second, stacked by exporter (top 10 by record count, remainder as Other), bucketed by ingest time. Normal: each exporter contributes a steady band. A band that thins out or disappears is an exporter fading — cross-check its row in the activity panel above; a step change in one band with steady traffic elsewhere often means an exporter's sampling or timeout configuration changed rather than the network.",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${datasource}"
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 13 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "min": 0,
+          "decimals": 1,
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 30,
+            "showPoints": "never",
+            "stacking": { "mode": "normal", "group": "A" },
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Other" },
+            "properties": [
+              {
+                "id": "color",
+                "value": { "mode": "fixed", "fixedColor": "#7f7f7f" }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": ["mean", "max", "lastNotNull"]
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "${datasource}"
+          },
+          "editorType": "sql",
+          "format": 0,
+          "queryType": "table",
+          "rawSql": "WITH top AS (SELECT exporterAddr AS dim FROM ${database}.flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) GROUP BY dim ORDER BY count() DESC LIMIT 10)\nSELECT toStartOfInterval(receivedAt, toIntervalSecond($bucket)) AS time,\n       if(exporterAddr IN (SELECT dim FROM top), if(exporterName != '', exporterName, exporterAddr), 'Other') AS series,\n       count() / $bucket AS rate\nFROM ${database}.flows\nWHERE $__timeFilter(receivedAt) AND timestamp >= $__fromTime - INTERVAL 1 DAY AND timestamp <= $__toTime + INTERVAL 1 DAY AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone)\nGROUP BY time, series\nORDER BY time",
+          "refId": "A",
+          "meta": { "timezone": "UTC" }
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Flow records by protocol",
+      "description": "Flow records received per second, stacked by flow protocol (NetFlow v5/v9, IPFIX, sFlow), bucketed by ingest time. Normal: the mix is stable — each device exports one protocol, so this is the exporter fleet seen by protocol. A protocol band vanishing means every exporter of that type stopped at once, which points at a shared cause: a template/parsing problem on the collector for that protocol, or a shared network path.",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${datasource}"
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 13 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "min": 0,
+          "decimals": 1,
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 30,
+            "showPoints": "never",
+            "stacking": { "mode": "normal", "group": "A" },
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": ["mean", "max", "lastNotNull"]
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "${datasource}"
+          },
+          "editorType": "sql",
+          "format": 0,
+          "queryType": "table",
+          "rawSql": "SELECT toStartOfInterval(receivedAt, toIntervalSecond($bucket)) AS time,\n       toString(flowProtocol) AS series,\n       count() / $bucket AS rate\nFROM ${database}.flows\nWHERE $__timeFilter(receivedAt) AND timestamp >= $__fromTime - INTERVAL 1 DAY AND timestamp <= $__toTime + INTERVAL 1 DAY AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone)\nGROUP BY time, series\nORDER BY time",
+          "refId": "A",
+          "meta": { "timezone": "UTC" }
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Collection lag over time — p50 / p95",
+      "description": "Median and 95th-percentile delay between a flow ending on the exporter (lastSwitched) and its record arriving at the collector (receivedAt), per bucket. Normal: flat, seconds to about a minute, set by the exporters' active/inactive timeouts; p95 well above p50 means a subset of exporters lags behind the rest. A step change in both percentiles is a configuration or clock event — compare with the per-exporter panels to see whether one exporter or all of them moved. Negative values mean exporter clocks run ahead of the collector.",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${datasource}"
+      },
+      "gridPos": { "h": 7, "w": 24, "x": 0, "y": 21 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 1,
+          "color": { "mode": "palette-classic" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 60 },
+              { "color": "red", "value": 300 }
+            ]
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": { "mode": "none" },
+            "gradientMode": "none",
+            "spanNulls": false,
+            "thresholdsStyle": { "mode": "dashed" }
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "p50" },
+            "properties": [
+              {
+                "id": "color",
+                "value": { "mode": "fixed", "fixedColor": "light-blue" }
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "p95" },
+            "properties": [
+              {
+                "id": "color",
+                "value": { "mode": "fixed", "fixedColor": "dark-blue" }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "${datasource}"
+          },
+          "editorType": "sql",
+          "format": 0,
+          "queryType": "table",
+          "rawSql": "SELECT toStartOfInterval(receivedAt, toIntervalSecond($bucket)) AS time,\n       quantile(0.5)(dateDiff('millisecond', lastSwitched, receivedAt)) / 1000 AS \"p50\",\n       quantile(0.95)(dateDiff('millisecond', lastSwitched, receivedAt)) / 1000 AS \"p95\"\nFROM ${database}.flows\nWHERE $__timeFilter(receivedAt) AND timestamp >= $__fromTime - INTERVAL 1 DAY AND timestamp <= $__toTime + INTERVAL 1 DAY AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone)\nGROUP BY time\nORDER BY time",
+          "refId": "A",
+          "meta": { "timezone": "UTC" }
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "table",
+      "title": "Exporter inventory — last seen, volume, drill-down",
+      "description": "Every exporter seen in the selected range: name (address where unnamed), protocols spoken, tenants and zones it feeds, when its last record arrived, how long it has been silent (background turns red past 15 minutes), and what it delivered. Sorted silent-first so the problem row is on top. Click an exporter name to open the Traffic Paths dashboard scoped to that exporter with the current filters and time range.",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${datasource}"
+      },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 28 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Exporter" },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Traffic paths for this exporter",
+                    "url": "/d/riptide-traffic-paths?${datasource:queryparam}&${database:queryparam}&${tenant:queryparam}&${zone:queryparam}&var-exporter=${__data.fields.Address}&from=${__from}&to=${__to}"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Silent for" },
+            "properties": [
+              { "id": "unit", "value": "dtdurations" },
+              {
+                "id": "custom.cellOptions",
+                "value": { "type": "color-background", "mode": "basic" }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "green", "value": null },
+                    { "color": "red", "value": 900 }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Volume" },
+            "properties": [{ "id": "unit", "value": "bytes" }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Records" },
+            "properties": [{ "id": "unit", "value": "short" }]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "footer": { "show": false }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "${datasource}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "queryType": "table",
+          "rawSql": "SELECT if(max(exporterName) != '', max(exporterName), exporterAddr) AS \"Exporter\",\n       exporterAddr AS \"Address\",\n       arrayStringConcat(groupUniqArray(toString(flowProtocol)), ', ') AS \"Protocols\",\n       arrayStringConcat(groupUniqArray(tenant), ', ') AS \"Tenants\",\n       arrayStringConcat(groupUniqArray(zone), ', ') AS \"Zones\",\n       max(receivedAt) AS \"Last seen\",\n       dateDiff('second', max(receivedAt), $__toTime) AS \"Silent for\",\n       count() AS \"Records\",\n       sum(bytes) AS \"Volume\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone)\nGROUP BY exporterAddr\nORDER BY \"Silent for\" DESC",
+          "refId": "A",
+          "meta": { "timezone": "UTC" }
+        }
+      ]
+    }
+  ]
+}

--- a/docs/docs/deploy/docker-compose.md
+++ b/docs/docs/deploy/docker-compose.md
@@ -23,17 +23,22 @@ This starts, from `ghcr.io/riptide-labs/riptide:latest`:
 | ch-ui | [`:5521`](http://localhost:5521) | browse the `riptide.flows` table |
 | grafana | [`:3000`](http://localhost:3000) | dashboards (ClickHouse datasource provisioned) |
 
-Grafana (admin/admin) ships two provisioned dashboards backed by the `flows` table and the
+Grafana (admin/admin) ships provisioned dashboards backed by the `flows` table and the
 `samples` bucket-expansion view:
 
 - **Riptide - Top 10**: stacked top-10 rate panels (AS, hosts, applications, services, protocols,
   exporters, interfaces) plus a source-AS statistics table with a 95th-percentile column.
 - **Riptide - Traffic Paths (Sankey)**: path diagrams (source AS → ingress
   interface → application → destination AS, and more), weighted by bytes over the selected range.
+- **Riptide - Host Investigation**: forensics for a single address — traffic, unique peers,
+  TCP flag profile, top peers/services with geo and AS context.
+- **Riptide - Collection Health**: is every exporter delivering? Reporting/silent-exporter
+  verdicts, a per-exporter activity timeline, collection lag percentiles, and an exporter
+  inventory with drill-down into Traffic Paths.
 
 The JSON sources live in `deployment/clickhouse/container-fs/grafana/provisioning/dashboards/`.
 UI edits last only until the provisioned JSON changes — use *Save as* to keep a customized copy.
-Both dashboards are deployment-neutral: a **Datasource** variable selects the ClickHouse
+The dashboards are deployment-neutral: a **Datasource** variable selects the ClickHouse
 connection and a **Database** variable (auto-populated from databases containing a `flows` table)
 selects the riptide database, so they import into any external Grafana without a specifically
 named or `defaultDatabase`-pinned datasource.


### PR DESCRIPTION
## What

Adds **Riptide - Collection Health**, a fifth provisioned Grafana dashboard: a NOC-style status wall answering *"is flow collection healthy right now — is every exporter delivering?"* None of the existing dashboards covers collection-pipeline health; they all analyze the traffic itself.

- **Verdict row**: exporters reporting (last 15 min), silent exporters (relative to range end), flow record rate, collection lag p95 — all pre-judged with thresholds/value mappings (NONE / STALLED / red states).
- **Drivers**: per-exporter activity state timeline (green receiving / red silent), record rates stacked by exporter (top 10 + Other) and by flow protocol.
- **Evidence**: collection lag p50/p95 over time with threshold lines, and an exporter inventory table (name→address fallback, protocols, tenants/zones, last seen, silence age) that drills into *Traffic Paths* carrying datasource, database, tenant/zone filters, exporter, and time range.

All panels read ingest time (`receivedAt`), not flow switch time, so they measure the collector, not the network. Lag compares `lastSwitched` vs `receivedAt`.

Also updates the docker-compose docs: the page claimed two provisioned dashboards while Host Investigation was already shipping unlisted; the list now names all of them.

## Verification

- All 9 panel queries macro-expanded and executed against the live local ClickHouse (`riptide-clickhouse-1`, ~1M real flow rows) — syntax, column names, and output shapes confirmed, including the empty-window and idle-collector cases (0 → NONE/STALLED mappings fire; lag returns NULL, not NaN).
- Dashboard JSON passes the netops dashboard linter (0 errors) including contrast/CVD color checks; queries reuse the house idioms (`${datasource}`/`${database}` variables, `$__conditionalAll` tenant/zone filters, `exporterName`-with-address-fallback labels).
- Adversarial review pass done; fixed its findings (range-end-relative silence instead of wall-clock `now()`, datasource carried through the drill-down link, NaN guard on the lag stat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)