### PR TITLE
fix(classification): CSV row order is the rule evaluation priority

### DIFF
--- a/docs/docs/enrichment.md
+++ b/docs/docs/enrichment.md
@@ -112,6 +112,12 @@ Spring resource location and defaults to the bundled `classification-rules.csv`:
 riptide.classification.rules=file:/etc/riptide/classification-rules.csv
 ```
 
+Row order is the evaluation priority: when several rules match a flow — common when a
+client's ephemeral port collides with another rule's registered port — the earliest
+matching row wins, in both directions of an omnidirectional rule. In a custom ruleset,
+put specific rules (address + port) above broad ones (port-only), or the broad row will
+shadow them.
+
 ## Locality
 
 Source/destination/flow locality (private vs. public address space) is derived for every

--- a/src/main/java/org/riptide/classification/internal/csv/CsvImporter.java
+++ b/src/main/java/org/riptide/classification/internal/csv/CsvImporter.java
@@ -7,6 +7,7 @@ package org.riptide.classification.internal.csv;
 
 import com.google.common.base.Strings;
 import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.riptide.classification.DefaultRule;
 import org.riptide.classification.Rule;
@@ -26,10 +27,24 @@ public final class CsvImporter {
 
         final var rules = new ArrayList<Rule>();
         final var format = createFormat(hasHeader);
-        final var parser = format.parse(new InputStreamReader(inputStream));
+        // Reject files whose first line is not the expected header: commons-csv would otherwise
+        // consume a rule row as pseudo-header, silently dropping it and shifting every position —
+        // and positions are the evaluation priority. Empty fields in that row make commons-csv
+        // itself refuse ("a header name is missing") before the name comparison can run.
+        final CSVParser parser;
+        try {
+            parser = format.parse(new InputStreamReader(inputStream));
+        } catch (final IllegalArgumentException e) {
+            throw new IOException("The rules file's first line is not the expected header '%s'. The header row is required."
+                    .formatted(String.join(";", HEADERS)), e);
+        }
+        if (hasHeader && !parser.getHeaderNames().equals(List.of(HEADERS))) {
+            throw new IOException("The rules file's first line is not the expected header '%s' but '%s'. The header row is required."
+                    .formatted(String.join(";", HEADERS), String.join(";", parser.getHeaderNames())));
+        }
         for (CSVRecord record : parser.getRecords()) {
             if (record.size() < HEADERS.length) {
-                throw new IOException("The provided rule ''%s'' cannot be parsed. Expected columns %s but received %s.".formatted(record, HEADERS.length, record.size()));
+                throw new IOException("The provided rule '%s' cannot be parsed. Expected columns %s but received %s.".formatted(record, HEADERS.length, record.size()));
             }
 
             final String name = record.get(0);
@@ -41,9 +56,9 @@ public final class CsvImporter {
             final String exportFilter = record.get(6);
             final String omnidirectional = record.get(7);
 
-            // Set values. The row order is the evaluation priority (Rule.getPosition): when
-            // several rules tie otherwise — e.g. an ephemeral port colliding with another
-            // rule's registered port — the earlier row wins deterministically.
+            // Set values. The row order is the evaluation priority (Rule.getPosition): the
+            // earliest matching row wins — even over a later, more specific rule — so specific
+            // rules must precede broad ones.
             final var rule = DefaultRule.builder()
                 .withName(Strings.emptyToNull(name))
                 .withDstPort(Strings.emptyToNull(dstPort))

--- a/src/main/java/org/riptide/classification/internal/csv/CsvImporter.java
+++ b/src/main/java/org/riptide/classification/internal/csv/CsvImporter.java
@@ -41,7 +41,9 @@ public final class CsvImporter {
             final String exportFilter = record.get(6);
             final String omnidirectional = record.get(7);
 
-            // Set values
+            // Set values. The row order is the evaluation priority (Rule.getPosition): when
+            // several rules tie otherwise — e.g. an ephemeral port colliding with another
+            // rule's registered port — the earlier row wins deterministically.
             final var rule = DefaultRule.builder()
                 .withName(Strings.emptyToNull(name))
                 .withDstPort(Strings.emptyToNull(dstPort))
@@ -51,6 +53,7 @@ public final class CsvImporter {
                 .withProtocol(Strings.emptyToNull(protocol))
                 .withExporterFilter(Strings.emptyToNull(exportFilter))
                 .withOmnidirectional(Boolean.parseBoolean(omnidirectional))
+                .withPosition(rules.size())
                 .build();
 
             rules.add(rule);

--- a/src/test/java/org/riptide/classification/internal/csv/CsvImporterTest.java
+++ b/src/test/java/org/riptide/classification/internal/csv/CsvImporterTest.java
@@ -17,6 +17,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class CsvImporterTest {
 
@@ -24,6 +25,16 @@ public class CsvImporterTest {
 
     private static List<Rule> parse(final String csv) throws IOException {
         return new CsvImporter().parse(new ByteArrayInputStream(csv.getBytes(StandardCharsets.UTF_8)), true);
+    }
+
+    private static DefaultClassificationEngine engineFor(final String rows) throws IOException, InterruptedException {
+        final var rules = parse(HEADER + rows);
+        return new DefaultClassificationEngine(() -> rules);
+    }
+
+    private static String classify(final DefaultClassificationEngine engine, final int srcPort, final int dstPort) {
+        return engine.classify(ClassificationRequest.builder()
+                .withProtocol(ProtocolType.TCP).withSrcPort(srcPort).withDstPort(dstPort).build());
     }
 
     @Test
@@ -37,6 +48,20 @@ public class CsvImporterTest {
         assertThat(rules).extracting(Rule::getPosition).containsExactly(0, 1, 2);
     }
 
+    @Test
+    void verifyMissingHeaderFailsFast() {
+        // Without the header line the first rule would be consumed as a pseudo-header,
+        // silently dropping it and shifting every position by one. Both shapes must fail:
+        // a first row with empty fields (rejected by commons-csv header parsing) ...
+        assertThatThrownBy(() -> parse("ntp;udp;;;;123;;true\n"))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("name;protocol");
+        // ... and a fully-populated first row, which commons-csv would happily consume.
+        assertThatThrownBy(() -> parse("ntp;udp;10.0.0.1;123;10.0.0.2;123;e1;true\n"))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("name;protocol");
+    }
+
     /**
      * Regression: a client ephemeral port that collides with another rule's registered port
      * (e.g. an https connection whose client side happens to be 8881, galaxy4d's port) matches
@@ -45,40 +70,56 @@ public class CsvImporterTest {
      */
     @Test
     void verifyEarlierRuleWinsEphemeralPortCollision() throws IOException, InterruptedException {
-        final var engine = new DefaultClassificationEngine(() -> {
-            try {
-                return parse(HEADER
-                        + "https;tcp;;;;443;;true\n"
-                        + "galaxy4d;tcp;;;;8881;;true\n");
-            } catch (final IOException e) {
-                throw new RuntimeException(e);
-            }
-        });
+        final var engine = engineFor(
+                "https;tcp;;;;443;;true\n"
+                + "galaxy4d;tcp;;;;8881;;true\n");
 
         // client -> server: dstPort matches https directly, srcPort matches galaxy4d reversed
-        assertThat(engine.classify(ClassificationRequest.builder()
-                .withProtocol(ProtocolType.TCP).withSrcPort(8881).withDstPort(443).build()))
-                .isEqualTo("https");
+        assertThat(classify(engine, 8881, 443)).isEqualTo("https");
         // server -> client: srcPort matches https reversed, dstPort matches galaxy4d directly
-        assertThat(engine.classify(ClassificationRequest.builder()
-                .withProtocol(ProtocolType.TCP).withSrcPort(443).withDstPort(8881).build()))
-                .isEqualTo("https");
+        assertThat(classify(engine, 443, 8881)).isEqualTo("https");
 
         // and the order is what decides: with the rows swapped, galaxy4d wins both directions
-        final var swapped = new DefaultClassificationEngine(() -> {
-            try {
-                return parse(HEADER
-                        + "galaxy4d;tcp;;;;8881;;true\n"
-                        + "https;tcp;;;;443;;true\n");
-            } catch (final IOException e) {
-                throw new RuntimeException(e);
+        final var swapped = engineFor(
+                "galaxy4d;tcp;;;;8881;;true\n"
+                + "https;tcp;;;;443;;true\n");
+        assertThat(classify(swapped, 8881, 443)).isEqualTo("galaxy4d");
+        assertThat(classify(swapped, 443, 8881)).isEqualTo("galaxy4d");
+    }
+
+    /**
+     * Row order is the evaluation priority, so the bundled ruleset's ordering is load-bearing:
+     * a broad rule placed before a more specific one shadows it. Guard the invariant the
+     * bundled file relies on — every rule constraining fewer than two of the classifier
+     * aspects (protocol, ports, addresses) stays at the very end, where it cannot shadow.
+     */
+    @Test
+    void verifyBundledRulesetKeepsBroadRulesLast() throws IOException {
+        final List<Rule> rules;
+        try (var stream = CsvImporterTest.class.getResourceAsStream("/classification-rules.csv")) {
+            rules = new CsvImporter().parse(stream, true);
+        }
+        assertThat(rules).hasSizeGreaterThan(6000);
+
+        int firstBroad = -1;
+        for (int i = 0; i < rules.size(); i++) {
+            final var rule = rules.get(i);
+            final var aspects = (rule.hasProtocolDefinition() ? 1 : 0)
+                    + (rule.hasSrcPortDefinition() ? 1 : 0)
+                    + (rule.hasDstPortDefinition() ? 1 : 0)
+                    + (rule.hasSrcAddressDefinition() ? 1 : 0)
+                    + (rule.hasDstAddressDefinition() ? 1 : 0);
+            if (aspects < 2) {
+                if (firstBroad == -1) {
+                    firstBroad = i;
+                }
+            } else if (firstBroad != -1) {
+                assertThat(i)
+                        .as("rule '%s' (row %s) is more specific than the broad rule at row %s before it"
+                                + " — broad rules must stay last or they shadow later rules",
+                                rule.getName(), i, firstBroad)
+                        .isLessThan(firstBroad);
             }
-        });
-        assertThat(swapped.classify(ClassificationRequest.builder()
-                .withProtocol(ProtocolType.TCP).withSrcPort(8881).withDstPort(443).build()))
-                .isEqualTo("galaxy4d");
-        assertThat(swapped.classify(ClassificationRequest.builder()
-                .withProtocol(ProtocolType.TCP).withSrcPort(443).withDstPort(8881).build()))
-                .isEqualTo("galaxy4d");
+        }
     }
 }

--- a/src/test/java/org/riptide/classification/internal/csv/CsvImporterTest.java
+++ b/src/test/java/org/riptide/classification/internal/csv/CsvImporterTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.classification.internal.csv;
+
+import org.junit.jupiter.api.Test;
+import org.riptide.classification.ClassificationRequest;
+import org.riptide.classification.ProtocolType;
+import org.riptide.classification.Rule;
+import org.riptide.classification.internal.DefaultClassificationEngine;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CsvImporterTest {
+
+    private static final String HEADER = "name;protocol;srcAddress;srcPort;dstAddress;dstPort;exporterFilter;omnidirectional\n";
+
+    private static List<Rule> parse(final String csv) throws IOException {
+        return new CsvImporter().parse(new ByteArrayInputStream(csv.getBytes(StandardCharsets.UTF_8)), true);
+    }
+
+    @Test
+    void verifyPositionsFollowRowOrder() throws IOException {
+        final var rules = parse(HEADER
+                + "ntp;udp;;;;123;;true\n"
+                + "ssh;tcp;;;;22;;true\n"
+                + "https;tcp;;;;443;;true\n");
+
+        assertThat(rules).extracting(Rule::getName).containsExactly("ntp", "ssh", "https");
+        assertThat(rules).extracting(Rule::getPosition).containsExactly(0, 1, 2);
+    }
+
+    /**
+     * Regression: a client ephemeral port that collides with another rule's registered port
+     * (e.g. an https connection whose client side happens to be 8881, galaxy4d's port) matches
+     * two omnidirectional rules with the same aspect count. The earlier CSV row must win — in
+     * both flow directions — instead of the winner depending on decision-tree internals.
+     */
+    @Test
+    void verifyEarlierRuleWinsEphemeralPortCollision() throws IOException, InterruptedException {
+        final var engine = new DefaultClassificationEngine(() -> {
+            try {
+                return parse(HEADER
+                        + "https;tcp;;;;443;;true\n"
+                        + "galaxy4d;tcp;;;;8881;;true\n");
+            } catch (final IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // client -> server: dstPort matches https directly, srcPort matches galaxy4d reversed
+        assertThat(engine.classify(ClassificationRequest.builder()
+                .withProtocol(ProtocolType.TCP).withSrcPort(8881).withDstPort(443).build()))
+                .isEqualTo("https");
+        // server -> client: srcPort matches https reversed, dstPort matches galaxy4d directly
+        assertThat(engine.classify(ClassificationRequest.builder()
+                .withProtocol(ProtocolType.TCP).withSrcPort(443).withDstPort(8881).build()))
+                .isEqualTo("https");
+
+        // and the order is what decides: with the rows swapped, galaxy4d wins both directions
+        final var swapped = new DefaultClassificationEngine(() -> {
+            try {
+                return parse(HEADER
+                        + "galaxy4d;tcp;;;;8881;;true\n"
+                        + "https;tcp;;;;443;;true\n");
+            } catch (final IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        assertThat(swapped.classify(ClassificationRequest.builder()
+                .withProtocol(ProtocolType.TCP).withSrcPort(8881).withDstPort(443).build()))
+                .isEqualTo("galaxy4d");
+        assertThat(swapped.classify(ClassificationRequest.builder()
+                .withProtocol(ProtocolType.TCP).withSrcPort(443).withDstPort(8881).build()))
+                .isEqualTo("galaxy4d");
+    }
+}


### PR DESCRIPTION
## Problem

`Rule.getPosition()` is documented as the evaluation order and `Classifier.compareTo` sorts by it — but `CsvImporter` never assigned it, so every imported rule carried `position = 0`. All matching classifiers landed in a single priority group, where only a strictly higher matched-aspect count breaks the tie.

Visible symptom (Flow Forensics, #370): an https connection whose client ephemeral port happened to be **8881** (galaxy4d's registered port) or **12865** (netperf's) matched two omnidirectional rules with equal aspect counts. The winner fell to decision-tree enumeration order — arbitrary and direction-dependent: the same connection classified `https` outbound and `galaxy4d` on the reply, splitting one conversation into several rows with contradictory Application labels next to a correct `TCP/443` Service column.

## Fix

`CsvImporter` assigns `position` from row order. The earlier CSV row now wins deterministically in both directions (reversed omnidirectional rules inherit the original's position, and a rule tying with its own reversal is benign — same name either way). The bundled ruleset's order is inherited from OpenNMS's priority-ordered set with well-known services first, and was verified safe for this change: all 6,237 leading rules carry exactly 2 aspects (protocol + dstPort), and the only lower-specificity rules (11 dstPort-only rows) sit at the very end where they cannot shadow anything.

**Semantic note:** row order is now load-bearing for user-supplied rulesets — a broad rule placed early shadows a more specific rule below it (previously the more specific one won via aspect count). Documented in `docs/docs/enrichment.md`. Flows ingested before this fix keep their stored labels until TTL expiry.

## Verification

- New `CsvImporterTest`: positions follow row order; the 443↔8881 collision resolves to the earlier row in **both** flow directions, and swapping the rows swaps the winner. Both tests verified to fail on pre-fix code (reply direction really did return `galaxy4d`).
- Adversarial review (agent-run, `/code-review` skill unavailable to model this session): no defects; group-split/first-match semantics, reversal ties, position-consumer blast radius, and tree shape all verified — tree construction never reads positions, so the decision tree is bit-identical.
- `mvn test` classification + configuration suites: 413 tests, 0 failures. `make jar` (full `mvn verify` with SpotBugs/checkstyle/Error Prone): BUILD SUCCESS.

## Review hardening (second commit, from `/code-review medium`)

The review confirmed the fix and surfaced hardening items, applied in `788f67e`:

- **Headerless-file swallow (CONFIRMED):** a rules file without the header line silently lost its first rule to the commons-csv pseudo-header and shifted every position. The importer now fails fast with an actionable message for both shapes (empty-field first row via wrapped commons-csv rejection; fully-populated first row via header-name check), with tests.
- **Ordering invariant now enforced (CONFIRMED):** new test loads the bundled 6,248-rule CSV and asserts rules with fewer than two classifier aspects stay at the end, where they cannot shadow later rules — previously stated only in prose.
- **Comment accuracy (CONFIRMED):** the importer comment no longer calls position a tie-break; the earliest matching row wins even over a later, more specific rule (matching the docs paragraph).
- **Test dedup + cosmetic (CONFIRMED):** engineFor/classify helpers replace duplicated try/catch lambdas; the pre-existing MessageFormat-style `''%s''` in the short-row error now renders as intended.

**Noted follow-up (PLAUSIBLE, not applied):** position determinism is enforced only at the CSV importer; a future second rule source (REST-configured rules, concatenated files each numbered 0..n) could reintroduce duplicate positions. A list-order ordinal in `DefaultClassificationEngine.reload()` or a final list-index tie-break in `Classifier.compareTo` would close that door — deferred since no current production path exercises it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

