### PR TITLE
⚡ Batch ClickHouse inserts across flows

### DIFF
--- a/docs/docs/configuration/clickhouse.md
+++ b/docs/docs/configuration/clickhouse.md
@@ -152,32 +152,57 @@ follow ClickHouse's guidance of 10k–100k rows per insert at roughly one insert
 `max-latency` also bounds how stale dashboards go at low flow rates. When the queue is full —
 ClickHouse cannot keep up — the collector **drops flows instead of blocking** (blocking would
 backpressure the parsers into the network socket, where the loss is invisible); drops are counted
-(`persister.batch.droppedRows`) and logged with a rate limit. Alongside sit a queue-depth gauge,
-a batch-size histogram, a flush timer (`persister.batch.flush`), and a `failedRows` counter for
+and logged with a rate limit. Alongside the `droppedRows` counter sit a queue-depth gauge, a
+batch-size histogram, a flush timer (`persister.batch.flush`), and a `failedRows` counter for
 batches whose insert failed.
 
-:::warning[Error visibility and metric semantics under batching]
+:::warning[Error visibility under batching — watch the logs]
 
 With batching enabled, **insert failures never surface to the ingest path**: a failed batch is
 logged by the flusher and counted in `persister.batch.failedRows`, and ingestion continues. The
 synchronous per-insert error signal (e.g. the `469 VIOLATED_CONSTRAINT` rejection in provisioned
-mode) only exists with `batch.enabled=false` (and coalescing off). Watch `failedRows` — it is the
-only signal that inserts are failing.
+mode) only exists with `batch.enabled=false` (and coalescing off).
 
-The pre-existing `logPersisting.persister` timer now measures only the **enqueue** latency (the
-hand-off into the buffer, normally microseconds); re-key dashboards that used it as insert
-duration to `persister.batch.flush`.
+Today the operator-facing signal is therefore the flusher's **`ERROR` log line** (`Failed to
+persist a batch of N flows`) — alert on it. The `persister.batch.*` metrics live only in the
+in-process registry: riptide currently ships **no metrics reporter or exporter** (the management
+server serves `/livez` and `/readyz` only), so they cannot be scraped or graphed yet. They are
+wired and ready for the day an exporter lands — a known gap, not a monitoring recommendation.
+
+Note also that the pre-existing `logPersisting.persister` timer now measures only the **enqueue**
+latency (the hand-off into the buffer, normally microseconds) rather than insert duration; the
+insert duration lives in `persister.batch.flush`. Relevant when metrics do become exportable.
 
 :::
 
+**A poison row now costs a whole batch.** Because rows are inserted together, a single row the
+server rejects fails the entire insert: up to `max-rows` flows are dropped instead of the one bad
+flow the per-record path would have lost. The flusher logs the batch size with the error and
+moves on (one bad batch never wedges ingestion), but a persistent source of rejected rows — a
+mis-tenanted collector against the multi-tenant CHECK barrier, say — now costs proportionally
+more data. Lowering `max-rows` limits the blast radius at the cost of throughput.
+
 On shutdown the repository stops accepting new flows and drains everything already accepted —
 buffered flows are flushed before the repository stops, preserving at-least-once delivery for
-accepted flows. Budget the service manager's stop timeout for the **whole** shutdown sequence,
-not just the grace period: the listeners stop first, each waiting up to ~5 s for its parser
-executor to finish in-flight dispatches (sequentially, per receiver), and only then does the
-batch drain's `shutdown-grace-period` start. Keep that sum below systemd's `TimeoutStopSec`
-(default 90 s), or the process is killed mid-drain. `max-latency` must stay below the grace
-period (enforced at startup), since the flusher notices the stop signal only between flush
+accepted flows.
+
+Budget the service manager's stop timeout for the **whole** shutdown sequence, not just the grace
+period. The listeners stop first and sequentially, and each **parser** waits up to 5 s for its
+dispatch executor to finish in-flight flows — note *per parser*, not per receiver: a `multi`
+receiver runs one parser per enabled protocol and stops them one after another, so a single
+`multi` receiver with all four protocols can take ~20 s on its own. Only then does the batch
+drain's `shutdown-grace-period` start:
+
+```
+worst case ≈ (5 s × total parsers across all receivers) + shutdown-grace-period + 1 s
+```
+
+The trailing second is the grace-expired path only: if the flusher has to be interrupted, it is
+given one more second to unwind before the queue is swept, so that the sweep and the client
+teardown never race an insert that is still in flight. A collector with one `multi` receiver
+(4 protocols) and one IPFIX receiver is therefore 5 × 5 + 5 + 1 = ~31 s. Keep that sum below systemd's `TimeoutStopSec` (default 90 s), or the process
+is killed mid-drain and the buffer is lost. `shutdown-grace-period` must be at least twice
+`max-latency` (enforced at startup), since the flusher notices the stop signal only between flush
 windows.
 
 ### Insert coalescing (`async-inserts`)

--- a/docs/docs/configuration/clickhouse.md
+++ b/docs/docs/configuration/clickhouse.md
@@ -13,7 +13,12 @@ riptide.clickhouse.username=default
 #riptide.clickhouse.password=vault://secret/riptide/clickhouse#password
 riptide.clickhouse.database=riptide
 riptide.clickhouse.manage-schema=true
-#riptide.clickhouse.async-inserts=   # unset: follows manage-schema — see below
+riptide.clickhouse.batch.enabled=true
+riptide.clickhouse.batch.max-rows=10000
+riptide.clickhouse.batch.max-latency=2s
+riptide.clickhouse.batch.queue-capacity=40000
+riptide.clickhouse.batch.shutdown-grace-period=5s
+#riptide.clickhouse.async-inserts=   # unset: derived — off under batching, see below
 ```
 
 ## Credentials
@@ -124,24 +129,80 @@ GROUP BY application ORDER BY bytes DESC LIMIT 10;
 
 Each rollup `X` is fed by a materialized view named `X_mv`. Query the table, never the `_mv`.
 
+### Insert batching (`batch.*`)
+
+Historically the collector inserted flows as they were dispatched — dispatch is per **flow
+record** — and every insert also feeds the four rollup views: each insert forms a ClickHouse part
+and fires all four materialized views, so many small inserts collapse throughput. Issue #382's
+benchmark, framed at the packet level (~24 flow records per received packet on average), capped a
+4-vCPU lab VM at ~150 inserts/s ≈ 3,600 rows/s with the CPU mostly idle. Since #382 the collector
+batches client-side: flows are buffered in a bounded in-memory queue and a single background
+flusher issues **one insert per batch**.
+
+| property | default | meaning |
+|---|---|---|
+| `riptide.clickhouse.batch.enabled` | `true` | Off falls back to the per-record insert path. |
+| `riptide.clickhouse.batch.max-rows` | `10000` | Flush when this many rows are buffered. |
+| `riptide.clickhouse.batch.max-latency` | `2s` | Flush whatever is buffered after this long. |
+| `riptide.clickhouse.batch.queue-capacity` | `40000` | Buffer bound; a full queue drops flows (counted). |
+| `riptide.clickhouse.batch.shutdown-grace-period` | `5s` | How long `stop()` waits for the drain. |
+
+A batch is flushed at `max-rows` rows or after `max-latency`, whichever comes first. The defaults
+follow ClickHouse's guidance of 10k–100k rows per insert at roughly one insert per second;
+`max-latency` also bounds how stale dashboards go at low flow rates. When the queue is full —
+ClickHouse cannot keep up — the collector **drops flows instead of blocking** (blocking would
+backpressure the parsers into the network socket, where the loss is invisible); drops are counted
+(`persister.batch.droppedRows`) and logged with a rate limit. Alongside sit a queue-depth gauge,
+a batch-size histogram, a flush timer (`persister.batch.flush`), and a `failedRows` counter for
+batches whose insert failed.
+
+:::warning[Error visibility and metric semantics under batching]
+
+With batching enabled, **insert failures never surface to the ingest path**: a failed batch is
+logged by the flusher and counted in `persister.batch.failedRows`, and ingestion continues. The
+synchronous per-insert error signal (e.g. the `469 VIOLATED_CONSTRAINT` rejection in provisioned
+mode) only exists with `batch.enabled=false` (and coalescing off). Watch `failedRows` — it is the
+only signal that inserts are failing.
+
+The pre-existing `logPersisting.persister` timer now measures only the **enqueue** latency (the
+hand-off into the buffer, normally microseconds); re-key dashboards that used it as insert
+duration to `persister.batch.flush`.
+
+:::
+
+On shutdown the repository stops accepting new flows and drains everything already accepted —
+buffered flows are flushed before the repository stops, preserving at-least-once delivery for
+accepted flows. Budget the service manager's stop timeout for the **whole** shutdown sequence,
+not just the grace period: the listeners stop first, each waiting up to ~5 s for its parser
+executor to finish in-flight dispatches (sequentially, per receiver), and only then does the
+batch drain's `shutdown-grace-period` start. Keep that sum below systemd's `TimeoutStopSec`
+(default 90 s), or the process is killed mid-drain. `max-latency` must stay below the grace
+period (enforced at startup), since the flusher notices the stop signal only between flush
+windows.
+
 ### Insert coalescing (`async-inserts`)
 
