### PR TITLE
feat(dashboards): direction and exporter filters on the Sankey dashboards

### DIFF
--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-sankey.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-sankey.json
@@ -140,6 +140,70 @@
           "text": "All",
           "value": "$__all"
         }
+      },
+      {
+        "name": "exporter",
+        "label": "Exporter",
+        "type": "query",
+        "datasource": {
+          "type": "grafana-clickhouse-datasource",
+          "uid": "${datasource}"
+        },
+        "query": {
+          "editorType": "sql",
+          "format": 1,
+          "queryType": "table",
+          "rawSql": "SELECT exporterAddr AS __value, if(argMax(exporterName, receivedAt) != '', argMax(exporterName, receivedAt), exporterAddr) AS __text FROM ${database}.flows GROUP BY exporterAddr ORDER BY __text"
+        },
+        "definition": "SELECT exporterAddr AS __value, if(argMax(exporterName, receivedAt) != '', argMax(exporterName, receivedAt), exporterAddr) AS __text FROM ${database}.flows GROUP BY exporterAddr ORDER BY __text",
+        "refresh": 1,
+        "sort": 1,
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        }
+      },
+      {
+        "name": "direction",
+        "label": "Direction",
+        "type": "custom",
+        "description": "Flow direction as reported by the exporter (observation-point relative: INGRESS = sampled entering the interface, EGRESS = leaving it). Many exporters only tag one direction \u2014 if a selection empties the diagrams, the exporter simply never reports that side; check the Collection Health dashboard's protocol/exporter panels before suspecting the network.",
+        "query": "Ingress : INGRESS, Egress : EGRESS, Unknown : UNKNOWN",
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [
+          {
+            "selected": false,
+            "text": "Ingress",
+            "value": "INGRESS"
+          },
+          {
+            "selected": false,
+            "text": "Egress",
+            "value": "EGRESS"
+          },
+          {
+            "selected": false,
+            "text": "Unknown",
+            "value": "UNKNOWN"
+          }
+        ]
       }
     ]
   },
