### PR TITLE
chore(dashboards): review-driven polish across the dashboard set

### DIFF
--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-host-investigation.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-host-investigation.json
@@ -5,7 +5,8 @@
     "riptide",
     "netflow",
     "security",
-    "host-investigation"
+    "host-investigation",
+    "audience:engineer"
   ],
   "timezone": "browser",
   "schemaVersion": 39,
@@ -16,7 +17,7 @@
     "to": "now"
   },
   "editable": true,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "templating": {
     "list": [
       {
@@ -66,7 +67,8 @@
           "selected": true,
           "text": "192.168.10.1",
           "value": "192.168.10.1"
-        }
+        },
+        "description": "IP address of the host under investigation (IPv4 or IPv6, as stored in the flows table)."
       },
       {
         "name": "limit",
@@ -192,7 +194,8 @@
           "unit": "bps",
           "color": {
             "mode": "palette-classic"
-          }
+          },
+          "min": 0
         },
         "overrides": []
       },
@@ -512,5 +515,17 @@
   "annotations": {
     "list": []
   },
-  "links": []
+  "links": [
+    {
+      "title": "Riptide dashboards",
+      "type": "dashboards",
+      "tags": [
+        "riptide"
+      ],
+      "asDropdown": true,
+      "includeVars": true,
+      "keepTime": true
+    }
+  ],
+  "description": "What is this one host doing? Investigation view for a single address: traffic in/out, peer fan-out and TCP flag profile on top, then the evidence \u2014 top peers, services, packet sizes and geo/AS context. Enter the host's IP (v4 or v6) in the Host box; typically reached from Top 10 or Conversations with filters and time range carried over."
 }

--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-sankey.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-sankey.json
@@ -3,7 +3,8 @@
   "title": "Riptide - Conversations & Tenancy (Sankey)",
   "tags": [
     "riptide",
-    "netflow"
+    "netflow",
+    "audience:engineer"
   ],
   "timezone": "browser",
   "schemaVersion": 39,
@@ -14,7 +15,7 @@
     "to": "now"
   },
   "editable": true,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "templating": {
     "list": [
       {
@@ -146,7 +147,7 @@
     {
       "id": 1,
       "type": "netsage-sankey-panel",
-      "title": "Traffic paths: Source AS - Ingress interface - Application - Destination AS",
+      "title": "Application paths: Source AS - Ingress interface - Application - Destination AS",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
         "uid": "${datasource}"
@@ -179,7 +180,8 @@
             "timezone": "UTC"
           }
         }
-      ]
+      ],
+      "description": "Byte-weighted path from originating AS through the ingress interface and classified application to the destination AS. Normal: thick ribbons follow known applications between expected ASes; an unknown AS or an unclassified application carrying real volume is the lead to follow."
     },
     {
       "id": 2,
@@ -217,7 +219,8 @@
             "timezone": "UTC"
           }
         }
-      ]
+      ],
+      "description": "Host-to-host conversations via the service (protocol/destination port) between them, reverse-DNS names where resolved. Answers 'what exactly is that host doing' after Top 10 flags it \u2014 one host fanning out to many services or many peers reads as scanning or probing."
     },
     {
       "id": 3,
@@ -255,11 +258,24 @@
             "timezone": "UTC"
           }
         }
-      ]
+      ],
+      "description": "Attributes traffic volume to tenant, zone and application. Normal: each tenant's ribbons flow through its own zones into expected applications; volume appearing under the wrong tenant or zone is a provisioning or classification error, not a network event."
     }
   ],
   "annotations": {
     "list": []
   },
-  "links": []
+  "links": [
+    {
+      "title": "Riptide dashboards",
+      "type": "dashboards",
+      "tags": [
+        "riptide"
+      ],
+      "asDropdown": true,
+      "includeVars": true,
+      "keepTime": true
+    }
+  ],
+  "description": "Who talks to whom, over which service, and which tenant, zone and application own the traffic? Byte-weighted Sankey views over the flows table for the selected range \u2014 the conversation/attribution companion to the routing-level Traffic Paths dashboard. Scope with Tenant/Zone/Locality; Limit caps fan-out per diagram."
 }

