### PR TITLE
test(parser): cover the gauge fix, and document that sessionCount changed meaning

### DIFF
--- a/docs/docs/deploy/operations.md
+++ b/docs/docs/deploy/operations.md
@@ -71,6 +71,25 @@ restart. Configuration is backward-compatible within a minor line; breaking conf
 moves are logged loudly at startup (e.g. the pre-0.1.0 `riptide.snmp.config.definitions`
 tree logs an explicit error pointing at `riptide.nodes`).
 
+### `parsers.<name>.sessionCount` changed meaning
+
+`sessionCount` used to report the **template** total, not the number of exporters — so it
+overstated by however many templates each exporter announces, and it moved when a single
+exporter merely re-announced its templates. It now reports what the name says: one per
+`(session, observation domain)` pair, i.e. per exporting process.
+
+Expect the value to **drop** on upgrade, by roughly the templates-per-exporter factor. Any
+dashboard or alert keyed on its magnitude needs rebaselining. The previous quantity is still
+published, under the name that describes it:
+
+| Gauge | Reports |
+|---|---|
+| `parsers.<name>.sessionCount` | exporters — `(session, observation domain)` pairs |
+| `parsers.<name>.templateCount` | templates held across all exporters |
+
+Template cardinality is the more useful of the two for capacity work: it is what drives the
+per-record cost of the parse path.
+
 ## Health endpoints & probes
 
 Riptide serves two plain-HTTP health endpoints on a management port (default `8080`) — no auth, no

--- a/src/main/java/org/riptide/flows/parser/session/UdpSessionManager.java
+++ b/src/main/java/org/riptide/flows/parser/session/UdpSessionManager.java
@@ -104,7 +104,14 @@ public class UdpSessionManager {
         return new UdpSession(sessionKey);
     }
 
-    /** Total templates held across all exporters. */
+    /**
+     * Total templates held across all exporters.
+     *
+     * <p>O(exporters) since the per-exporter indexing, where it used to be a {@code size()} field
+     * read, and it backs the {@code parsers.<name>.templateCount} gauge — so a metrics scrape now
+     * walks the outer map. That is a few thousand map reads at realistic fleet sizes, against a
+     * scrape interval measured in seconds, but it is not free: do not call it per packet.
+     */
     public int count() {
         return this.templates.values().stream().mapToInt(Map::size).sum();
     }