@@ -174,7 +238,7 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "SELECT concat(toString(srcAs), ': ', ifNull(srcAsOrg, 'unknown')) AS \"Source AS\",\n       concat(exporterAddr, ' - ', ifNull(inputSnmpIfName, concat('if', toString(inputSnmp))), if(inputSnmpIfAlias IS NULL, '', concat(' (', inputSnmpIfAlias, ')'))) AS \"Ingress\",\n       ifNull(application, 'unclassified') AS \"Application\",\n       concat(toString(dstAs), ': ', ifNull(dstAsOrg, 'unknown')) AS \"Destination AS\",\n       sum(bytes) AS \"Bytes\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Source AS\", \"Ingress\", \"Application\", \"Destination AS\"\nORDER BY \"Bytes\" DESC\nLIMIT $limit",
+          "rawSql": "SELECT concat(toString(srcAs), ': ', ifNull(srcAsOrg, 'unknown')) AS \"Source AS\",\n       concat(exporterAddr, ' - ', ifNull(inputSnmpIfName, concat('if', toString(inputSnmp))), if(inputSnmpIfAlias IS NULL, '', concat(' (', inputSnmpIfAlias, ')'))) AS \"Ingress\",\n       ifNull(application, 'unclassified') AS \"Application\",\n       concat(toString(dstAs), ': ', ifNull(dstAsOrg, 'unknown')) AS \"Destination AS\",\n       sum(bytes) AS \"Bytes\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND $__conditionalAll(direction IN (${direction:singlequote}), $direction) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Source AS\", \"Ingress\", \"Application\", \"Destination AS\"\nORDER BY \"Bytes\" DESC\nLIMIT $limit",
           "refId": "A",
           "meta": {
             "timezone": "UTC"
@@ -213,7 +277,7 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "SELECT ifNull(srcAddrHostname, replaceOne(toString(srcAddr), '::ffff:', '')) AS \"Source\",\n       concat(transform(protocol, [1, 2, 6, 17, 41, 47, 50, 51, 58, 89, 132], ['ICMP', 'IGMP', 'TCP', 'UDP', 'IPv6', 'GRE', 'ESP', 'AH', 'IPv6-ICMP', 'OSPFIGP', 'SCTP'], concat('proto-', toString(protocol))), '/', toString(dstPort)) AS \"Service\",\n       ifNull(dstAddrHostname, replaceOne(toString(dstAddr), '::ffff:', '')) AS \"Destination\",\n       sum(bytes) AS \"Bytes\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Source\", \"Service\", \"Destination\"\nORDER BY \"Bytes\" DESC\nLIMIT $limit",
+          "rawSql": "SELECT ifNull(srcAddrHostname, replaceOne(toString(srcAddr), '::ffff:', '')) AS \"Source\",\n       concat(transform(protocol, [1, 2, 6, 17, 41, 47, 50, 51, 58, 89, 132], ['ICMP', 'IGMP', 'TCP', 'UDP', 'IPv6', 'GRE', 'ESP', 'AH', 'IPv6-ICMP', 'OSPFIGP', 'SCTP'], concat('proto-', toString(protocol))), '/', toString(dstPort)) AS \"Service\",\n       ifNull(dstAddrHostname, replaceOne(toString(dstAddr), '::ffff:', '')) AS \"Destination\",\n       sum(bytes) AS \"Bytes\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND $__conditionalAll(direction IN (${direction:singlequote}), $direction) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Source\", \"Service\", \"Destination\"\nORDER BY \"Bytes\" DESC\nLIMIT $limit",
           "refId": "A",
           "meta": {
             "timezone": "UTC"
@@ -252,7 +316,7 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "SELECT tenant AS \"Tenant\",\n       zone AS \"Zone\",\n       ifNull(application, 'unclassified') AS \"Application\",\n       sum(bytes) AS \"Bytes\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Tenant\", \"Zone\", \"Application\"\nORDER BY \"Bytes\" DESC\nLIMIT $limit",
+          "rawSql": "SELECT tenant AS \"Tenant\",\n       zone AS \"Zone\",\n       ifNull(application, 'unclassified') AS \"Application\",\n       sum(bytes) AS \"Bytes\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND $__conditionalAll(direction IN (${direction:singlequote}), $direction) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Tenant\", \"Zone\", \"Application\"\nORDER BY \"Bytes\" DESC\nLIMIT $limit",
           "refId": "A",
           "meta": {
             "timezone": "UTC"
@@ -277,5 +341,5 @@
       "keepTime": true
     }
   ],
-  "description": "Who talks to whom, over which service, and which tenant, zone and application own the traffic? Byte-weighted Sankey views over the flows table for the selected range \u2014 the conversation/attribution companion to the routing-level Traffic Paths dashboard. Scope with Tenant/Zone/Locality; Limit caps fan-out per diagram."
+  "description": "Who talks to whom, over which service, and which tenant, zone and application own the traffic? Byte-weighted Sankey views over the flows table for the selected range \u2014 the conversation/attribution companion to the routing-level Traffic Paths dashboard. Scope with Tenant/Zone/Locality/Exporter/Direction; Limit caps fan-out per diagram."
 }

--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-traffic-paths.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-traffic-paths.json
@@ -170,6 +170,41 @@
             "$__all"
           ]
         }
+      },
+      {
+        "name": "direction",
+        "label": "Direction",
+        "type": "custom",
+        "description": "Flow direction as reported by the exporter (observation-point relative: INGRESS = sampled entering the interface, EGRESS = leaving it). Many exporters only tag one direction \u2014 if a selection empties the diagrams, the exporter simply never reports that side; check the Collection Health dashboard's protocol/exporter panels before suspecting the network.",
+        "query": "Ingress : INGRESS, Egress : EGRESS, Unknown : UNKNOWN",
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [
+          {
+            "selected": false,
+            "text": "Ingress",
+            "value": "INGRESS"
+          },
+          {
+            "selected": false,
+            "text": "Egress",
+            "value": "EGRESS"
+          },
+          {
+            "selected": false,
+            "text": "Unknown",
+            "value": "UNKNOWN"
+          }
+        ]
       }
     ]
   },