-The collector inserts once per received packet, and every insert also feeds the four rollup
-views. Without coalescing, that many small inserts collapse throughput on modest hardware —
-measured on two cores: 206 inserts/s without the rollups, 56 with them, **607 with the rollups
-and server-side coalescing** (`async_insert`, acknowledged on buffer append).
+Server-side coalescing (`async_insert`, acknowledged on buffer append) was the previous answer to
+the small-insert flood — measured on two cores: 206 inserts/s without the rollups, 56 with
+them, 607 with the rollups and coalescing. Client-side [batching](#insert-batching-batch) has
+superseded it: the server receives one large insert per batch, which coalescing cannot improve
+on. Coalescing also hides insert errors from the collector entirely: the insert is acknowledged
+before the server evaluates it, so a row the server later rejects is dropped **without any error
+anywhere** — including a mis-tenanted row failing the CHECK barrier. (With coalescing off, a
+failed insert is at least visible: as a flusher error log plus `persister.batch.failedRows`
+under batching, or as a synchronous exception with batching disabled.)
 
-`riptide.clickhouse.async-inserts` controls it, and **unset follows `manage-schema`**:
+`riptide.clickhouse.async-inserts` unset therefore now derives as:
 
-- **manage mode → on.** No write barrier exists, and flow transport is lossy UDP anyway — the
-  ~200 ms server-side buffer window changes nothing an operator relies on.
-- **provisioned mode → off.** The insert is acknowledged before the server evaluates it, so a
-  row the server later rejects is dropped **without the collector seeing an error** — including a
-  mis-tenanted row failing the CHECK barrier. Isolation still holds (the row never lands), but
-  the synchronous `469 VIOLATED_CONSTRAINT` signal is part of the provisioned-mode contract, so
-  coalescing stays off unless you opt in.
+- **batching enabled (default) → off.** Superseded, and off keeps insert errors visible to the
+  flusher.
+- **batching disabled → follows `manage-schema`** (the pre-batching default): on in manage mode
+  — no write barrier exists and flow transport is lossy UDP anyway — and off in provisioned
+  mode, where the synchronous `469 VIOLATED_CONSTRAINT` rejection is part of the isolation
+  contract. Without this fallback, `batch.enabled=false` alone would silently land on the
+  measured-slowest combination (56 inserts/s).
 
-Set the property explicitly to override either default.
+Set the property explicitly to override either derivation.
 
 ### Retention
 

--- a/src/main/java/org/riptide/config/ClickhouseConfig.java
+++ b/src/main/java/org/riptide/config/ClickhouseConfig.java
@@ -9,6 +9,8 @@ import lombok.Data;
 import org.riptide.secrets.SecretRef;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.time.Duration;
+
 @Data
 @ConfigurationProperties(prefix = "riptide.clickhouse")
 public final class ClickhouseConfig {
@@ -36,24 +38,128 @@ public final class ClickhouseConfig {
         private boolean manageSchema = true;
 
         /**
-         * Server-side insert coalescing ({@code async_insert}). The pipeline inserts once per
-         * received packet, and each insert also feeds the rollup materialized views — without
-         * coalescing, that many small inserts collapse ingestion throughput on modest hardware
-         * (measured 206 → 56 inserts/s with the four rollups on two cores). With coalescing the
-         * server buffers and merges them (measured 607 inserts/s), at the price of asynchronous
-         * error reporting: the insert is acknowledged when buffered, so a row the server later
-         * rejects — notably a mis-tenanted row failing the multi-tenant CHECK barrier — is dropped
-         * without the collector seeing an error.
+         * Server-side insert coalescing ({@code async_insert}). Historically the pipeline
+         * inserted once per flow record, and each insert also feeds the rollup materialized
+         * views — without coalescing, that many small inserts collapse ingestion throughput on
+         * modest hardware (measured 206 → 56 inserts/s with the four rollups on two cores;
+         * coalescing brought it to 607). That role is superseded by the client-side batching
+         * buffer (see {@link BatchConfig}): the collector now hands the server one large insert
+         * per batch, which server-side coalescing cannot improve on. Coalescing also costs
+         * insert-error visibility: the insert is acknowledged when buffered
+         * ({@code wait_for_async_insert=0}), so a row the server later rejects — notably a
+         * mis-tenanted row failing the multi-tenant CHECK barrier — is dropped without the
+         * collector seeing an error.
          *
-         * <p>Unset (default) follows {@link #manageSchema}: on in manage mode (single-tenant,
-         * where the barrier does not exist and flow transport is lossy UDP anyway), off in
-         * provisioned mode (where the barrier's synchronous rejection is part of the isolation
-         * contract). Set explicitly to override either way.
+         * <p>Note the supersession changes who sees an error, not just throughput: with batching
+         * enabled, insert failures surface as flusher error logs plus the
+         * {@code persister.batch.failedRows} counter — not as synchronous exceptions to the
+         * caller. The synchronous rejection signal only exists with batching disabled and
+         * coalescing off.
+         *
+         * <p>Unset (default) is off while batching is enabled. With batching disabled it falls
+         * back to the pre-batching derived default — on exactly in manage mode (single-tenant,
+         * lossy UDP transport), off in provisioned mode (synchronous CHECK-barrier rejection is
+         * part of the isolation contract) — because otherwise a {@code batch.enabled=false}
+         * config would silently land on the measured-slowest combination (56 inserts/s). Set
+         * explicitly to override either way.
          */
         private Boolean asyncInserts;
 
-        /** The effective setting: the explicit value if set, otherwise on exactly in manage mode. */
+        /**
+         * The effective setting: the explicit value if set; unset is off under batching (which
+         * supersedes coalescing), otherwise the pre-batching derived default (on exactly in
+         * manage mode).
+         */
         public boolean isAsyncInserts() {
-                return this.asyncInserts != null ? this.asyncInserts : this.manageSchema;
+                if (this.asyncInserts != null) {
+                        return this.asyncInserts;
+                }
+                return !this.batch.isEnabled() && this.manageSchema;
+        }
+
+        private BatchConfig batch = new BatchConfig();
+
+        /**
+         * Client-side insert batching: a bounded queue in front of the repository, drained by a
+         * single background flusher into one insert per batch. Each insert forms a part and fires
+         * the four rollup materialized views, so many small inserts collapse throughput — the
+         * per-record path capped a 4-vCPU host at ~150 inserts/s ≈ 3,600 rows/s with the CPU
+         * mostly idle. ClickHouse guidance is 10k–100k rows per insert at roughly one insert per
+         * second; the defaults below sit at the low end of that.
+         */
+        @Data
+        public static final class BatchConfig {
+                /** Off falls back to the per-record insert path (one insert per persist call). */
+                private boolean enabled = true;
+
+                /**
+                 * Flush once this many rows are buffered, even if {@link #maxLatency} has not
+                 * elapsed. 10k is the low end of the ClickHouse guidance — large enough to
+                 * amortize part formation and rollup fan-out, small enough to keep a batch's
+                 * heap footprint modest.
+                 */
+                private int maxRows = 10_000;
+
+                /**
+                 * Flush whatever is buffered after this long, even below {@link #maxRows} —
+                 * bounds how stale dashboards go at low flow rates. 2 s matches the ~1 insert/s
+                 * guidance (issue #382's 200 ms would undersize batches below ClickHouse's
+                 * 1,000-row floor). Must stay well below {@link #shutdownGracePeriod}: the
+                 * flusher notices the stop signal only between drain windows.
+                 */
+                private Duration maxLatency = Duration.ofSeconds(2);
+
+                /**
+                 * Bound of the buffer between producers and the flusher: 40k = four full
+                 * batches, enough to ride out one slow insert. When full, producers drop flows
+                 * (counted + logged) instead of blocking — ClickHouse latency otherwise
+                 * backpressures the parser executors into the Netty socket, where the loss is
+                 * invisible.
+                 */
+                private int queueCapacity = 40_000;
+
+                /**
+                 * How long {@code stop()} waits for the flusher to drain accepted rows before
+                 * giving up. Keep this below the service manager's stop timeout (systemd
+                 * {@code TimeoutStopSec}), or the process is killed mid-drain — and note the
+                 * listeners stop first, each waiting up to ~5 s for its parser executor, before
+                 * this grace period even starts.
+                 */
+                private Duration shutdownGracePeriod = Duration.ofSeconds(5);
+
+                /**
+                 * Fail fast on values that would misbehave at runtime; called when the batching
+                 * repository is constructed. {@code maxRows <= 0} would busy-spin the flusher,
+                 * {@code queueCapacity <= 0} only surfaces as an opaque queue exception, and
+                 * {@code maxLatency >= shutdownGracePeriod} makes the shutdown drain miss its
+                 * grace window (the flusher notices the stop signal only between drain windows).
+                 */
+                public void validate() {
+                        if (this.maxRows <= 0) {
+                                throw new IllegalArgumentException(
+                                        "riptide.clickhouse.batch.max-rows must be > 0 (got " + this.maxRows + ")");
+                        }
+                        if (this.queueCapacity <= 0) {
+                                throw new IllegalArgumentException(
+                                        "riptide.clickhouse.batch.queue-capacity must be > 0 (got " + this.queueCapacity + ")");
+                        }
+                        if (this.maxLatency == null || this.maxLatency.isZero() || this.maxLatency.isNegative()) {
+                                throw new IllegalArgumentException(
+                                        "riptide.clickhouse.batch.max-latency must be positive (got " + this.maxLatency + ")");
+                        }
+                        if (this.shutdownGracePeriod == null || this.shutdownGracePeriod.isZero()
+                                        || this.shutdownGracePeriod.isNegative()) {
+                                throw new IllegalArgumentException(
+                                        "riptide.clickhouse.batch.shutdown-grace-period must be positive (got "
+                                                + this.shutdownGracePeriod + ")");
+                        }
+                        if (this.maxLatency.compareTo(this.shutdownGracePeriod) >= 0) {
+                                throw new IllegalArgumentException(
+                                        "riptide.clickhouse.batch.max-latency (" + this.maxLatency
+                                                + ") must be shorter than shutdown-grace-period ("
+                                                + this.shutdownGracePeriod
+                                                + ") — the flusher notices the stop signal only between drain windows");
+                        }
+                }
         }
 }

--- a/src/main/java/org/riptide/config/ClickhouseConfig.java
+++ b/src/main/java/org/riptide/config/ClickhouseConfig.java
@@ -104,8 +104,9 @@ public final class ClickhouseConfig {
                  * Flush whatever is buffered after this long, even below {@link #maxRows} —
                  * bounds how stale dashboards go at low flow rates. 2 s matches the ~1 insert/s
                  * guidance (issue #382's 200 ms would undersize batches below ClickHouse's
-                 * 1,000-row floor). Must stay well below {@link #shutdownGracePeriod}: the
-                 * flusher notices the stop signal only between drain windows.
+                 * 1,000-row floor). Must be at most half of {@link #shutdownGracePeriod}
+                 * (enforced at startup): the flusher notices the stop signal only between drain
+                 * windows, so one full window can pass before the drain even begins.
                  */
                 private Duration maxLatency = Duration.ofSeconds(2);
 
@@ -130,9 +131,10 @@ public final class ClickhouseConfig {
                 /**
                  * Fail fast on values that would misbehave at runtime; called when the batching
                  * repository is constructed. {@code maxRows <= 0} would busy-spin the flusher,
-                 * {@code queueCapacity <= 0} only surfaces as an opaque queue exception, and
-                 * {@code maxLatency >= shutdownGracePeriod} makes the shutdown drain miss its
-                 * grace window (the flusher notices the stop signal only between drain windows).
+                 * {@code queueCapacity <= 0} only surfaces as an opaque queue exception, and a
+                 * {@code shutdownGracePeriod} under twice {@code maxLatency} leaves the drain no
+                 * usable time (the flusher notices the stop signal only between drain windows,
+                 * so up to one full window is gone before it even starts draining).
                  */
                 public void validate() {
                         if (this.maxRows <= 0) {
@@ -153,12 +155,12 @@ public final class ClickhouseConfig {
                                         "riptide.clickhouse.batch.shutdown-grace-period must be positive (got "
                                                 + this.shutdownGracePeriod + ")");
                         }
-                        if (this.maxLatency.compareTo(this.shutdownGracePeriod) >= 0) {
+                        if (this.shutdownGracePeriod.compareTo(this.maxLatency.multipliedBy(2)) < 0) {
                                 throw new IllegalArgumentException(
-                                        "riptide.clickhouse.batch.max-latency (" + this.maxLatency
-                                                + ") must be shorter than shutdown-grace-period ("
-                                                + this.shutdownGracePeriod
-                                                + ") — the flusher notices the stop signal only between drain windows");
+                                        "riptide.clickhouse.batch.shutdown-grace-period (" + this.shutdownGracePeriod
+                                                + ") must be at least twice max-latency (" + this.maxLatency
+                                                + ") — the flusher notices the stop signal only between drain windows, "
+                                                + "so anything less leaves no time to drain the queue");
                         }
                 }
         }

--- a/src/main/java/org/riptide/configuration/ClickhouseConfiguration.java
+++ b/src/main/java/org/riptide/configuration/ClickhouseConfiguration.java
@@ -5,7 +5,10 @@
 
 package org.riptide.configuration;
 
+import com.codahale.metrics.MetricRegistry;
 import org.riptide.config.ClickhouseConfig;
+import org.riptide.repository.FlowRepository;
+import org.riptide.repository.clickhouse.BatchingFlowRepository;
 import org.riptide.repository.clickhouse.ClickhouseRepository;
 import org.riptide.secrets.SecretResolvers;
 import org.springframework.context.annotation.Bean;
@@ -14,9 +17,16 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class ClickhouseConfiguration {
     @Bean
-    public ClickhouseRepository clickhouseRepository(final ClickhouseRepository.FlowMapper flowMapper,
-                                                     final ClickhouseConfig config,
-                                                     final SecretResolvers secretResolvers) {
-        return new ClickhouseRepository(flowMapper, config, secretResolvers);
+    public FlowRepository clickhouseRepository(final ClickhouseRepository.FlowMapper flowMapper,
+                                               final ClickhouseConfig config,
+                                               final SecretResolvers secretResolvers,
+                                               final MetricRegistry metricRegistry) {
+        final var repository = new ClickhouseRepository(flowMapper, config, secretResolvers);
+        // The batching decorator is the default write path; disabling it falls back to the raw
+        // per-record repository (one insert per persist call).
+        if (config.getBatch().isEnabled()) {
+            return new BatchingFlowRepository(repository, config.getBatch(), metricRegistry);
+        }
+        return repository;
     }
 }

--- a/src/main/java/org/riptide/flows/Daemon.java
+++ b/src/main/java/org/riptide/flows/Daemon.java
@@ -182,11 +182,15 @@ public class Daemon implements ApplicationRunner {
         this.started = false;
         // Listeners first: the parsers stop accepting packets and finish their in-flight
         // dispatches, so the pipeline's shutdown drain below sees every accepted flow. A
-        // failing listener must not keep the pipeline (and its batch drain) from stopping.
+        // failing listener must not keep the pipeline (and its batch drain) from stopping —
+        // the flusher is a daemon thread, so a skipped drain silently loses the whole buffer.
+        // Exception, not RuntimeException: Listener.stop() declares no checked exceptions, but
+        // the Netty listeners call syncUninterruptibly(), which sneaky-throws the future's
+        // cause — checked exceptions included. Do not "tidy" this back to RuntimeException.
         for (final var listener : this.listeners) {
             try {
                 listener.stop();
-            } catch (final RuntimeException e) {
+            } catch (final Exception e) {
                 log.warn("Failed to stop listener {}", listener.getName(), e);
             }
         }

--- a/src/main/java/org/riptide/flows/Daemon.java
+++ b/src/main/java/org/riptide/flows/Daemon.java
@@ -180,8 +180,17 @@ public class Daemon implements ApplicationRunner {
     @PreDestroy
     public void stop() throws Exception {
         this.started = false;
+        // Listeners first: the parsers stop accepting packets and finish their in-flight
+        // dispatches, so the pipeline's shutdown drain below sees every accepted flow. A
+        // failing listener must not keep the pipeline (and its batch drain) from stopping.
+        for (final var listener : this.listeners) {
+            try {
+                listener.stop();
+            } catch (final RuntimeException e) {
+                log.warn("Failed to stop listener {}", listener.getName(), e);
+            }
+        }
         this.pipeline.stop();
-        this.listeners.forEach(Listener::stop);
     }
 
     /** The configured receivers, for health reporting. */

--- a/src/main/java/org/riptide/flows/parser/ParserBase.java
+++ b/src/main/java/org/riptide/flows/parser/ParserBase.java
@@ -97,6 +97,21 @@ public abstract class ParserBase implements Parser {
     public void stop() {
         if (this.executor != null) {
             this.executor.shutdown();
+            try {
+                // Bounded wait for the in-flight dispatches to land in the repository (and its
+                // batch buffer) before the pipeline behind them is stopped and drained.
+                if (!this.executor.awaitTermination(5, SECONDS)) {
+                    log.warn("Parser {} executor did not terminate in time; cancelling remaining dispatches", this.name);
+                    // Cancel what is left: abandoned non-daemon workers would wedge JVM exit,
+                    // and shutdownNow also unblocks a caller stuck in the rejection handler's
+                    // blocking put().
+                    this.executor.shutdownNow();
+                }
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.warn("Interrupted while stopping parser {}; cancelling remaining dispatches", this.name);
+                this.executor.shutdownNow();
+            }
             this.executor = null;
         }
     }

--- a/src/main/java/org/riptide/management/HealthService.java
+++ b/src/main/java/org/riptide/management/HealthService.java
@@ -11,8 +11,9 @@ import org.springframework.stereotype.Component;
 
 /**
  * Evaluates collector health for the management endpoints. Deliberately never references ClickHouse:
- * there is no write buffer and a single collector has no failover, so gating readiness on ClickHouse
- * would only add load-balancer convergence loss for no benefit (see the add-health-endpoints design).
+ * the only write buffer is the small bounded batching queue (flushed within seconds, drained on
+ * shutdown) and a single collector has no failover, so gating readiness on ClickHouse would only
+ * add load-balancer convergence loss for no benefit (see the add-health-endpoints design).
  */
 @Component
 public class HealthService {

--- a/src/main/java/org/riptide/repository/clickhouse/BatchingFlowRepository.java
+++ b/src/main/java/org/riptide/repository/clickhouse/BatchingFlowRepository.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.repository.clickhouse;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.google.common.collect.Queues;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.riptide.config.ClickhouseConfig;
+import org.riptide.pipeline.EnrichedFlow;
+import org.riptide.pipeline.FlowException;
+import org.riptide.repository.FlowRepository;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Batching decorator around a {@link FlowRepository}: producers enqueue flows into a bounded
+ * queue, a single background flusher drains them and hands the delegate one large insert per
+ * batch (at {@code maxRows} rows or after {@code maxLatency}, whichever comes first). Each
+ * ClickHouse insert forms a part and fires the four rollup materialized views, so collapsing the
+ * per-record inserts into batches is what buys the throughput (see
+ * {@link ClickhouseConfig.BatchConfig} for the sizing rationale).
+ *
+ * <p>Loss model: a full queue drops flows (counted, rate-limited warn) instead of blocking —
+ * blocking would backpressure the parser executors into the Netty socket where loss is invisible.
+ * Insert failures likewise surface as flusher error logs and the {@code failedRows} counter, not
+ * as exceptions to the caller. {@code stop()} rejects new flows and drains everything already
+ * accepted within the shutdown grace period, preserving at-least-once for accepted flows. A
+ * stopped instance cannot be restarted: {@code start()} after {@code stop()} fails loud, because
+ * a half-alive instance that silently drops everything would be worse than a crash.
+ */
+@Slf4j
+public class BatchingFlowRepository implements FlowRepository {
+
+    /**
+     * The offer budget for one persist() call — shared across its rows, not per row: under
+     * sustained overload per-row waits would add up to exactly the blocking backpressure this
+     * class exists to avoid. Short on purpose: a queue that stays full means ClickHouse cannot
+     * keep up, and stalling the parser executors longer only moves the loss somewhere invisible.
+     */
+    private static final long OFFER_TIMEOUT_MS = 100;
+
+    /** Minimum spacing between drop warnings; the dropped counter carries the exact tally. */
+    private static final long DROP_WARN_INTERVAL_MS = 10_000;
+
+    private final FlowRepository delegate;
+
+    private final ClickhouseConfig.BatchConfig config;
+
+    private final LinkedBlockingQueue<EnrichedFlow> queue;
+
+    /** Set once by stop(): producers reject-new, the flusher switches to its final drain. */
+    private final AtomicBoolean stopped = new AtomicBoolean();
+
+    private volatile Thread flusher;
+
+    private final AtomicLong lastDropWarnMillis = new AtomicLong();
+
+    private final Counter droppedRows;
+    private final Counter failedRows;
+    private final Histogram batchSize;
+    private final Timer flushTimer;
+
+    public BatchingFlowRepository(final FlowRepository delegate,
+                                  final ClickhouseConfig.BatchConfig config,
+                                  final MetricRegistry metricRegistry) {
+        this.delegate = Objects.requireNonNull(delegate);
+        this.config = Objects.requireNonNull(config);
+        Objects.requireNonNull(metricRegistry);
+
+        // Fail fast on nonsensical values: maxRows=0 would busy-spin the flusher, and
+        // queueCapacity=0 would surface as an opaque LinkedBlockingQueue exception here.
+        config.validate();
+
+        this.queue = new LinkedBlockingQueue<>(config.getQueueCapacity());
+
+        this.droppedRows = metricRegistry.counter(MetricRegistry.name("persister", "batch", "droppedRows"));
+        this.failedRows = metricRegistry.counter(MetricRegistry.name("persister", "batch", "failedRows"));
+        this.batchSize = metricRegistry.histogram(MetricRegistry.name("persister", "batch", "batchSize"));
+        this.flushTimer = metricRegistry.timer(MetricRegistry.name("persister", "batch", "flush"));
+
+        final String queueDepthGauge = MetricRegistry.name("persister", "batch", "queueDepth");
+        // Replace, don't keep: a stale gauge left by a previous instance would keep reading that
+        // instance's dead queue — worse than no gauge at all.
+        metricRegistry.remove(queueDepthGauge);
+        metricRegistry.register(queueDepthGauge, (Gauge<Integer>) this.queue::size);
+    }
+
+    @Override
+    public void persist(final List<EnrichedFlow> flows) throws FlowException, IOException {
+        // One offer budget for the whole call (see OFFER_TIMEOUT_MS): the first rows may wait
+        // for space, and once the budget is spent the rest gets non-blocking offers only.
+        final long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(OFFER_TIMEOUT_MS);
+        for (int i = 0; i < flows.size(); i++) {
+            if (this.stopped.get()) {
+                // Reject-new after stop(): the drain must converge on the rows accepted so far.
+                drop(flows.size() - i, "repository is stopping");
+                return;
+            }
+            try {
+                final long remaining = deadline - System.nanoTime();
+                final boolean accepted = remaining > 0
+                        ? this.queue.offer(flows.get(i), remaining, TimeUnit.NANOSECONDS)
+                        : this.queue.offer(flows.get(i));
+                if (!accepted) {
+                    // Budget exhausted against a still-full queue: drop the remainder in one go
+                    // rather than burning a timeout per row.
+                    drop(flows.size() - i, "queue is full — ClickHouse cannot keep up");
+                    return;
+                }
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                drop(flows.size() - i, "producer interrupted");
+                return;
+            }
+        }
+    }
+
+    private void drop(final int rows, final String reason) {
+        this.droppedRows.inc(rows);
+        final long now = System.currentTimeMillis();
+        final long last = this.lastDropWarnMillis.get();
+        // Rate-limited: under sustained overload every offer times out, and a warn per flow
+        // would drown the log. The counter carries the exact tally.
+        if (now - last >= DROP_WARN_INTERVAL_MS && this.lastDropWarnMillis.compareAndSet(last, now)) {
+            log.warn("Dropping flows ({}); {} dropped in total", reason, this.droppedRows.getCount());
+        }
+    }
+
+    @Override
+    public void start() {
+        if (this.stopped.get()) {
+            // Fail loud: a "restarted" instance would accept nothing and silently drop every
+            // flow — the worst possible failure mode for a persister.
+            throw new IllegalStateException("BatchingFlowRepository is stopped and cannot be restarted");
+        }
+
+        // Delegate first: the flusher must not insert before the schema is ensured/validated.
+        this.delegate.start();
+
+        final Thread thread = new ThreadFactoryBuilder()
+                .setNameFormat("clickhouse-batch-flusher")
+                .setDaemon(true)
+                .build()
+                .newThread(this::flushLoop);
+        this.flusher = thread;
+        thread.start();
+    }
+
+    private void flushLoop() {
+        while (!Thread.currentThread().isInterrupted()) {
+            // A fresh list per batch: the delegate (and tests) may retain the reference.
+            final List<EnrichedFlow> batch = new ArrayList<>();
+            try {
+                if (this.stopped.get()) {
+                    // Final drain: non-blocking, so the loop exits as soon as the queue is empty.
+                    this.queue.drainTo(batch, this.config.getMaxRows());
+                    if (batch.isEmpty()) {
+                        return;
+                    }
+                } else {
+                    try {
+                        // Blocks until maxRows are available or maxLatency elapsed — the two
+                        // flush triggers in one call.
+                        Queues.drain(this.queue, batch, this.config.getMaxRows(), this.config.getMaxLatency());
+                    } catch (final InterruptedException e) {
+                        // Only stop() interrupts us, and only after the grace period expired —
+                        // the insert below would be interrupted too, so give up instead of
+                        // flushing; stop()'s leftover sweep accounts for what stays behind.
+                        Thread.currentThread().interrupt();
+                        if (!batch.isEmpty()) {
+                            log.warn("Flusher interrupted with {} rows drained but unflushed", batch.size());
+                        }
+                        return;
+                    }
+                }
+                if (!batch.isEmpty()) {
+                    flush(batch);
+                }
+            } catch (final Throwable e) {
+                // Throwable on purpose: this is the only flusher, and a silent death (a metrics
+                // bug, an Error, anything unforeseen) would turn into a permanent 100% drop.
+                // Count whatever was in hand, log, and keep looping.
+                this.failedRows.inc(batch.size());
+                log.error("Unexpected error in the batch flusher — continuing", e);
+            }
+        }
+    }
+
+    /**
+     * Hand one batch to the delegate. Never throws: a poison batch (mapping bug, rejected rows,
+     * unreachable server after client-side retries) is logged and counted, and the flusher moves
+     * on — one bad batch must not wedge the pipeline. An interrupt during the insert stays
+     * visible on the thread (the delegate restores the flag), so the loop above still exits.
+     */
+    private void flush(final List<EnrichedFlow> batch) {
+        this.batchSize.update(batch.size());
+        try (var ctx = this.flushTimer.time()) {
+            this.delegate.persist(batch);
+        } catch (final FlowException | IOException | RuntimeException e) {
+            this.failedRows.inc(batch.size());
+            log.error("Failed to persist a batch of {} flows — dropping the batch", batch.size(), e);
+        }
+    }
+
+    @Override
+    public void stop() {
+        if (!this.stopped.compareAndSet(false, true)) {
+            // Idempotent: the drain and the delegate stop must run exactly once.
+            return;
+        }
+        final Thread thread = this.flusher;
+        boolean graceExpired = false;
+        if (thread != null) {
+            try {
+                // The flusher sees the stop flag at the latest after the current drain window
+                // (maxLatency < grace, enforced by validate()), then drains the queue
+                // non-blocking and exits.
+                thread.join(Math.max(1, this.config.getShutdownGracePeriod().toMillis()));
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            if (thread.isAlive()) {
+                // Grace expired — a wedged or very slow insert. Interrupt as a last resort and
+                // account for what stays behind.
+                graceExpired = true;
+                thread.interrupt();
+                log.warn("Batch flusher did not drain within {}; about {} accepted rows undelivered",
+                        this.config.getShutdownGracePeriod(), this.queue.size());
+            }
+            this.flusher = null;
+        }
+        // Straggler sweep: a producer may pass the stopped check and offer after the flusher's
+        // final drain — without this, those rows would be lost uncounted. One best-effort insert.
+        final List<EnrichedFlow> leftovers = new ArrayList<>();
+        this.queue.drainTo(leftovers);
+        if (!leftovers.isEmpty()) {
+            if (graceExpired) {
+                // The grace budget is spent and the delegate is why. Another blocking insert
+                // would hang shutdown past the service manager's stop timeout (the client has
+                // no socket timeout by default) for rows that are unlikely to land anyway.
+                this.failedRows.inc(leftovers.size());
+                log.error("Dropping {} leftover flows: the shutdown grace period is exhausted",
+                        leftovers.size());
+            } else {
+                try {
+                    this.delegate.persist(leftovers);
+                } catch (final FlowException | IOException | RuntimeException e) {
+                    this.failedRows.inc(leftovers.size());
+                    log.error("Failed to persist {} leftover flows during shutdown — dropping them",
+                            leftovers.size(), e);
+                }
+            }
+        }
+        this.delegate.stop();
+    }
+}

--- a/src/main/java/org/riptide/repository/clickhouse/BatchingFlowRepository.java
+++ b/src/main/java/org/riptide/repository/clickhouse/BatchingFlowRepository.java
@@ -55,7 +55,14 @@ public class BatchingFlowRepository implements FlowRepository {
     private static final long OFFER_TIMEOUT_MS = 100;
 
     /** Minimum spacing between drop warnings; the dropped counter carries the exact tally. */
-    private static final long DROP_WARN_INTERVAL_MS = 10_000;
+    private static final long DROP_WARN_INTERVAL_NANOS = TimeUnit.SECONDS.toNanos(10);
+
+    /**
+     * How long stop() waits for the flusher to unwind after the post-grace interrupt, before
+     * sweeping the queue itself. Without it the sweep would drain the same queue concurrently
+     * with the dying flusher, and delegate.stop() could run with an insert still in flight.
+     */
+    private static final long INTERRUPT_JOIN_MS = 1_000;
 
     private final FlowRepository delegate;
 
@@ -68,8 +75,11 @@ public class BatchingFlowRepository implements FlowRepository {
 
     private volatile Thread flusher;
 
-    private final AtomicLong lastDropWarnMillis = new AtomicLong();
+    /** nanoTime, not wall clock: an NTP step backwards would mute drop warnings for the skew. */
+    private final AtomicLong lastDropWarnNanos = new AtomicLong(System.nanoTime() - DROP_WARN_INTERVAL_NANOS);
 
+    private final MetricRegistry metricRegistry;
+    private final String queueDepthGauge;
     private final Counter droppedRows;
     private final Counter failedRows;
     private final Histogram batchSize;
@@ -80,7 +90,7 @@ public class BatchingFlowRepository implements FlowRepository {
                                   final MetricRegistry metricRegistry) {
         this.delegate = Objects.requireNonNull(delegate);
         this.config = Objects.requireNonNull(config);
-        Objects.requireNonNull(metricRegistry);
+        this.metricRegistry = Objects.requireNonNull(metricRegistry);
 
         // Fail fast on nonsensical values: maxRows=0 would busy-spin the flusher, and
         // queueCapacity=0 would surface as an opaque LinkedBlockingQueue exception here.
@@ -93,11 +103,11 @@ public class BatchingFlowRepository implements FlowRepository {
         this.batchSize = metricRegistry.histogram(MetricRegistry.name("persister", "batch", "batchSize"));
         this.flushTimer = metricRegistry.timer(MetricRegistry.name("persister", "batch", "flush"));
 
-        final String queueDepthGauge = MetricRegistry.name("persister", "batch", "queueDepth");
+        this.queueDepthGauge = MetricRegistry.name("persister", "batch", "queueDepth");
         // Replace, don't keep: a stale gauge left by a previous instance would keep reading that
-        // instance's dead queue — worse than no gauge at all.
-        metricRegistry.remove(queueDepthGauge);
-        metricRegistry.register(queueDepthGauge, (Gauge<Integer>) this.queue::size);
+        // instance's dead queue — worse than no gauge at all. stop() unregisters it again.
+        metricRegistry.remove(this.queueDepthGauge);
+        metricRegistry.register(this.queueDepthGauge, (Gauge<Integer>) this.queue::size);
     }
 
     @Override
@@ -132,11 +142,11 @@ public class BatchingFlowRepository implements FlowRepository {
 
     private void drop(final int rows, final String reason) {
         this.droppedRows.inc(rows);
-        final long now = System.currentTimeMillis();
-        final long last = this.lastDropWarnMillis.get();
+        final long now = System.nanoTime();
+        final long last = this.lastDropWarnNanos.get();
         // Rate-limited: under sustained overload every offer times out, and a warn per flow
         // would drown the log. The counter carries the exact tally.
-        if (now - last >= DROP_WARN_INTERVAL_MS && this.lastDropWarnMillis.compareAndSet(last, now)) {
+        if (now - last >= DROP_WARN_INTERVAL_NANOS && this.lastDropWarnNanos.compareAndSet(last, now)) {
             log.warn("Dropping flows ({}); {} dropped in total", reason, this.droppedRows.getCount());
         }
     }
@@ -147,6 +157,11 @@ public class BatchingFlowRepository implements FlowRepository {
             // Fail loud: a "restarted" instance would accept nothing and silently drop every
             // flow — the worst possible failure mode for a persister.
             throw new IllegalStateException("BatchingFlowRepository is stopped and cannot be restarted");
+        }
+        if (this.flusher != null) {
+            // A second start() would re-run the delegate's manage-mode DDL and orphan the first
+            // flusher, which stop() then never joins.
+            throw new IllegalStateException("BatchingFlowRepository is already started");
         }
 
         // Delegate first: the flusher must not insert before the schema is ensured/validated.
@@ -180,9 +195,12 @@ public class BatchingFlowRepository implements FlowRepository {
                     } catch (final InterruptedException e) {
                         // Only stop() interrupts us, and only after the grace period expired —
                         // the insert below would be interrupted too, so give up instead of
-                        // flushing; stop()'s leftover sweep accounts for what stays behind.
+                        // flushing. These rows already left the queue, so stop()'s leftover
+                        // sweep cannot see them: count them here or they vanish from every
+                        // counter.
                         Thread.currentThread().interrupt();
                         if (!batch.isEmpty()) {
+                            this.failedRows.inc(batch.size());
                             log.warn("Flusher interrupted with {} rows drained but unflushed", batch.size());
                         }
                         return;
@@ -235,37 +253,72 @@ public class BatchingFlowRepository implements FlowRepository {
                 Thread.currentThread().interrupt();
             }
             if (thread.isAlive()) {
-                // Grace expired — a wedged or very slow insert. Interrupt as a last resort and
-                // account for what stays behind.
+                // Grace expired — a wedged or very slow insert. Interrupt as a last resort, then
+                // give the flusher a moment to unwind: otherwise the sweep below drains the same
+                // queue concurrently with the dying thread and delegate.stop() can run with an
+                // insert still in flight.
                 graceExpired = true;
                 thread.interrupt();
                 log.warn("Batch flusher did not drain within {}; about {} accepted rows undelivered",
                         this.config.getShutdownGracePeriod(), this.queue.size());
+                try {
+                    thread.join(INTERRUPT_JOIN_MS);
+                } catch (final InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                if (thread.isAlive()) {
+                    // Best effort: proceed rather than hang shutdown on an unresponsive thread.
+                    log.warn("Batch flusher still alive after the interrupt — continuing shutdown");
+                }
             }
             this.flusher = null;
         }
+
         // Straggler sweep: a producer may pass the stopped check and offer after the flusher's
-        // final drain — without this, those rows would be lost uncounted. One best-effort insert.
-        final List<EnrichedFlow> leftovers = new ArrayList<>();
-        this.queue.drainTo(leftovers);
-        if (!leftovers.isEmpty()) {
+        // final drain — without this, those rows would be lost uncounted.
+        sweep(graceExpired);
+
+        this.delegate.stop();
+
+        // A producer parked in the timed offer() can still land a row after the sweep. Nothing
+        // can insert it any more (the delegate is stopped), but silent loss is the one outcome
+        // this class must never have — count it.
+        final List<EnrichedFlow> residue = new ArrayList<>();
+        this.queue.drainTo(residue);
+        if (!residue.isEmpty()) {
+            this.droppedRows.inc(residue.size());
+            log.warn("Dropping {} flows offered after the shutdown drain", residue.size());
+        }
+
+        // Unregister the gauge: left behind, it would read this dead instance's queue forever.
+        this.metricRegistry.remove(this.queueDepthGauge);
+    }
+
+    /**
+     * Drain whatever the flusher left behind, in {@code maxRows}-sized chunks: {@code
+     * queueCapacity} is a multiple of {@code maxRows}, so one unchunked drain could produce an
+     * insert several times larger than any the flusher would ever issue. The healthy path goes
+     * through {@link #flush} so the batch-size histogram and flush timer see it too.
+     *
+     * @param graceExpired when the flusher had to be interrupted: the grace budget is spent and
+     *                     the delegate is why, so another blocking insert would hang shutdown
+     *                     past the service manager's stop timeout (the client has no socket
+     *                     timeout by default) for rows unlikely to land anyway. Count and log.
+     */
+    private void sweep(final boolean graceExpired) {
+        while (true) {
+            final List<EnrichedFlow> chunk = new ArrayList<>();
+            this.queue.drainTo(chunk, this.config.getMaxRows());
+            if (chunk.isEmpty()) {
+                return;
+            }
             if (graceExpired) {
-                // The grace budget is spent and the delegate is why. Another blocking insert
-                // would hang shutdown past the service manager's stop timeout (the client has
-                // no socket timeout by default) for rows that are unlikely to land anyway.
-                this.failedRows.inc(leftovers.size());
+                this.failedRows.inc(chunk.size());
                 log.error("Dropping {} leftover flows: the shutdown grace period is exhausted",
-                        leftovers.size());
+                        chunk.size());
             } else {
-                try {
-                    this.delegate.persist(leftovers);
-                } catch (final FlowException | IOException | RuntimeException e) {
-                    this.failedRows.inc(leftovers.size());
-                    log.error("Failed to persist {} leftover flows during shutdown — dropping them",
-                            leftovers.size(), e);
-                }
+                flush(chunk);
             }
         }
-        this.delegate.stop();
     }
 }

--- a/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
+++ b/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
@@ -89,10 +89,11 @@ public class ClickhouseRepository implements FlowRepository {
                 .compressClientRequest(true)
                 .compressServerResponse(true);
         if (config.isAsyncInserts()) {
-            // Server-side coalescing for the per-packet inserts (see ClickhouseConfig#asyncInserts
-            // for the trade-off and measurements). wait_for_async_insert=0 acknowledges on buffer
-            // append — waiting for the flush would serialize the pipeline on the flush interval,
-            // which benchmarks slower than not coalescing at all (14 vs 56 inserts/s).
+            // Server-side coalescing, now opt-in: client-side batching supersedes it (see
+            // ClickhouseConfig#asyncInserts for the trade-off and measurements).
+            // wait_for_async_insert=0 acknowledges on buffer append — waiting for the flush would
+            // serialize the pipeline on the flush interval, which benchmarks slower than not
+            // coalescing at all (14 vs 56 inserts/s).
             builder.serverSetting("async_insert", "1")
                     .serverSetting("wait_for_async_insert", "0");
         }
@@ -105,7 +106,13 @@ public class ClickhouseRepository implements FlowRepository {
             // Persist raw flows
             this.client.insert("flows", flows.stream().map(this.flowMapper::flow).toList()).get();
 
-        } catch (final InterruptedException | ExecutionException e) {
+        } catch (final InterruptedException e) {
+            // Restore the flag before wrapping: the batching flusher swallows FlowException (a
+            // poison batch must not wedge it) and relies on the thread's interrupt status to
+            // observe a shutdown-drain interrupt.
+            Thread.currentThread().interrupt();
+            throw new FlowException(e);
+        } catch (final ExecutionException e) {
             throw new FlowException(e);
         }
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,19 +26,20 @@ riptide.clickhouse.database=riptide
 # Client-side insert batching: flows are buffered and inserted as one insert per batch, flushed
 # at max-rows rows or after max-latency, whichever comes first (per-flow-record inserts collapse
 # throughput — each insert forms a part and fires the four rollup views). A full queue drops
-# flows (counted + logged) instead of blocking the parsers; failed inserts surface as flusher
-# error logs + the persister.batch.failedRows counter, not as errors on the ingest path. The
-# service manager's stop timeout (systemd TimeoutStopSec) must cover the listener stops (up to
-# ~5s per receiver) plus shutdown-grace-period, so the shutdown drain can finish.
+# flows (counted + logged) instead of blocking the parsers; a failed insert costs the whole
+# batch and surfaces as a flusher ERROR log line (alert on it — metrics are not exported yet),
+# never as an error on the ingest path. Budget the service manager's stop timeout (systemd
+# TimeoutStopSec) as (5s x total parsers) + shutdown-grace-period: each parser awaits its
+# dispatch executor for up to 5s and a 'multi' receiver has one parser per protocol.
 #riptide.clickhouse.batch.enabled=true
 #riptide.clickhouse.batch.max-rows=10000
 #riptide.clickhouse.batch.max-latency=2s
 #riptide.clickhouse.batch.queue-capacity=40000
 #riptide.clickhouse.batch.shutdown-grace-period=5s
-# Server-side insert coalescing. Unset derives: off while batching is enabled (superseded by
-# batching, which keeps insert errors visible); with batching disabled it follows manage-schema
-# (on in manage mode, off in provisioned mode).
-#riptide.clickhouse.async-inserts=false
+# Server-side insert coalescing. Unset it derives (it is NOT a fixed false): off while batching
+# is enabled (superseded by batching, which keeps insert errors visible); with batching disabled
+# it follows manage-schema — on in manage mode, off in provisioned mode. Set it to pin a value.
+#riptide.clickhouse.async-inserts=
 
 # SNMP CACHE
 riptide.snmp.cache.retentionMs=600000

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,6 +23,22 @@ riptide.clickhouse.endpoint=http://localhost:8123
 riptide.clickhouse.username=default
 #riptide.clickhouse.password=vault://secret/riptide/clickhouse#password
 riptide.clickhouse.database=riptide
+# Client-side insert batching: flows are buffered and inserted as one insert per batch, flushed
+# at max-rows rows or after max-latency, whichever comes first (per-flow-record inserts collapse
+# throughput — each insert forms a part and fires the four rollup views). A full queue drops
+# flows (counted + logged) instead of blocking the parsers; failed inserts surface as flusher
+# error logs + the persister.batch.failedRows counter, not as errors on the ingest path. The
+# service manager's stop timeout (systemd TimeoutStopSec) must cover the listener stops (up to
+# ~5s per receiver) plus shutdown-grace-period, so the shutdown drain can finish.
+#riptide.clickhouse.batch.enabled=true
+#riptide.clickhouse.batch.max-rows=10000
+#riptide.clickhouse.batch.max-latency=2s
+#riptide.clickhouse.batch.queue-capacity=40000
+#riptide.clickhouse.batch.shutdown-grace-period=5s
+# Server-side insert coalescing. Unset derives: off while batching is enabled (superseded by
+# batching, which keeps insert errors visible); with batching disabled it follows manage-schema
+# (on in manage mode, off in provisioned mode).
+#riptide.clickhouse.async-inserts=false
 
 # SNMP CACHE
 riptide.snmp.cache.retentionMs=600000

--- a/src/test/java/org/riptide/config/ClickhouseConfigTest.java
+++ b/src/test/java/org/riptide/config/ClickhouseConfigTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.config;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The {@code asyncInserts} derivation: batching supersedes server-side coalescing, but only
+ * while batching is actually enabled — with it off the pre-batching manage-mode default applies,
+ * so a {@code batch.enabled=false} config does not silently land on the slowest combination.
+ */
+class ClickhouseConfigTest {
+
+    @Test
+    void asyncInsertsAreOffWhileBatchingIsEnabled() {
+        final var config = new ClickhouseConfig();
+        config.setManageSchema(true);
+
+        // Batching is on by default and supersedes coalescing — even in manage mode.
+        Assertions.assertThat(config.getBatch().isEnabled()).isTrue();
+        Assertions.assertThat(config.isAsyncInserts()).isFalse();
+    }
+
+    @Test
+    void asyncInsertsFallBackToManageModeWhenBatchingIsDisabled() {
+        final var config = new ClickhouseConfig();
+        config.getBatch().setEnabled(false);
+
+        config.setManageSchema(true);
+        Assertions.assertThat(config.isAsyncInserts()).isTrue();
+
+        // Provisioned mode keeps the synchronous CHECK-barrier rejection.
+        config.setManageSchema(false);
+        Assertions.assertThat(config.isAsyncInserts()).isFalse();
+    }
+
+    @Test
+    void explicitAsyncInsertsWinsOverEitherDerivation() {
+        final var config = new ClickhouseConfig();
+
+        // Explicitly on, against the batching-enabled derivation.
+        config.setAsyncInserts(true);
+        Assertions.assertThat(config.isAsyncInserts()).isTrue();
+
+        // Explicitly off, against the batching-disabled manage-mode derivation.
+        config.setAsyncInserts(false);
+        config.getBatch().setEnabled(false);
+        config.setManageSchema(true);
+        Assertions.assertThat(config.isAsyncInserts()).isFalse();
+    }
+}

--- a/src/test/java/org/riptide/configuration/ClickhouseConfigurationTest.java
+++ b/src/test/java/org/riptide/configuration/ClickhouseConfigurationTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.configuration;
+
+import com.codahale.metrics.MetricRegistry;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.riptide.config.ClickhouseConfig;
+import org.riptide.repository.clickhouse.BatchingFlowRepository;
+import org.riptide.repository.clickhouse.ClickhouseRepository;
+import org.riptide.repository.clickhouse.ClickhouseRepository$FlowMapperImpl;
+import org.riptide.secrets.SecretResolvers;
+
+/**
+ * Wiring test for the repository bean: the batch.enabled flag decides between the batching
+ * decorator and the raw per-record repository. Constructing a ClickhouseRepository performs no
+ * I/O (the client only connects on start()/persist()), so this runs without a server.
+ */
+class ClickhouseConfigurationTest {
+
+    @Test
+    void beanIsTheBatchingDecoratorWhenBatchingIsEnabled() {
+        final var repository = new ClickhouseConfiguration().clickhouseRepository(
+                new ClickhouseRepository$FlowMapperImpl(), new ClickhouseConfig(), SecretResolvers.defaults(),
+                new MetricRegistry());
+
+        Assertions.assertThat(repository).isInstanceOf(BatchingFlowRepository.class);
+    }
+
+    @Test
+    void beanIsTheRawRepositoryWhenBatchingIsDisabled() {
+        final var config = new ClickhouseConfig();
+        config.getBatch().setEnabled(false);
+
+        final var repository = new ClickhouseConfiguration().clickhouseRepository(
+                new ClickhouseRepository$FlowMapperImpl(), config, SecretResolvers.defaults(),
+                new MetricRegistry());
+
+        Assertions.assertThat(repository).isInstanceOf(ClickhouseRepository.class);
+    }
+}

--- a/src/test/java/org/riptide/repository/clickhouse/BatchingFlowRepositoryTest.java
+++ b/src/test/java/org/riptide/repository/clickhouse/BatchingFlowRepositoryTest.java
@@ -19,6 +19,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
 import java.util.stream.IntStream;
@@ -197,6 +198,58 @@ class BatchingFlowRepositoryTest {
     }
 
     @Test
+    void secondStartFailsInsteadOfOrphaningTheFirstFlusher() {
+        this.repository = repository(batchConfig(10, Duration.ofMillis(100)));
+        this.repository.start();
+
+        Assertions.assertThatThrownBy(this.repository::start)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("already started");
+    }
+
+    @Test
+    void concurrentProducersLoseNoFlowsAndAreBatchedTogether() throws Exception {
+        // The production shape: 2 × cores parser threads call persist() concurrently. Every flow
+        // must end up either delivered or counted as dropped — never silently gone.
+        final int threads = 4;
+        final int perThread = 250;
+        this.repository = repository(batchConfig(500, Duration.ofMillis(200)));
+        this.repository.start();
+
+        final var start = new CountDownLatch(1);
+        final var done = new CountDownLatch(threads);
+        for (int t = 0; t < threads; t++) {
+            final var worker = new Thread(() -> {
+                try {
+                    start.await();
+                    for (final var flow : flows(perThread)) {
+                        this.repository.persist(List.of(flow));
+                    }
+                } catch (final Exception e) {
+                    throw new IllegalStateException(e);
+                } finally {
+                    done.countDown();
+                }
+            }, "producer-" + t);
+            worker.setDaemon(true);
+            worker.start();
+        }
+        start.countDown();
+        Assertions.assertThat(done.await(10, TimeUnit.SECONDS))
+                .as("producers finished").isTrue();
+
+        // stop() drains synchronously, so the tally is complete once it returns.
+        this.repository.stop();
+
+        final int total = threads * perThread;
+        Assertions.assertThat(this.delegate.count() + droppedRows() + failedRows())
+                .as("every flow is either delivered or counted")
+                .isEqualTo(total);
+        // Batching actually happened: far fewer inserts than flows.
+        Assertions.assertThat(this.delegate.inserts.get()).isLessThan(total);
+    }
+
+    @Test
     void stopBeforeStartSweepsQueuedRowsWithoutFailing() throws Exception {
         // Never started: no flusher exists, so only stop()'s leftover sweep can deliver — the
         // same path that catches rows offered between the flusher's final drain and stop().
@@ -263,12 +316,14 @@ class BatchingFlowRepositoryTest {
     }
 
     @Test
-    void rejectsMaxLatencyNotBelowShutdownGracePeriod() {
-        final var config = batchConfig(10, Duration.ofSeconds(2));
-        config.setShutdownGracePeriod(Duration.ofSeconds(2));
+    void rejectsShutdownGracePeriodUnderTwiceMaxLatency() {
+        // Merely-greater is not enough: one full drain window can pass before the drain starts,
+        // so 4900ms/5000ms would leave 100ms to empty the whole queue.
+        final var config = batchConfig(10, Duration.ofMillis(4900));
+        config.setShutdownGracePeriod(Duration.ofSeconds(5));
         Assertions.assertThatThrownBy(() -> repository(config))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("shorter than shutdown-grace-period");
+                .hasMessageContaining("at least twice max-latency");
     }
 
     private BatchingFlowRepository repository(final ClickhouseConfig.BatchConfig config) {
@@ -288,9 +343,9 @@ class BatchingFlowRepositoryTest {
         config.setMaxRows(maxRows);
         config.setMaxLatency(maxLatency);
         config.setQueueCapacity(1_000);
-        // Validation requires maxLatency < grace; keep the margin small so tests that leave the
-        // flusher parked in an empty drain window on stop() do not burn a production-sized grace.
-        config.setShutdownGracePeriod(maxLatency.plusMillis(500));
+        // Validation requires grace >= 2 × maxLatency; keep the margin tight so tests that leave
+        // the flusher parked in an empty drain window on stop() do not burn a production grace.
+        config.setShutdownGracePeriod(maxLatency.multipliedBy(3));
         return config;
     }
 
@@ -357,7 +412,9 @@ class BatchingFlowRepositoryTest {
                     throw new FlowException(e);
                 }
             }
-            if (this.failuresRemaining.getAndDecrement() > 0) {
+            // Decrement only while positive: a plain getAndDecrement() would also count down on
+            // every successful persist, so a later-armed failure would silently disarm.
+            if (this.failuresRemaining.getAndUpdate(remaining -> remaining > 0 ? remaining - 1 : remaining) > 0) {
                 throw new FlowException("poison batch");
             }
             this.store.persist(flows);

--- a/src/test/java/org/riptide/repository/clickhouse/BatchingFlowRepositoryTest.java
+++ b/src/test/java/org/riptide/repository/clickhouse/BatchingFlowRepositoryTest.java
@@ -1,0 +1,371 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.repository.clickhouse;
+
+import com.codahale.metrics.MetricRegistry;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.riptide.config.ClickhouseConfig;
+import org.riptide.pipeline.EnrichedFlow;
+import org.riptide.pipeline.FlowException;
+import org.riptide.repository.FlowRepository;
+import org.riptide.repository.TestRepository;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
+import java.util.stream.IntStream;
+
+/**
+ * Unit tests for the batching decorator against an in-memory delegate: the flush triggers, the
+ * drop policy, poison-batch resilience, the shutdown drain, the lifecycle guards, and the config
+ * validation.
+ */
+class BatchingFlowRepositoryTest {
+
+    private final ObservableRepository delegate = new ObservableRepository();
+
+    private final MetricRegistry metricRegistry = new MetricRegistry();
+
+    private BatchingFlowRepository repository;
+
+    @AfterEach
+    void tearDown() {
+        if (this.repository != null) {
+            this.delegate.unblock();
+            this.repository.stop();
+        }
+    }
+
+    @Test
+    void flushesWhenBatchSizeIsReachedBeforeMaxLatency() throws Exception {
+        // The await deadline is shorter than maxLatency: only the size trigger can pass it.
+        this.repository = repository(batchConfig(5, Duration.ofMillis(1500)));
+        this.repository.start();
+
+        this.repository.persist(flows(5));
+
+        await(Duration.ofMillis(750), "size-triggered flush", () -> this.delegate.count() == 5);
+        Assertions.assertThat(this.delegate.inserts.get()).isEqualTo(1);
+    }
+
+    @Test
+    void flushesBufferedRowsWhenMaxLatencyElapses() throws Exception {
+        // maxRows far above what is offered: only the time trigger can flush.
+        this.repository = repository(batchConfig(10_000, Duration.ofMillis(150)));
+        this.repository.start();
+
+        for (final var flow : flows(3)) {
+            this.repository.persist(List.of(flow));
+        }
+
+        await(Duration.ofSeconds(3), "time-triggered flush", () -> this.delegate.count() == 3);
+    }
+
+    @Test
+    void emptyFlushWindowCausesNoInsert() throws Exception {
+        this.repository = repository(batchConfig(10, Duration.ofMillis(50)));
+        this.repository.start();
+
+        // Nothing is offered, so several flush windows pass empty — assert throughout that the
+        // delegate never sees an insert (an empty insert would show as inserts > 0, not count).
+        final var deadline = Instant.now().plusMillis(300);
+        while (Instant.now().isBefore(deadline)) {
+            Assertions.assertThat(this.delegate.inserts.get()).isZero();
+            Thread.sleep(20);
+        }
+
+        this.repository.stop();
+        Assertions.assertThat(this.delegate.inserts.get()).isZero();
+    }
+
+    @Test
+    void dropsFlowsWhenTheQueueStaysFull() throws Exception {
+        // Wedge the delegate so the single-row batches stop draining: one row in flight, one row
+        // filling the capacity-1 queue, and the third offer must time out and drop.
+        this.delegate.block();
+        final var config = batchConfig(1, Duration.ofMillis(300));
+        config.setQueueCapacity(1);
+        this.repository = repository(config);
+        this.repository.start();
+
+        final var flows = flows(3);
+        this.repository.persist(List.of(flows.get(0)));
+        await(Duration.ofSeconds(3), "first row in flight", () -> this.delegate.inserts.get() == 1);
+        this.repository.persist(List.of(flows.get(1)));
+        this.repository.persist(List.of(flows.get(2)));
+
+        Assertions.assertThat(droppedRows()).isEqualTo(1);
+
+        // Un-wedge: the two accepted rows must still be delivered by the shutdown drain.
+        this.delegate.unblock();
+        this.repository.stop();
+        Assertions.assertThat(this.delegate.count()).isEqualTo(2);
+    }
+
+    @Test
+    void multiRowPersistDropsTheRemainderWhenTheQueueFillsUp() throws Exception {
+        // Same wedge as above, but with one multi-row persist call: its offer budget is per
+        // call, so once the capacity-1 queue is full the whole remainder drops in one go.
+        this.delegate.block();
+        final var config = batchConfig(1, Duration.ofMillis(300));
+        config.setQueueCapacity(1);
+        this.repository = repository(config);
+        this.repository.start();
+
+        final var flows = flows(4);
+        this.repository.persist(List.of(flows.get(0)));
+        await(Duration.ofSeconds(3), "first row in flight", () -> this.delegate.inserts.get() == 1);
+        // Three rows in one call: the first fills the queue, the remaining two are the remainder.
+        this.repository.persist(flows.subList(1, 4));
+
+        Assertions.assertThat(droppedRows()).isEqualTo(2);
+
+        this.delegate.unblock();
+        this.repository.stop();
+        Assertions.assertThat(this.delegate.count()).isEqualTo(2);
+    }
+
+    @Test
+    void poisonBatchIsDroppedAndSubsequentBatchesStillFlush() throws Exception {
+        this.delegate.failuresRemaining.set(1);
+        this.repository = repository(batchConfig(2, Duration.ofMillis(600)));
+
+        // Queued before start(): the flusher finds both rows waiting and drains them as one
+        // deterministic batch, which the delegate poisons.
+        this.repository.persist(flows(2));
+        this.repository.start();
+        await(Duration.ofSeconds(3), "poison batch attempted", () -> this.delegate.inserts.get() == 1);
+
+        this.repository.persist(flows(2));
+
+        await(Duration.ofSeconds(3), "flush after the poison batch", () -> this.delegate.count() == 2);
+        Assertions.assertThat(failedRows()).isEqualTo(2);
+    }
+
+    @Test
+    void stopDrainsAllAcceptedRowsAndRejectsNewOnes() throws Exception {
+        // maxRows unreachable and maxLatency short enough for the drain to converge in-grace.
+        final var config = batchConfig(10_000, Duration.ofMillis(300));
+        config.setShutdownGracePeriod(Duration.ofSeconds(2));
+        this.repository = repository(config);
+        this.repository.start();
+
+        for (final var flow : flows(25)) {
+            this.repository.persist(List.of(flow));
+        }
+        this.repository.stop();
+
+        // stop() is synchronous: once it returns, every accepted row has been delivered.
+        Assertions.assertThat(this.delegate.count()).isEqualTo(25);
+
+        // After stop() the repository rejects (and counts) instead of accepting silently.
+        this.repository.persist(flows(1));
+        Assertions.assertThat(droppedRows()).isEqualTo(1);
+        Assertions.assertThat(this.delegate.count()).isEqualTo(25);
+    }
+
+    @Test
+    void stopIsIdempotentAndStopsTheDelegateOnlyOnce() throws Exception {
+        this.repository = repository(batchConfig(10, Duration.ofMillis(100)));
+        this.repository.start();
+        this.repository.persist(flows(2));
+
+        this.repository.stop();
+        this.repository.stop();
+
+        Assertions.assertThat(this.delegate.count()).isEqualTo(2);
+        Assertions.assertThat(this.delegate.stops.get()).isEqualTo(1);
+    }
+
+    @Test
+    void startAfterStopFailsLoudInsteadOfSilentlyDropping() {
+        this.repository = repository(batchConfig(10, Duration.ofMillis(100)));
+        this.repository.start();
+        this.repository.stop();
+
+        Assertions.assertThatThrownBy(this.repository::start)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("cannot be restarted");
+    }
+
+    @Test
+    void stopBeforeStartSweepsQueuedRowsWithoutFailing() throws Exception {
+        // Never started: no flusher exists, so only stop()'s leftover sweep can deliver — the
+        // same path that catches rows offered between the flusher's final drain and stop().
+        this.repository = repository(batchConfig(10, Duration.ofMillis(100)));
+        this.repository.persist(flows(3));
+
+        this.repository.stop();
+
+        Assertions.assertThat(this.delegate.count()).isEqualTo(3);
+        Assertions.assertThat(this.delegate.inserts.get()).isEqualTo(1);
+    }
+
+    @Test
+    void leftoverSweepFailureIsCountedInsteadOfThrown() throws Exception {
+        this.delegate.failuresRemaining.set(1);
+        this.repository = repository(batchConfig(10, Duration.ofMillis(100)));
+        this.repository.persist(flows(2));
+
+        this.repository.stop();
+
+        Assertions.assertThat(this.delegate.count()).isZero();
+        Assertions.assertThat(failedRows()).isEqualTo(2);
+    }
+
+    @Test
+    void wedgedDelegateDoesNotEarnASecondInsertAfterTheGracePeriod() throws Exception {
+        // The flusher is stuck in an insert that outlives the grace period. The leftover sweep
+        // must not attempt another blocking insert against the same wedged delegate: the client
+        // has no socket timeout by default, so that would hang shutdown indefinitely — past the
+        // service manager's stop timeout — for rows that are unlikely to land anyway.
+        this.delegate.block();
+        this.repository = repository(batchConfig(1, Duration.ofMillis(100)));
+        this.repository.start();
+        this.repository.persist(flows(1));
+        await(Duration.ofSeconds(2), "flusher blocked inside the delegate",
+                () -> this.delegate.inserts.get() == 1);
+        this.repository.persist(flows(3));
+
+        this.repository.stop();
+
+        Assertions.assertThat(this.delegate.inserts.get())
+                .as("no sweep insert once the grace period is exhausted")
+                .isEqualTo(1);
+        Assertions.assertThat(failedRows())
+                .as("the undelivered leftovers are counted, not silently lost")
+                .isGreaterThanOrEqualTo(3);
+    }
+
+    @Test
+    void rejectsNonPositiveMaxRows() {
+        final var config = batchConfig(0, Duration.ofMillis(100));
+        Assertions.assertThatThrownBy(() -> repository(config))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("max-rows");
+    }
+
+    @Test
+    void rejectsNonPositiveQueueCapacity() {
+        final var config = batchConfig(10, Duration.ofMillis(100));
+        config.setQueueCapacity(0);
+        Assertions.assertThatThrownBy(() -> repository(config))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("queue-capacity");
+    }
+
+    @Test
+    void rejectsMaxLatencyNotBelowShutdownGracePeriod() {
+        final var config = batchConfig(10, Duration.ofSeconds(2));
+        config.setShutdownGracePeriod(Duration.ofSeconds(2));
+        Assertions.assertThatThrownBy(() -> repository(config))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("shorter than shutdown-grace-period");
+    }
+
+    private BatchingFlowRepository repository(final ClickhouseConfig.BatchConfig config) {
+        return new BatchingFlowRepository(this.delegate, config, this.metricRegistry);
+    }
+
+    private long droppedRows() {
+        return this.metricRegistry.counter(MetricRegistry.name("persister", "batch", "droppedRows")).getCount();
+    }
+
+    private long failedRows() {
+        return this.metricRegistry.counter(MetricRegistry.name("persister", "batch", "failedRows")).getCount();
+    }
+
+    private static ClickhouseConfig.BatchConfig batchConfig(final int maxRows, final Duration maxLatency) {
+        final var config = new ClickhouseConfig.BatchConfig();
+        config.setMaxRows(maxRows);
+        config.setMaxLatency(maxLatency);
+        config.setQueueCapacity(1_000);
+        // Validation requires maxLatency < grace; keep the margin small so tests that leave the
+        // flusher parked in an empty drain window on stop() do not burn a production-sized grace.
+        config.setShutdownGracePeriod(maxLatency.plusMillis(500));
+        return config;
+    }
+
+    private static List<EnrichedFlow> flows(final int count) {
+        return IntStream.range(0, count)
+                .mapToObj(i -> EnrichedFlow.builder().srcPort(i).build())
+                .toList();
+    }
+
+    /** Deadline-based polling; fails the test on timeout. Never a bare sleep. */
+    private static void await(final Duration timeout, final String description, final BooleanSupplier condition)
+            throws InterruptedException {
+        final var deadline = Instant.now().plus(timeout);
+        while (Instant.now().isBefore(deadline)) {
+            if (condition.getAsBoolean()) {
+                return;
+            }
+            Thread.sleep(20);
+        }
+        Assertions.fail("Timed out after %s waiting for %s".formatted(timeout, description));
+    }
+
+    /**
+     * Delegate around a {@link TestRepository} (which cannot be extended here — its persist
+     * declares no checked exceptions) that additionally counts inserts and stops, and can fail
+     * or block on demand.
+     */
+    private static final class ObservableRepository implements FlowRepository {
+
+        private final TestRepository store = new TestRepository(new MetricRegistry());
+
+        private final AtomicInteger inserts = new AtomicInteger();
+
+        private final AtomicInteger stops = new AtomicInteger();
+
+        private final AtomicInteger failuresRemaining = new AtomicInteger();
+
+        private volatile CountDownLatch blockOn;
+
+        long count() {
+            return this.store.count();
+        }
+
+        void block() {
+            this.blockOn = new CountDownLatch(1);
+        }
+
+        void unblock() {
+            final var latch = this.blockOn;
+            if (latch != null) {
+                latch.countDown();
+            }
+        }
+
+        @Override
+        public void persist(final List<EnrichedFlow> flows) throws FlowException {
+            this.inserts.incrementAndGet();
+            final var latch = this.blockOn;
+            if (latch != null) {
+                try {
+                    latch.await();
+                } catch (final InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new FlowException(e);
+                }
+            }
+            if (this.failuresRemaining.getAndDecrement() > 0) {
+                throw new FlowException("poison batch");
+            }
+            this.store.persist(flows);
+        }
+
+        @Override
+        public void stop() {
+            this.stops.incrementAndGet();
+        }
+    }
+}

--- a/src/test/java/org/riptide/repository/clickhouse/ClickhouseRepositoryIT.java
+++ b/src/test/java/org/riptide/repository/clickhouse/ClickhouseRepositoryIT.java
@@ -6,6 +6,7 @@
 package org.riptide.repository.clickhouse;
 
 import com.clickhouse.client.api.Client;
+import com.codahale.metrics.MetricRegistry;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -21,6 +22,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.net.InetAddress;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -200,13 +202,16 @@ public class ClickhouseRepositoryIT {
     }
 
     @Test
-    void asyncInsertsDefaultOnInManageModeAndFeedTheRollups() throws Exception {
-        // Manage mode defaults async-inserts on (ClickhouseConfig#isAsyncInserts). The insert is
-        // acknowledged when buffered, so visibility is eventual — the flush is forced here to keep
-        // the test deterministic; production readers poll (dashboards), they do not read-after-write.
+    void asyncInsertsOptInStillFeedsTheRollups() throws Exception {
+        // Async inserts default off while batching is enabled, since batching supersedes them
+        // (ClickhouseConfig#isAsyncInserts); the coalesced path stays available as an opt-in. The
+        // insert is acknowledged when buffered, so visibility is eventual — the flush is forced
+        // here to keep the test deterministic; production readers poll (dashboards), they do not
+        // read-after-write.
         final var config = configFor("async_mode", true);
         config.setAsyncInserts(null);
-        Assertions.assertThat(config.isAsyncInserts()).isTrue();
+        Assertions.assertThat(config.isAsyncInserts()).isFalse();
+        config.setAsyncInserts(true);
 
         final var repo = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), config, RESOLVERS);
         repo.start();
@@ -222,6 +227,38 @@ public class ClickhouseRepositoryIT {
         Assertions.assertThat(queryClient.queryAll(
                         "SELECT sum(bytes) AS b FROM async_mode.flows_by_application_1m")
                 .getFirst().getLong("b")).isEqualTo(1000L);
+    }
+
+    @Test
+    void batchingDecoratorDrainsAcceptedFlowsOnStopAndFeedsRollups() throws Exception {
+        final var config = configFor("batching", true);
+        final var repository = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), config, RESOLVERS);
+        // maxRows stays at the production 10k so the size trigger never fires for a handful of
+        // flows — delivery rides the time trigger and the shutdown drain. maxLatency is small and
+        // the grace generous (vs the production 2s/5s) so a cold first insert on slow CI cannot
+        // outlive the grace mid-drain.
+        config.getBatch().setMaxLatency(Duration.ofMillis(500));
+        config.getBatch().setShutdownGracePeriod(Duration.ofSeconds(15));
+        final var batching = new BatchingFlowRepository(repository, config.getBatch(), new MetricRegistry());
+        batching.start();
+
+        final var minute = Instant.now().truncatedTo(ChronoUnit.MINUTES).minus(5, ChronoUnit.MINUTES);
+        for (int i = 0; i < 5; i++) {
+            // Singleton lists, like the production dispatcher hands the persister.
+            batching.persist(List.of(testFlow(minute.plusSeconds(i), 20001 + i, 443, 100L)));
+        }
+        batching.stop();
+
+        // stop() drained: every accepted row is queryable once it returns.
+        final var count = queryClient.queryAll("SELECT count() AS c FROM batching.flows")
+                .getFirst().getLong("c");
+        Assertions.assertThat(count).isEqualTo(5);
+
+        // The batched insert fired the rollup materialized views (one target as the canary).
+        final var rollupBytes = queryClient.queryAll(
+                        "SELECT sum(bytes) AS b FROM batching.flows_by_application_1m")
+                .getFirst().getLong("b");
+        Assertions.assertThat(rollupBytes).isEqualTo(500L);
     }
 
     @Test


### PR DESCRIPTION
## What does this change?

`ClickhouseRepository.persist()` issued one blocking `client.insert().get()` per *flow record* — the dispatcher hands `Pipeline.process` singleton lists, so the packet-level framing in the issue understates it. On the 4-vCPU lab VM that capped throughput at ~3,600 rows/s (~150 inserts/s) with CPU ~70% idle, and every insert formed a part and fired all four rollup materialized views.

A new `BatchingFlowRepository` decorator sits at the `FlowRepository` seam: producers enqueue into a bounded queue, and a single flusher hands the delegate one insert per **10k rows or 2 s**, whichever comes first. That should drop the insert cadence below one per second and amortise part formation and MV execution across the batch.

**Flush interval is 2 s, not the 200 ms the issue proposed.** At the current rate 200 ms yields ~720-row batches — under the 1,000-row floor ClickHouse recommends, and ~5 inserts/s against its ~1/s guidance. Akvorado uses 50k/5 s and Vector 10 MB/1 s for comparison. Details in the research doc that preceded this work.

Related changes that batching forced:

- **`async-inserts` becomes opt-in while batching is on** (`unset → batch.enabled ? false : manageSchema`). Server-side coalescing cannot improve on one large insert, and `wait_for_async_insert=0` acknowledged inserts before the server evaluated them — so rejected rows vanished silently. The conditional keeps the `batch.enabled=false` escape hatch on the old, faster-of-the-two path rather than the measured-slowest combination.
- **Shutdown reordered**: listeners stop before the pipeline so in-flight dispatches land before the drain, each listener isolated so one failure cannot skip it, and `ParserBase.stop()` gained a bounded await plus `shutdownNow()`.
- **Loss is now counted, never silent**: a full queue drops with a counter and a rate-limited warn instead of blocking, because blocking backpressures the parser executors into the Netty socket where loss is invisible.

Closes #382

## How was it verified?

- `mvn verify` → **BUILD SUCCESS**, 820 tests, plus JaCoCo, Checkstyle, SpotBugs and Error Prone gates.
- `mvn verify -Pe2e -Dit.test=ClickhouseRepositoryIT` → **BUILD SUCCESS**, 13 tests against the ClickHouse container, including a new drain-on-stop test asserting rows land and the rollups are fed.
- 17 unit tests cover both flush triggers, the empty window, drop-when-full (single and multi-row), poison-batch resilience, lifecycle guards, concurrent producers, and a wedged delegate at shutdown.

**Not yet verified: the throughput claim itself.** The benchmark re-run on the lab (`experiments/riptide-flow-capacity/`) is still outstanding — that is what turns "should be materially higher than 3,600 rows/s" into evidence, via `system.query_log` insert cadence and `system.part_log` NewPart rate.

## Anything reviewers should look at closely?

**The shutdown path** (`BatchingFlowRepository.stop()`) is where the risk concentrates. Sequence: reject new rows → join the flusher within the grace period → on expiry, interrupt and wait 1 s for it to unwind → sweep leftovers in `max-rows` chunks → stop the delegate → count anything that arrived after. If the grace period expires the sweep deliberately does **not** attempt another insert: the client has no socket timeout by default, so that would hang shutdown past `TimeoutStopSec` precisely when ClickHouse is unhealthy.

**`Daemon.stop()` catches `Exception`, not `RuntimeException`, on purpose.** `Listener.stop()` declares no checked exceptions, but the Netty listeners call `syncUninterruptibly()`, which sneaky-throws the future's cause. Narrowing it back would let a channel-close fault skip the drain and silently lose the buffer.

**Known trade-offs and follow-ups (all recorded, none blocking):**

- **Metrics are collected but exported nowhere.** There is no reporter and no metrics endpoint, so `persister.batch.*` counters are unreadable in production; the docs name the flusher's error log as the operator signal instead. Worth its own PR.
- **No health signal for write-path failure** — with ClickHouse unreachable the collector drops everything while `/readyz` reports up.
- **Batching amplifies a poison row** from one lost flow to a whole batch; there is no bisect or dead-letter path yet.
- **Insert deduplication is deferred**, so a retried batch can duplicate on a lost acknowledgement — the same exposure the async path already had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)