--- a/src/test/java/org/riptide/flows/parser/UdpParserBaseTest.java
+++ b/src/test/java/org/riptide/flows/parser/UdpParserBaseTest.java
@@ -41,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class UdpParserBaseTest {
 
     private static final InetSocketAddress REMOTE = new InetSocketAddress("10.0.0.1", 51000);
+    private static final InetSocketAddress SECOND_REMOTE = new InetSocketAddress("10.0.0.3", 51000);
     private static final InetSocketAddress LOCAL = new InetSocketAddress("10.0.0.2", 4739);
     private static final int TEMPLATE_ID = 256;
 
@@ -51,6 +52,8 @@ class UdpParserBaseTest {
     /** P = installs a garbage template mid-packet, then fails; Q = probes for that template. */
     private static final byte POISONED = 'P';
     private static final byte PROBE_POISON = 'Q';
+    /** S = adds a SECOND template to the same exporter, without failing the packet. */
+    private static final byte ADD_SECOND_TEMPLATE = 'S';
     private static final int GARBAGE_TEMPLATE_ID = 300;
 
     private ScheduledExecutorService executor;
@@ -99,10 +102,52 @@ class UdpParserBaseTest {
         assertThat(this.parser.templateResolved).isTrue();
     }
 
+    /**
+     * {@code sessionCount} and {@code templateCount} must report different quantities.
+     *
+     * <p>{@code sessionCount} was wired to the template total for years — it counted templates while
+     * its name promised exporters, so it overstated by however many templates each exporter
+     * announces and moved when an exporter merely re-announced. Nothing caught that, because neither
+     * gauge was covered. This pins both by making the two numbers differ: two exporters, three
+     * templates.
+     */
+    @Test
+    void gaugesReportExportersAndTemplatesSeparately() throws Exception {
+        final var registry = new MetricRegistry();
+        final var parser = new StubParser(registry);
+        parser.start(this.executor);
+        try {
+            parse(parser, ADD_TEMPLATE, REMOTE);
+            parse(parser, ADD_TEMPLATE, SECOND_REMOTE);
+            // a second template for the first exporter only — this is what separates the gauges
+            parse(parser, ADD_SECOND_TEMPLATE, REMOTE);
+
+            assertThat(gauge(registry, "sessionCount"))
+                    .as("exporters, i.e. (session, observation domain) pairs")
+                    .isEqualTo(2);
+            assertThat(gauge(registry, "templateCount"))
+                    .as("templates across all exporters")
+                    .isEqualTo(3);
+        } finally {
+            parser.stop();
+        }
+    }
+
+    private static int gauge(final MetricRegistry registry, final String name) {
+        final var g = registry.getGauges().get(MetricRegistry.name("parsers", "stub", name));
+        assertThat(g).as("gauge parsers.stub.%s is registered", name).isNotNull();
+        return (Integer) g.getValue();
+    }
+
     private void parse(final byte marker) throws Exception {
+        parse(this.parser, marker, REMOTE);
+    }
+
+    private static void parse(final UdpParserBase parser, final byte marker, final InetSocketAddress remote)
+            throws Exception {
         final ByteBuf buffer = Unpooled.buffer().writeByte(marker);
         try {
-            this.parser.parse(Instant.now(), buffer, REMOTE, LOCAL).join();
+            parser.parse(Instant.now(), buffer, remote, LOCAL).join();
         } finally {
             buffer.release();
         }
@@ -114,8 +159,12 @@ class UdpParserBaseTest {
         private boolean garbageTemplateRetained;
 
         StubParser() {
+            this(new MetricRegistry());
+        }
+
+        StubParser(final MetricRegistry metricRegistry) {
             super(Protocol.IPFIX, "stub", (source, flow) -> { }, new Identity("t", "o", "z", "s"),
-                    new MetricRegistry());
+                    metricRegistry);
         }
 
         @Override
@@ -136,6 +185,9 @@ class UdpParserBaseTest {
                             .withFields(List.of(field())).build());
                     throw new InvalidPacketException(buffer, "Invalid set ID: %d", 0);
                 }
+                case ADD_SECOND_TEMPLATE -> session.addTemplate(0,
+                        Template.builder(GARBAGE_TEMPLATE_ID, Template.Type.TEMPLATE)
+                                .withFields(List.of(field())).build());
                 case PROBE_POISON -> {
                     try {
                         session.getResolver(0).lookupTemplate(GARBAGE_TEMPLATE_ID);


### PR DESCRIPTION
Review follow-ups on #390. Three findings, all low/medium, none blocking — #390 is already merged.

### 1. Neither gauge was tested

The premise of #390's gauge fix is that `sessionCount` was wired to the wrong quantity for years and
nobody noticed. Nothing prevented it being swapped back.

`gaugesReportExportersAndTemplatesSeparately` pins both by making the two numbers **differ** — two
exporters, three templates — which is the only way to tell them apart.

**Verified it actually catches the regression**, rather than assuming: restoring the pre-#390 wiring
fails it with `expected: 2 but was: 3`, and the `templateCount` assertion fails outright because the
gauge does not exist. Worth stating explicitly, since #390 shipped a concurrency test that turned out
*not* to catch its target regression.

`StubParser` now takes a `MetricRegistry` so a test can read the gauges.

### 2. `sessionCount` changed meaning with no operator-facing note

`docs/docs/deploy/operations.md`, under Upgrading: the value **drops** on upgrade by roughly the
templates-per-exporter factor, anything alerting on its magnitude needs rebaselining, and the old
quantity is still published as `templateCount`. Includes a table of what each gauge reports.

### 3. `count()` silently became O(exporters), on a scrape path

Javadoc note on `UdpSessionManager.count()`: it was a `size()` field read, it is now a walk of the
outer map, and it backs the new `templateCount` gauge — so a metrics scrape pays it. Cheap at
realistic fleet sizes, but it should not be called per packet, and that was previously unremarked.

### Tests

824 unit tests (823 + the new one). `make jar` clears Error Prone, Checkstyle, SpotBugs and the fuzz
suites.

Refs #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)