@@ -199,7 +234,7 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "SELECT concat(toString(srcAs), ': ', ifNull(srcAsOrg, 'unknown')) AS \"Source AS\",\n       concat(if(exporterName != '', exporterName, exporterAddr), ' - ', ifNull(inputSnmpIfName, concat('if', toString(inputSnmp)))) AS \"Ingress\",\n       concat(if(exporterName != '', exporterName, exporterAddr), ' - ', ifNull(outputSnmpIfName, concat('if', toString(outputSnmp)))) AS \"Egress\",\n       concat(toString(dstAs), ': ', ifNull(dstAsOrg, 'unknown')) AS \"Destination AS\",\n       round(sum(bytes) * 8 / (toUnixTimestamp($__toTime) - toUnixTimestamp($__fromTime))) AS \"Bits/s\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Source AS\", \"Ingress\", \"Egress\", \"Destination AS\"\nORDER BY \"Bits/s\" DESC\nLIMIT $depth",
+          "rawSql": "SELECT concat(toString(srcAs), ': ', ifNull(srcAsOrg, 'unknown')) AS \"Source AS\",\n       concat(if(exporterName != '', exporterName, exporterAddr), ' - ', ifNull(inputSnmpIfName, concat('if', toString(inputSnmp)))) AS \"Ingress\",\n       concat(if(exporterName != '', exporterName, exporterAddr), ' - ', ifNull(outputSnmpIfName, concat('if', toString(outputSnmp)))) AS \"Egress\",\n       concat(toString(dstAs), ': ', ifNull(dstAsOrg, 'unknown')) AS \"Destination AS\",\n       round(sum(bytes) * 8 / (toUnixTimestamp($__toTime) - toUnixTimestamp($__fromTime))) AS \"Bits/s\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(direction IN (${direction:singlequote}), $direction) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Source AS\", \"Ingress\", \"Egress\", \"Destination AS\"\nORDER BY \"Bits/s\" DESC\nLIMIT $depth",
           "refId": "A"
         }
       ]
@@ -229,7 +264,7 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "SELECT if(srcCountry = '', 'unknown', srcCountry) AS \"Source Country\",\n       concat(toString(srcAs), ': ', ifNull(srcAsOrg, 'unknown')) AS \"Source AS\",\n       if(exporterName != '', exporterName, exporterAddr) AS \"Exporter\",\n       ifNull(dstAddrHostname, replaceOne(toString(dstAddr), '::ffff:', '')) AS \"Destination\",\n       concat(transform(protocol, [1, 2, 6, 17, 41, 47, 50, 51, 58, 89, 132], ['ICMP', 'IGMP', 'TCP', 'UDP', 'IPv6', 'GRE', 'ESP', 'AH', 'IPv6-ICMP', 'OSPFIGP', 'SCTP'], concat('proto-', toString(protocol))), '/', toString(dstPort)) AS \"Service\",\n       round(sum(bytes) * 8 / (toUnixTimestamp($__toTime) - toUnixTimestamp($__fromTime))) AS \"Bits/s\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Source Country\", \"Source AS\", \"Exporter\", \"Destination\", \"Service\"\nORDER BY \"Bits/s\" DESC\nLIMIT $depth",
+          "rawSql": "SELECT if(srcCountry = '', 'unknown', srcCountry) AS \"Source Country\",\n       concat(toString(srcAs), ': ', ifNull(srcAsOrg, 'unknown')) AS \"Source AS\",\n       if(exporterName != '', exporterName, exporterAddr) AS \"Exporter\",\n       ifNull(dstAddrHostname, replaceOne(toString(dstAddr), '::ffff:', '')) AS \"Destination\",\n       concat(transform(protocol, [1, 2, 6, 17, 41, 47, 50, 51, 58, 89, 132], ['ICMP', 'IGMP', 'TCP', 'UDP', 'IPv6', 'GRE', 'ESP', 'AH', 'IPv6-ICMP', 'OSPFIGP', 'SCTP'], concat('proto-', toString(protocol))), '/', toString(dstPort)) AS \"Service\",\n       round(sum(bytes) * 8 / (toUnixTimestamp($__toTime) - toUnixTimestamp($__fromTime))) AS \"Bits/s\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(direction IN (${direction:singlequote}), $direction) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Source Country\", \"Source AS\", \"Exporter\", \"Destination\", \"Service\"\nORDER BY \"Bits/s\" DESC\nLIMIT $depth",
           "refId": "A"
         }
       ]
