### PR TITLE
fix(dashboards): exporter picker — correct column order, dedupe, current name

### DIFF
--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-flow-forensics.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-flow-forensics.json
@@ -172,9 +172,9 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "SELECT DISTINCT if(exporterName != '', exporterName, exporterAddr) AS __text, exporterAddr AS __value FROM ${database}.flows ORDER BY __text"
+          "rawSql": "SELECT exporterAddr AS __value, if(argMax(exporterName, receivedAt) != '', argMax(exporterName, receivedAt), exporterAddr) AS __text FROM ${database}.flows GROUP BY exporterAddr ORDER BY __text"
         },
-        "definition": "SELECT DISTINCT if(exporterName != '', exporterName, exporterAddr) AS __text, exporterAddr AS __value FROM ${database}.flows ORDER BY __text",
+        "definition": "SELECT exporterAddr AS __value, if(argMax(exporterName, receivedAt) != '', argMax(exporterName, receivedAt), exporterAddr) AS __text FROM ${database}.flows GROUP BY exporterAddr ORDER BY __text",
         "refresh": 1,
         "sort": 1,
         "current": {

--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-host-investigation.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-host-investigation.json
@@ -154,9 +154,9 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "SELECT DISTINCT if(exporterName != '', exporterName, exporterAddr) AS __text, exporterAddr AS __value FROM ${database}.flows ORDER BY __text"
+          "rawSql": "SELECT exporterAddr AS __value, if(argMax(exporterName, receivedAt) != '', argMax(exporterName, receivedAt), exporterAddr) AS __text FROM ${database}.flows GROUP BY exporterAddr ORDER BY __text"
         },
-        "definition": "SELECT DISTINCT if(exporterName != '', exporterName, exporterAddr) AS __text, exporterAddr AS __value FROM ${database}.flows ORDER BY __text",
+        "definition": "SELECT exporterAddr AS __value, if(argMax(exporterName, receivedAt) != '', argMax(exporterName, receivedAt), exporterAddr) AS __text FROM ${database}.flows GROUP BY exporterAddr ORDER BY __text",
         "refresh": 1,
         "includeAll": true,
         "multi": true,

--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-traffic-paths.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-traffic-paths.json
@@ -154,9 +154,9 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "SELECT DISTINCT if(exporterName != '', exporterName, exporterAddr) AS __text, exporterAddr AS __value FROM ${database}.flows ORDER BY __text"
+          "rawSql": "SELECT exporterAddr AS __value, if(argMax(exporterName, receivedAt) != '', argMax(exporterName, receivedAt), exporterAddr) AS __text FROM ${database}.flows GROUP BY exporterAddr ORDER BY __text"
         },
-        "definition": "SELECT DISTINCT if(exporterName != '', exporterName, exporterAddr) AS __text, exporterAddr AS __value FROM ${database}.flows ORDER BY __text",
+        "definition": "SELECT exporterAddr AS __value, if(argMax(exporterName, receivedAt) != '', argMax(exporterName, receivedAt), exporterAddr) AS __text FROM ${database}.flows GROUP BY exporterAddr ORDER BY __text",
         "refresh": 1,
         "includeAll": true,
         "multi": true,


### PR DESCRIPTION
## What

Fixes the exporter filter variable on the three dashboards that have one (Traffic Paths, Host Investigation, Flow Forensics). Three layered problems, one query:

1. **Latent positional bug (the real find):** the ClickHouse datasource plugin resolves variable queries by column *position* — `fields[0]` = value, `fields[1]` = text — and ignores the `__text`/`__value` aliases. The old query put text first, so once exporters gain names via `riptide.nodes`, the picker would have filtered `exporterAddr IN ('<name>')` and matched nothing. It only appeared to work while the fallback label equalled the address. Value now comes first.
2. **Duplicate entries:** `SELECT DISTINCT` over per-row labels shows a device twice once its history spans unnamed and named periods. Now `GROUP BY exporterAddr` — one entry per device.
3. **Rename semantics:** `argMax(exporterName, receivedAt)` labels the device with its *current* name, not the lexicographically greatest historical one; empty-name devices fall back to the address.

The variable's value remains `exporterAddr`, so all panel filters and drill-down links are unchanged.

Note for operators: pickers showing plain IPs means the exporters have no `riptide.nodes.<name>` entry covering them (see `docs/docs/configuration/nodes-and-snmp.md`) — the dashboards fall back correctly; naming is collector config.

## Verification

- New query executed against live ClickHouse: real table, plus synthetic mixed-history and renamed-exporter cases (most-recent name wins, IP fallback intact, one row per device).
- Adversarial review agent traced the plugin's variable resolution in `grafana/clickhouse-datasource` source to confirm positional matching, validated the aggregate-in-if under GROUP BY, and measured the new query faster than the old DISTINCT (0.010s vs 0.028s on ~1M rows). Verdict mergeable; its one optional suggestion (argMax) is applied in this head.
- Skill linter: 0 errors on all six dashboards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)