--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-top-10.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-top-10.json
@@ -3,7 +3,8 @@
   "title": "Riptide - Top 10",
   "tags": [
     "riptide",
-    "netflow"
+    "netflow",
+    "audience:engineer"
   ],
   "timezone": "browser",
   "schemaVersion": 39,
@@ -193,7 +194,8 @@
             "timezone": "UTC"
           }
         }
-      ]
+      ],
+      "description": "Total flow-reported traffic rate across the selected scope. Sanity anchor for everything below: if this is near zero, check the Collection Health dashboard before reading any top-10 ranking."
     },
     {
       "id": 2,
@@ -245,7 +247,8 @@
             "timezone": "UTC"
           }
         }
-      ]
+      ],
+      "description": "Total bytes carried by flows in the selected range and scope. Switch Tenant/Zone/Locality to compare slices; the top-10 panels below explain who moved it."
     },
     {
       "id": 3,
@@ -297,7 +300,8 @@
             "timezone": "UTC"
           }
         }
-      ]
+      ],
+      "description": "Number of flow records behind these panels \u2014 a confidence indicator, not a traffic measure. Low counts (sampled exporters, short ranges) make the rankings noisy; widen the range before trusting close calls."
     },
     {
       "id": 4,
@@ -380,7 +384,8 @@
             "timezone": "UTC"
           }
         }
-      ]
+      ],
+      "description": "Traffic rate by originating autonomous system \u2014 top 10 by volume, remainder stacked as the grey Other band. A new entrant or a suddenly growing AS is a traffic source worth explaining."
     },
     {
       "id": 5,
@@ -463,7 +468,8 @@
             "timezone": "UTC"
           }
         }
-      ]
+      ],
+      "description": "Traffic rate by destination autonomous system \u2014 top 10 by volume, remainder stacked as the grey Other band. Where does our traffic go; sudden shifts point at CDN moves, new services, or exfiltration."
     },
     {
       "id": 6,
@@ -546,7 +552,8 @@
             "timezone": "UTC"
           }
         }
-      ]
+      ],
+      "description": "Traffic rate by source host, reverse-DNS name where resolved, plain address otherwise. A single host dominating the stack is the first suspect for link saturation \u2014 open it in Host Investigation (dashboards menu)."
     },
     {
       "id": 7,
@@ -629,7 +636,8 @@
             "timezone": "UTC"
           }
         }
-      ]
+      ],
+      "description": "Traffic rate by destination host, reverse-DNS name where resolved, plain address otherwise. A single sink drawing outsized volume \u2014 backup target, update server, or data sink worth verifying \u2014 stands out here."
     },
     {
       "id": 8,
@@ -712,7 +720,8 @@
             "timezone": "UTC"
           }
         }
-      ]
+      ],
+      "description": "Traffic rate by classified application; 'unclassified' means no classification rule matched. Normal: unclassified stays a small share \u2014 a growing unclassified band means the rule set needs attention, not the network."
     },
     {
       "id": 9,
@@ -795,7 +804,8 @@
             "timezone": "UTC"
           }
         }
-      ]
+      ],
+      "description": "Traffic rate by protocol/destination-port pair \u2014 the port-level view for when application classification is too coarse. Unexpected high-volume ports are the lead to chase in Conversations."
     },
     {
       "id": 10,
@@ -878,7 +888,8 @@
             "timezone": "UTC"
           }
         }
-      ]
+      ],
+      "description": "Traffic rate by IP protocol. Normal: TCP and UDP dominate; a visible share of anything else (GRE, ESP, ICMP) deserves an explanation \u2014 tunnels, VPNs, or something probing."
     },
     {
       "id": 11,
@@ -961,7 +972,8 @@
             "timezone": "UTC"
           }
         }
-      ]
+      ],
+      "description": "Traffic rate by exporting device \u2014 which vantage points see the traffic. An exporter's band fading while others hold steady may be a collection problem, not a traffic change: check Collection Health."
     },
     {
       "id": 12,
@@ -1044,7 +1056,8 @@
             "timezone": "UTC"
           }
         }