@@ -259,7 +294,7 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "SELECT if(exporterName != '', exporterName, exporterAddr) AS \"Exporter\",\n       concat(toString(dstAs), ': ', ifNull(dstAsOrg, 'unknown')) AS \"Destination AS\",\n       if(dstCountry = '', 'unknown', dstCountry) AS \"Destination Country\",\n       if(dstCity = '', 'unknown', dstCity) AS \"Destination City\",\n       round(sum(bytes) * 8 / (toUnixTimestamp($__toTime) - toUnixTimestamp($__fromTime))) AS \"Bits/s\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Exporter\", \"Destination AS\", \"Destination Country\", \"Destination City\"\nORDER BY \"Bits/s\" DESC\nLIMIT $depth",
+          "rawSql": "SELECT if(exporterName != '', exporterName, exporterAddr) AS \"Exporter\",\n       concat(toString(dstAs), ': ', ifNull(dstAsOrg, 'unknown')) AS \"Destination AS\",\n       if(dstCountry = '', 'unknown', dstCountry) AS \"Destination Country\",\n       if(dstCity = '', 'unknown', dstCity) AS \"Destination City\",\n       round(sum(bytes) * 8 / (toUnixTimestamp($__toTime) - toUnixTimestamp($__fromTime))) AS \"Bits/s\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(direction IN (${direction:singlequote}), $direction) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Exporter\", \"Destination AS\", \"Destination Country\", \"Destination City\"\nORDER BY \"Bits/s\" DESC\nLIMIT $depth",
           "refId": "A"
         }
       ]
@@ -289,7 +324,7 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "SELECT if(srcCity = '', 'unknown', srcCity) AS \"Source City\",\n       toString(srcLocality) AS \"Source Locality\",\n       if(exporterName != '', exporterName, exporterAddr) AS \"Exporter\",\n       toString(dstLocality) AS \"Destination Locality\",\n       if(dstCity = '', 'unknown', dstCity) AS \"Destination City\",\n       round(sum(bytes) * 8 / (toUnixTimestamp($__toTime) - toUnixTimestamp($__fromTime))) AS \"Bits/s\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Source City\", \"Source Locality\", \"Exporter\", \"Destination Locality\", \"Destination City\"\nORDER BY \"Bits/s\" DESC\nLIMIT $depth",
+          "rawSql": "SELECT if(srcCity = '', 'unknown', srcCity) AS \"Source City\",\n       toString(srcLocality) AS \"Source Locality\",\n       if(exporterName != '', exporterName, exporterAddr) AS \"Exporter\",\n       toString(dstLocality) AS \"Destination Locality\",\n       if(dstCity = '', 'unknown', dstCity) AS \"Destination City\",\n       round(sum(bytes) * 8 / (toUnixTimestamp($__toTime) - toUnixTimestamp($__fromTime))) AS \"Bits/s\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(direction IN (${direction:singlequote}), $direction) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Source City\", \"Source Locality\", \"Exporter\", \"Destination Locality\", \"Destination City\"\nORDER BY \"Bits/s\" DESC\nLIMIT $depth",
           "refId": "A"
         }
       ]
@@ -319,7 +354,7 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "SELECT concat(if(exporterName != '', exporterName, exporterAddr), ' - ', ifNull(inputSnmpIfName, concat('if', toString(inputSnmp)))) AS \"Entry\",\n       concat(if(exporterName != '', exporterName, exporterAddr), ' - ', ifNull(outputSnmpIfName, concat('if', toString(outputSnmp)))) AS \"Exit\",\n       concat(toString(dstAs), ': ', ifNull(dstAsOrg, 'unknown')) AS \"Destination AS\",\n       round(sum(bytes) * 8 / (toUnixTimestamp($__toTime) - toUnixTimestamp($__fromTime))) AS \"Bits/s\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Entry\", \"Exit\", \"Destination AS\"\nORDER BY \"Bits/s\" DESC\nLIMIT $depth",
+          "rawSql": "SELECT concat(if(exporterName != '', exporterName, exporterAddr), ' - ', ifNull(inputSnmpIfName, concat('if', toString(inputSnmp)))) AS \"Entry\",\n       concat(if(exporterName != '', exporterName, exporterAddr), ' - ', ifNull(outputSnmpIfName, concat('if', toString(outputSnmp)))) AS \"Exit\",\n       concat(toString(dstAs), ': ', ifNull(dstAsOrg, 'unknown')) AS \"Destination AS\",\n       round(sum(bytes) * 8 / (toUnixTimestamp($__toTime) - toUnixTimestamp($__fromTime))) AS \"Bits/s\"\nFROM ${database}.flows\nWHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(direction IN (${direction:singlequote}), $direction) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND $__conditionalAll(flowLocality = '$locality', $locality)\nGROUP BY \"Entry\", \"Exit\", \"Destination AS\"\nORDER BY \"Bits/s\" DESC\nLIMIT $depth",
           "refId": "A"
         }
       ]
