### PR TITLE
chore(dashboards): fix Sankey title collision, clearer rate units

### DIFF
--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-collection-health.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-collection-health.json
@@ -263,7 +263,7 @@
       "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
       "fieldConfig": {
         "defaults": {
-          "unit": "cps",
+          "unit": "suffix:flows/s",
           "decimals": 1,
           "color": { "mode": "thresholds" },
           "thresholds": {
@@ -441,7 +441,7 @@
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 13 },
       "fieldConfig": {
         "defaults": {
-          "unit": "cps",
+          "unit": "suffix:flows/s",
           "min": 0,
           "decimals": 1,
           "color": { "mode": "palette-classic" },
@@ -504,7 +504,7 @@
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 13 },
       "fieldConfig": {
         "defaults": {
-          "unit": "cps",
+          "unit": "suffix:flows/s",
           "min": 0,
           "decimals": 1,
           "color": { "mode": "palette-classic" },

--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-sankey.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-sankey.json
@@ -1,6 +1,6 @@
 {
   "uid": "riptide-sankey",
-  "title": "Riptide - Traffic Paths (Sankey)",
+  "title": "Riptide - Conversations & Tenancy (Sankey)",
   "tags": [
     "riptide",
     "netflow"

--- a/docs/docs/deploy/docker-compose.md
+++ b/docs/docs/deploy/docker-compose.md
@@ -28,10 +28,12 @@ Grafana (admin/admin) ships provisioned dashboards backed by the `flows` table a
 
 - **Riptide - Top 10**: stacked top-10 rate panels (AS, hosts, applications, services, protocols,
   exporters, interfaces) plus a source-AS statistics table with a 95th-percentile column.
-- **Riptide - Traffic Paths (Sankey)**: path diagrams (source AS → ingress
-  interface → application → destination AS, and more), weighted by bytes over the selected range.
+- **Riptide - Traffic Paths (Sankey)**: exporter-filterable path diagrams — AS peering
+  (source AS → ingress → egress → destination AS), situational-awareness, geo
+  origination/termination, and ultimate-exit views, weighted by bytes over the selected range.
 - **Riptide - Conversations & Tenancy (Sankey)**: the lighter companion — host-to-host
-  conversations by service, plus tenant → zone → application attribution.
+  conversations by service, tenant → zone → application attribution, and a source AS →
+  ingress interface → application → destination AS path view.
 - **Riptide - Host Investigation**: forensics for a single address — traffic, unique peers,
   TCP flag profile, top peers/services with geo and AS context.
 - **Riptide - Collection Health**: is every exporter delivering? Reporting/silent-exporter

--- a/docs/docs/deploy/docker-compose.md
+++ b/docs/docs/deploy/docker-compose.md
@@ -30,6 +30,8 @@ Grafana (admin/admin) ships provisioned dashboards backed by the `flows` table a
   exporters, interfaces) plus a source-AS statistics table with a 95th-percentile column.
 - **Riptide - Traffic Paths (Sankey)**: path diagrams (source AS → ingress
   interface → application → destination AS, and more), weighted by bytes over the selected range.
+- **Riptide - Conversations & Tenancy (Sankey)**: the lighter companion — host-to-host
+  conversations by service, plus tenant → zone → application attribution.
 - **Riptide - Host Investigation**: forensics for a single address — traffic, unique peers,
   TCP flag profile, top peers/services with geo and AS context.
 - **Riptide - Collection Health**: is every exporter delivering? Reporting/silent-exporter


### PR DESCRIPTION
## What

- **Title collision**: `riptide-sankey.json` and `riptide-traffic-paths.json` both carried the title *Riptide - Traffic Paths (Sankey)*, so provisioned Grafana listed two identically named dashboards. The newer, richer `riptide-traffic-paths` keeps the name; the older one is retitled **Riptide - Conversations & Tenancy (Sankey)** after its distinct content. Filename and uid are unchanged, so existing links and bookmarks keep working.
- **Units**: the collection-health rate panels rendered Grafana's `cps` unit as the cryptic "c/s"; they now use the custom suffix unit `suffix:flows/s`, rendering "853 flows/s".
- **Docs**: the docker-compose page now lists the renamed dashboard, and the two Sankey bullets each describe their dashboard's actual panels (the application-hop path chain was described under the wrong one).

## Verification

- Deep-compared the sankey JSON against main: the change is title-only, no key loss or reformatting.
- Collection-health JSON re-passes the netops dashboard linter (0 errors, same accepted warnings as before).
- Adversarial review agent pass done; its two findings (suffix unit had a space after the colon → double-space rendering; docs bullet described the wrong dashboard) are fixed in this head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)