-      ]
+      ],
+      "description": "Traffic rate by exporter ingress interface \u2014 which links carry the load into the monitored network. Read together with Top 10 Exporters to localise a saturating link."
     },
     {
       "id": 13,
@@ -1125,11 +1138,24 @@
             "timezone": "UTC"
           }
         }
-      ]
+      ],
+      "description": "Ranked source-AS table for the range: total volume plus the 95th-percentile rate \u2014 the number used for billing and capacity comparisons, deliberately insensitive to short bursts."
     }
   ],
   "annotations": {
     "list": []
   },
-  "links": []
+  "links": [
+    {
+      "title": "Riptide dashboards",
+      "type": "dashboards",
+      "tags": [
+        "riptide"
+      ],
+      "asDropdown": true,
+      "includeVars": true,
+      "keepTime": true
+    }
+  ],
+  "description": "Which ASes, hosts, applications and services dominate traffic over the selected range? Fleet-compare view over the flows table (byte-weighted, bucketed via the samples view and the Bucket variable); every rate panel stacks the top 10 plus an 'Other' remainder. Scope with Tenant/Zone/Locality; drill into a host via the Host Investigation dashboard (dashboards menu, filters and time carried over)."
 }

--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-traffic-paths.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-traffic-paths.json
@@ -4,7 +4,8 @@
   "tags": [
     "riptide",
     "netflow",
-    "traffic-paths"
+    "traffic-paths",
+    "audience:engineer"
   ],
   "timezone": "browser",
   "schemaVersion": 39,
@@ -15,7 +16,7 @@
     "to": "now"
   },
   "editable": true,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "templating": {
     "list": [
       {
@@ -327,5 +328,17 @@
   "annotations": {
     "list": []
   },
-  "links": []
+  "links": [
+    {
+      "title": "Riptide dashboards",
+      "type": "dashboards",
+      "tags": [
+        "riptide"
+      ],
+      "asDropdown": true,
+      "includeVars": true,
+      "keepTime": true
+    }
+  ],
+  "description": "How does traffic route through the network \u2014 which AS pairs peer across which exporters, where does it originate and terminate geographically, and where does it exit? Byte-weighted Sankey paths over the flows table for the selected range. Scope with Tenant/Zone/Locality/Exporter; Depth caps nodes per column to keep the diagrams readable."
 }


### PR DESCRIPTION
## What

Structured review pass (netops dashboard skill, review mode) over the four pre-existing dashboards — Top 10, Traffic Paths, Conversations & Tenancy, Host Investigation — followed by the fixes:

- **Descriptions everywhere**: dashboard-level intent on all four, and panel descriptions on the 16 panels that had none (what it measures / what normal looks like / what to do when it isn't).
- **Audience declared**: `audience:engineer` tag on all four, activating the linter's audience-fit checks (time range, refresh, panel budget all already fit that role).
- **Shared crosshair** (`graphTooltip: 1`) on the three dashboards that had it off, so panels read against each other in time.
- **No dead ends**: the *Riptide dashboards* dropdown link (carrying filters and time range) on all four, matching Collection Health.
- **Host Investigation**: traffic-rate axis pinned to `min: 0` (both series are non-negative sums; autoscaling made flat traffic look volatile), and a description on the Host variable.
- **Conversations & Tenancy**: the leftover *"Traffic paths:"* panel retitled *"Application paths:"* so it stops shadowing the sibling dashboard's name.

No queries changed; uids unchanged, so provisioning reloads in place.

## Verification

- Dashboard linter warnings drop **35 → 17** across the four; every remaining warning is the known ClickHouse-plugin legendFormat false positive (series are named via SQL aliases) — same accepted class as Collection Health. 0 errors, color/contrast checks pass.
- Adversarial review agent deep-compared each file against main (only the advertised keys changed), validated the link-object shape against the shipped precedent, confirmed the `min: 0` pin can't clip data, and fact-checked every new description sentence against the underlying rawSql (rDNS fallback, p95 column, 'unclassified' label, grey Other override). Verdict: mergeable, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)