@@ -340,5 +375,5 @@
       "keepTime": true
     }
   ],
-  "description": "How does traffic route through the network \u2014 which AS pairs peer across which exporters, where does it originate and terminate geographically, and where does it exit? Byte-weighted Sankey paths over the flows table for the selected range. Scope with Tenant/Zone/Locality/Exporter; Depth caps nodes per column to keep the diagrams readable."
+  "description": "How does traffic route through the network \u2014 which AS pairs peer across which exporters, where does it originate and terminate geographically, and where does it exit? Byte-weighted Sankey paths over the flows table for the selected range. Scope with Tenant/Zone/Locality/Exporter/Direction; Depth caps nodes per column to keep the diagrams readable."
 }

--- a/docs/docs/deploy/docker-compose.md
+++ b/docs/docs/deploy/docker-compose.md
@@ -28,12 +28,13 @@ Grafana (admin/admin) ships provisioned dashboards backed by the `flows` table a
 
 - **Riptide - Top 10**: stacked top-10 rate panels (AS, hosts, applications, services, protocols,
   exporters, interfaces) plus a source-AS statistics table with a 95th-percentile column.
-- **Riptide - Traffic Paths (Sankey)**: exporter-filterable path diagrams — AS peering
-  (source AS → ingress → egress → destination AS), situational-awareness, geo
+- **Riptide - Traffic Paths (Sankey)**: exporter- and direction-filterable path diagrams —
+  AS peering (source AS → ingress → egress → destination AS), situational-awareness, geo
   origination/termination, and ultimate-exit views, weighted by bytes over the selected range.
 - **Riptide - Conversations & Tenancy (Sankey)**: the lighter companion — host-to-host
   conversations by service, tenant → zone → application attribution, and a source AS →
-  ingress interface → application → destination AS path view.
+  ingress interface → application → destination AS path view, filterable by exporter and
+  flow direction.
 - **Riptide - Host Investigation**: forensics for a single address — traffic, unique peers,
   TCP flag profile, top peers/services with geo and AS context.
 - **Riptide - Flow Forensics**: slice flows by any combination of tenant, zone, exporter,


### PR DESCRIPTION
## What

- **Direction filter** (Ingress / Egress / Unknown, multi + All) on both Sankey dashboards — Traffic Paths and Conversations & Tenancy — wired into all eight panel queries via the house `$__conditionalAll` pattern, so 'All' stays a no-op.
- **Exporter filter added to Conversations & Tenancy**, which was the one dashboard missing it (Traffic Paths already had one — its old title still on the other dashboard caused the confusion). Uses the corrected value-first `argMax` picker from #365: current name, address fallback, one entry per device.
- The Direction variable's description warns that many exporters tag only one direction, so an empty diagram after selecting Egress points at exporter reporting, not the network.
- Dashboard descriptions and docs bullets updated to match the new filter sets.

## Verification

- All eight panel queries executed against the live local ClickHouse in both open-filter and direction+exporter-filtered variants — 16/16 pass.
- Skill linter: 0 errors, 0 warnings on both dashboards.
- Adversarial review agent deep-compared both files against main (pure insertions, no key loss), confirmed `${direction:singlequote}` interpolates the value side of the text:value pairs against the schema's `Enum8` (values match exactly, including UNKNOWN for untagged flows), and verified clause placement in every rawSql. Its one finding — docs bullet drift introduced by this branch — is fixed in this head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)