### PR TITLE
refactor: clear Error Prone warnings and ratchet the checks to errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,7 @@
                     <compilerArgs>
                         <arg>-XDcompilePolicy=simple</arg>
                         <arg>--should-stop=ifError=FLOW</arg>
-                        <!-- These three checks are warning-free; hold them at ERROR so they stay that way. -->
+                        <!-- These three checks are warning-free or explicitly suppressed; hold them at ERROR so they stay that way. -->
                         <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/target/generated-sources/.* -Xep:EqualsGetClass:ERROR -Xep:NarrowingCompoundAssignment:ERROR -Xep:ExposedPrivateType:ERROR</arg>
                         <arg>
                             -Amapstruct.unmappedTargetPolicy=ERROR

--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,8 @@
                     <compilerArgs>
                         <arg>-XDcompilePolicy=simple</arg>
                         <arg>--should-stop=ifError=FLOW</arg>
-                        <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/target/generated-sources/.*</arg>
+                        <!-- Warning-free as of the classification cleanup; keep them that way. -->
+                        <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/target/generated-sources/.* -Xep:EqualsGetClass:ERROR -Xep:NarrowingCompoundAssignment:ERROR -Xep:ExposedPrivateType:ERROR</arg>
                         <arg>
                             -Amapstruct.unmappedTargetPolicy=ERROR
                         </arg>

--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,7 @@
                     <compilerArgs>
                         <arg>-XDcompilePolicy=simple</arg>
                         <arg>--should-stop=ifError=FLOW</arg>
-                        <!-- Warning-free as of the classification cleanup; keep them that way. -->
+                        <!-- These three checks are warning-free; hold them at ERROR so they stay that way. -->
                         <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/target/generated-sources/.* -Xep:EqualsGetClass:ERROR -Xep:NarrowingCompoundAssignment:ERROR -Xep:ExposedPrivateType:ERROR</arg>
                         <arg>
                             -Amapstruct.unmappedTargetPolicy=ERROR

