### PR TITLE
release: merge v0.6.6 version commits back to main

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.riptide.flows</groupId>
     <artifactId>riptide-flows</artifactId>
-    <version>0.6.6</version>
+    <version>0.6.7-SNAPSHOT</version>
     <name>riptide-flows</name>
     <description>NetFlow analysis engine</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.riptide.flows</groupId>
     <artifactId>riptide-flows</artifactId>
-    <version>0.6.6-SNAPSHOT</version>
+    <version>0.6.6</version>
     <name>riptide-flows</name>
     <description>NetFlow analysis engine</description>
 


### PR DESCRIPTION
Merges the v0.6.6 release commits back to main. Net diff: pom.xml project version `0.6.6-SNAPSHOT` → `0.6.7-SNAPSHOT` (the v0.6.6 release commit plus the next-snapshot commit, both generated by `make release`).

Review: reduced agent-based pass over the one-line automated diff (per the small-config-diff rule) — confirmed the diff contains only the pom version line, the `v0.6.6` tag points at the commit whose tree carries `0.6.6`, and no other file hard-codes the version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)