--- a/src/main/java/org/riptide/classification/internal/decision/Threshold.java
+++ b/src/main/java/org/riptide/classification/internal/decision/Threshold.java
@@ -54,8 +54,10 @@ public abstract class Threshold<T extends Comparable<T>> {
 
     /**
      * Bundles the information how a rule matches a threshold. More than one flag may be {@code true}.
+     * Package-private (not private) because the protected {@code match} implementations in the
+     * nested subclasses reference it in their signatures.
      */
-    private static class Match {
+    static class Match {
         final boolean lt, eq, gt, na;
 
         Match(boolean lt, boolean eq, boolean gt, boolean na) {
@@ -274,6 +276,10 @@ public abstract class Threshold<T extends Comparable<T>> {
             }
         }
 
+        // getClass() (not instanceof) is load-bearing: the SrcPort and DstPort subclasses share
+        // the port value but must stay distinct in the candidate-threshold Set — an instanceof
+        // equals would collapse SrcPort(n) and DstPort(n) and corrupt the decision tree.
+        @SuppressWarnings("EqualsGetClass")
         @Override
         public final boolean equals(Object o) {
             if (this == o) {
@@ -376,6 +382,10 @@ public abstract class Threshold<T extends Comparable<T>> {
             }
         }
 
+        // getClass() (not instanceof) is load-bearing: the SrcAddress and DstAddress subclasses
+        // share the address value but must stay distinct in the candidate-threshold Set — an
+        // instanceof equals would collapse them and corrupt the decision tree.
+        @SuppressWarnings("EqualsGetClass")
         @Override
         public final boolean equals(Object o) {
             if (this == o) {

--- a/src/main/java/org/riptide/classification/internal/decision/Threshold.java
+++ b/src/main/java/org/riptide/classification/internal/decision/Threshold.java
@@ -57,7 +57,7 @@ public abstract class Threshold<T extends Comparable<T>> {
      * Package-private (not private) because the protected {@code match} implementations in the
      * nested subclasses reference it in their signatures.
      */
-    static class Match {
+    static final class Match {
         final boolean lt, eq, gt, na;
 
         Match(boolean lt, boolean eq, boolean gt, boolean na) {
@@ -67,7 +67,7 @@ public abstract class Threshold<T extends Comparable<T>> {
             this.na = na;
         }
 
-        static Match NA = new Match(false, false, false, true);
+        static final Match NA = new Match(false, false, false, true);
     }
 
     protected final Function<Bounds, Bound<T>> getBound;

--- a/src/main/java/org/riptide/classification/internal/value/IPPortRange.java
+++ b/src/main/java/org/riptide/classification/internal/value/IPPortRange.java
@@ -41,10 +41,9 @@ public class IPPortRange {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof IPPortRange that)) {
             return false;
         }
-        IPPortRange that = (IPPortRange) o;
         return begin == that.begin && end == that.end;
     }
 

--- a/src/main/java/org/riptide/classification/internal/value/IPPortRange.java
+++ b/src/main/java/org/riptide/classification/internal/value/IPPortRange.java
@@ -10,7 +10,7 @@ import lombok.ToString;
 import java.util.Objects;
 
 @ToString
-public class IPPortRange {
+public final class IPPortRange {
     private final int begin;
     private final int end;
 

--- a/src/main/java/org/riptide/classification/internal/value/IpRange.java
+++ b/src/main/java/org/riptide/classification/internal/value/IpRange.java
@@ -46,10 +46,9 @@ public class IpRange implements Iterable<IpAddr> {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof IpRange ipAddrs)) {
             return false;
         }
-        IpRange ipAddrs = (IpRange) o;
         return begin.equals(ipAddrs.begin) && end.equals(ipAddrs.end);
     }
 

--- a/src/main/java/org/riptide/classification/internal/value/IpRange.java
+++ b/src/main/java/org/riptide/classification/internal/value/IpRange.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-public class IpRange implements Iterable<IpAddr> {
+public final class IpRange implements Iterable<IpAddr> {
 
     public static IpRange of(String addr) {
         final var a = IpAddr.of(addr);
@@ -46,10 +46,10 @@ public class IpRange implements Iterable<IpAddr> {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof IpRange ipAddrs)) {
+        if (!(o instanceof IpRange that)) {
             return false;
         }
-        return begin.equals(ipAddrs.begin) && end.equals(ipAddrs.end);
+        return begin.equals(that.begin) && end.equals(that.end);
     }
 
     @Override

--- a/src/main/java/org/riptide/classification/internal/value/IpValue.java
+++ b/src/main/java/org/riptide/classification/internal/value/IpValue.java
@@ -90,6 +90,12 @@ public class IpValue implements RuleValue<IpAddr, IpValue> {
 
         final byte[] address = InetAddresses.forString(cidr.substring(0, slashIndex)).getAddress();
         final int mask = Integer.parseInt(cidr.substring(slashIndex + 1));
+        if (mask < 0 || mask > address.length * 8) {
+            // out-of-range masks must fail loudly: /-1../-7 would otherwise silently match
+            // the whole address space and oversized masks a single address
+            throw new IllegalArgumentException(
+                    "Invalid CIDR mask /" + mask + " for a " + (address.length * 8) + "-bit address: " + cidr);
+        }
 
         // Mask the lower bound with all zero
         final byte[] lower = Arrays.copyOf(address, address.length);

--- a/src/main/java/org/riptide/classification/internal/value/IpValue.java
+++ b/src/main/java/org/riptide/classification/internal/value/IpValue.java
@@ -97,7 +97,7 @@ public class IpValue implements RuleValue<IpAddr, IpValue> {
             if (i * 8 >= mask) {
                 lower[i] = (byte) 0x00;
             } else {
-                lower[i] &= 0xFF << (8 - (mask - i * 8));
+                lower[i] = (byte) (lower[i] & (0xFF << (8 - (mask - i * 8))));
             }
         }
 
@@ -107,7 +107,7 @@ public class IpValue implements RuleValue<IpAddr, IpValue> {
             if (i * 8 >= mask) {
                 upper[i] = (byte) 0xFF;
             } else {
-                upper[i] |= 0xFF >> (mask - i * 8);
+                upper[i] = (byte) (upper[i] | (0xFF >> (mask - i * 8)));
             }
         }
 

--- a/src/main/java/org/riptide/flows/parser/ie/InformationElementDatabase.java
+++ b/src/main/java/org/riptide/flows/parser/ie/InformationElementDatabase.java
@@ -30,8 +30,7 @@ public final class InformationElementDatabase {
         @Override
         public boolean equals(final Object o) {
             if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            Key that = (Key) o;
+            if (!(o instanceof Key that)) return false;
             return Objects.equals(this.protocol, that.protocol)
                     && Objects.equals(this.enterpriseNumber, that.enterpriseNumber)
                     && Objects.equals(this.informationElementIdentifier, that.informationElementIdentifier);

--- a/src/main/java/org/riptide/flows/parser/ie/InformationElementDatabase.java
+++ b/src/main/java/org/riptide/flows/parser/ie/InformationElementDatabase.java
@@ -14,7 +14,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 public final class InformationElementDatabase {
-    public static class Key {
+    public static final class Key {
         private final Protocol protocol;
         private final Long enterpriseNumber;
         private final Integer informationElementIdentifier;

--- a/src/main/java/org/riptide/flows/parser/ipfix/IpfixUdpParser.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/IpfixUdpParser.java
@@ -98,8 +98,7 @@ public class IpfixUdpParser extends UdpParserBase implements DispatchableUdpPars
         @Override
         public boolean equals(final Object o) {
             if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            final SessionKey that = (SessionKey) o;
+            if (!(o instanceof SessionKey that)) return false;
             return Objects.equals(this.localAddress, that.localAddress)
                     && Objects.equals(this.remoteAddress, that.remoteAddress);
         }

--- a/src/main/java/org/riptide/flows/parser/ipfix/IpfixUdpParser.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/IpfixUdpParser.java
@@ -86,7 +86,7 @@ public class IpfixUdpParser extends UdpParserBase implements DispatchableUdpPars
         return new SessionKey(remoteAddress, localAddress);
     }
 
-    public static class SessionKey implements UdpSessionManager.SessionKey {
+    public static final class SessionKey implements UdpSessionManager.SessionKey {
         private final InetSocketAddress remoteAddress;
         private final InetSocketAddress localAddress;
 

--- a/src/main/java/org/riptide/flows/parser/netflow9/Netflow9UdpParser.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/Netflow9UdpParser.java
@@ -79,7 +79,7 @@ public class Netflow9UdpParser extends UdpParserBase implements DispatchableUdpP
         return new SessionKey(remoteAddress.getAddress(), localAddress);
     }
 
-    public static class SessionKey implements UdpSessionManager.SessionKey {
+    public static final class SessionKey implements UdpSessionManager.SessionKey {
         private final InetAddress remoteAddress;
         private final InetSocketAddress localAddress;
 

--- a/src/main/java/org/riptide/flows/parser/netflow9/Netflow9UdpParser.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/Netflow9UdpParser.java
@@ -91,8 +91,7 @@ public class Netflow9UdpParser extends UdpParserBase implements DispatchableUdpP
         @Override
         public boolean equals(final Object o) {
             if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            final SessionKey that = (SessionKey) o;
+            if (!(o instanceof SessionKey that)) return false;
             return Objects.equals(this.localAddress, that.localAddress)
                     && Objects.equals(this.remoteAddress, that.remoteAddress);
         }

--- a/src/main/java/org/riptide/flows/parser/session/UdpSessionManager.java
+++ b/src/main/java/org/riptide/flows/parser/session/UdpSessionManager.java
@@ -118,7 +118,8 @@ public class UdpSessionManager {
         InetAddress getRemoteAddress();
     }
 
-    private static final class DomainKey {
+    // Package-private (not private) because the public TemplateKey exposes it in a field.
+    static final class DomainKey {
         public final SessionKey sessionKey;
         public final long observationDomainId;
 

--- a/src/test/java/org/riptide/classification/internal/decision/ThresholdTest.java
+++ b/src/test/java/org/riptide/classification/internal/decision/ThresholdTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.classification.internal.decision;
+
+import org.junit.jupiter.api.Test;
+import org.riptide.classification.DefaultRule;
+import org.riptide.classification.IpAddr;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ThresholdTest {
+
+    /**
+     * The getClass()-based equals in {@link Threshold.Port} and {@link Threshold.Address} is
+     * load-bearing: src- and dst-side thresholds with equal values must coexist in the
+     * candidate-threshold set or the decision tree loses one axis's split candidates. This pins
+     * the invariant against a future instanceof "modernization" (see the suppressions in
+     * {@link Threshold}).
+     */
+    @Test
+    void verifySrcAndDstThresholdsOfEqualValueStayDistinct() {
+        assertThat(new Threshold.SrcPort(443)).isNotEqualTo(new Threshold.DstPort(443));
+        assertThat(new Threshold.SrcAddress(IpAddr.of("10.0.0.1")))
+                .isNotEqualTo(new Threshold.DstAddress(IpAddr.of("10.0.0.1")));
+
+        // and end to end: a rule with equal src/dst values keeps a candidate per side
+        final var rule = DefaultRule.builder().withName("r").withProtocol("tcp")
+                .withSrcPort(443).withDstPort(443)
+                .withSrcAddress("10.0.0.1").withDstAddress("10.0.0.1")
+                .build();
+        final var thresholds = PreprocessedRule.of(rule).thresholds;
+        assertThat(thresholds).filteredOn(t -> t instanceof Threshold.SrcPort).hasSize(1);
+        assertThat(thresholds).filteredOn(t -> t instanceof Threshold.DstPort).hasSize(1);
+        assertThat(thresholds).filteredOn(t -> t instanceof Threshold.SrcAddress).isNotEmpty();
+        assertThat(thresholds).filteredOn(t -> t instanceof Threshold.DstAddress).isNotEmpty();
+    }
+}

--- a/src/test/java/org/riptide/classification/internal/decision/ThresholdTest.java
+++ b/src/test/java/org/riptide/classification/internal/decision/ThresholdTest.java
@@ -22,6 +22,12 @@ public class ThresholdTest {
      */
     @Test
     void verifySrcAndDstThresholdsOfEqualValueStayDistinct() {
+        // positive controls first — without them a broken always-false equals would pass
+        assertThat(new Threshold.SrcPort(443)).isEqualTo(new Threshold.SrcPort(443));
+        assertThat(new Threshold.DstPort(443)).isEqualTo(new Threshold.DstPort(443));
+        assertThat(new Threshold.SrcAddress(IpAddr.of("10.0.0.1")))
+                .isEqualTo(new Threshold.SrcAddress(IpAddr.of("10.0.0.1")));
+
         assertThat(new Threshold.SrcPort(443)).isNotEqualTo(new Threshold.DstPort(443));
         assertThat(new Threshold.SrcAddress(IpAddr.of("10.0.0.1")))
                 .isNotEqualTo(new Threshold.DstAddress(IpAddr.of("10.0.0.1")));
@@ -34,7 +40,8 @@ public class ThresholdTest {
         final var thresholds = PreprocessedRule.of(rule).thresholds;
         assertThat(thresholds).filteredOn(t -> t instanceof Threshold.SrcPort).hasSize(1);
         assertThat(thresholds).filteredOn(t -> t instanceof Threshold.DstPort).hasSize(1);
-        assertThat(thresholds).filteredOn(t -> t instanceof Threshold.SrcAddress).isNotEmpty();
-        assertThat(thresholds).filteredOn(t -> t instanceof Threshold.DstAddress).isNotEmpty();
+        // a single-address rule expands to boundary thresholds that dedupe to one per side
+        assertThat(thresholds).filteredOn(t -> t instanceof Threshold.SrcAddress).hasSize(1);
+        assertThat(thresholds).filteredOn(t -> t instanceof Threshold.DstAddress).hasSize(1);
     }
 }

--- a/src/test/java/org/riptide/classification/internal/value/IpValueTest.java
+++ b/src/test/java/org/riptide/classification/internal/value/IpValueTest.java
@@ -160,4 +160,17 @@ public class IpValueTest {
         }
         Assertions.assertThat(value.isInRange(IpAddr.of("2001:0DB8:0:CD30::2"))).isFalse();
     }
+    @Test
+    void verifyCidrMaskBounds() {
+        // valid boundaries parse
+        Assertions.assertThat(IpValue.parseCIDR("10.0.0.0/0")).isNotNull();
+        Assertions.assertThat(IpValue.parseCIDR("10.0.0.0/32")).isNotNull();
+        Assertions.assertThat(IpValue.parseCIDR("2001:db8::/128")).isNotNull();
+
+        // out-of-range masks fail loudly instead of silently matching everything or nothing
+        Assertions.assertThatThrownBy(() -> IpValue.parseCIDR("10.0.0.0/-1")).isInstanceOf(IllegalArgumentException.class);
+        Assertions.assertThatThrownBy(() -> IpValue.parseCIDR("10.0.0.0/-8")).isInstanceOf(IllegalArgumentException.class);
+        Assertions.assertThatThrownBy(() -> IpValue.parseCIDR("10.0.0.0/33")).isInstanceOf(IllegalArgumentException.class);
+        Assertions.assertThatThrownBy(() -> IpValue.parseCIDR("2001:db8::/129")).isInstanceOf(IllegalArgumentException.class);
+    }
 }


### PR DESCRIPTION
## Change

Every CI build has been annotating Error Prone warnings from three patterns (GitHub truncates at 10; there were 14 sites across the classification engine and flow parsers). This clears all of them and escalates the three checks to `-Xep:…:ERROR` so they cannot creep back.

- **NarrowingCompoundAssignment** (IpValue CIDR masking): explicit `(byte)` casts — per JLS 15.26.2 the compound form already performed exactly this promote-op-truncate sequence, so the change is definitionally equivalent; the truncation was always the intended semantics, just invisible.
- **EqualsGetClass**: five leaf value/key classes (`IpRange`, `IPPortRange`, `InformationElementDatabase.Key`, both parser `SessionKey`s — none subclassed, the two SessionKeys unrelated types) convert to `instanceof` pattern matching. `Threshold.Port`/`Address` **keep `getClass()` with a documented suppression**: their Src/Dst subclasses share values but must stay distinct in the candidate-threshold `Set` — the suggested instanceof equals would collapse `SrcPort(443)`/`DstPort(443)` (guaranteed to co-occur via `PreprocessedRule.reverse()`) and silently corrupt the decision tree.
- **ExposedPrivateType**: `Threshold.Match` and `UdpSessionManager.DomainKey` become package-private, matching what their signatures already implied.

## Verification

- `make jar` with the ratchet active: BUILD SUCCESS, 796 tests, 0 occurrences of the three patterns.
- Adversarial review (agent-run): zero findings. Verified bit-for-bit mask equivalence incl. sign extension, the absence of subclasses for every instanceof conversion, that the unqualified `instanceof SessionKey` binds to the concrete class (not the shared interface — cross-parser keys stay unequal), the reality of the threshold-Set collapse scenario justifying the suppressions, suppression effectiveness at ERROR severity, and that the pom flags reach both compile and test-compile with no profile escape hatch.

## Structured review rounds (bmad code-review)

Two adversarial rounds (Blind Hunter + Edge Case Hunter) on top of the original agent review, findings applied in `3a1e96d` and `d853d5f`:

- **Round 1:** the five instanceof-equals classes are now `final` (instanceof is only contract-safe when subclassing can't introduce asymmetry); new `ThresholdTest` pins the SrcPort/DstPort and SrcAddress/DstAddress distinctness invariant the suppressions describe; pom comment scoped; naming consistency.
- **Round 2:** the edge pass surfaced a real pre-existing defect on the touched lines — `parseCIDR` accepted out-of-range masks, and `/-1`–`/-7` **silently matched the entire address space** (a typo'd custom rule would classify all traffic); now rejected loudly with boundary tests (`/0`, `/32`, `/128` valid; `/-1`, `/-8`, `/33`, `/129` rejected). Plus: positive equality controls in ThresholdTest (an always-false equals would have passed the round-1 test), `Match`/`NA` made final, pom comment acknowledges the suppressions.
- **Deferred** (recorded, pre-existing design): sealed-hierarchy modernization for Threshold, TemplateKey/DomainKey API encapsulation, DomainKey equals autoboxing.

Final state: `make jar` BUILD SUCCESS, **798 tests**, zero occurrences of the three ratcheted patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

