### PR TITLE
perf(clickhouse): make insert compression configurable, and rule out the POJO-reflection rewrite

### DIFF
--- a/docs/docs/configuration/clickhouse.md
+++ b/docs/docs/configuration/clickhouse.md
@@ -13,6 +13,7 @@ riptide.clickhouse.username=default
 #riptide.clickhouse.password=vault://secret/riptide/clickhouse#password
 riptide.clickhouse.database=riptide
 riptide.clickhouse.manage-schema=true
+#riptide.clickhouse.compress-requests=true   # false trades bandwidth for CPU on a LAN
 riptide.clickhouse.batch.enabled=true
 riptide.clickhouse.batch.max-rows=10000
 riptide.clickhouse.batch.max-latency=2s
@@ -146,6 +147,7 @@ flusher issues **one insert per batch**.
 | `riptide.clickhouse.batch.max-latency` | `2s` | Flush whatever is buffered after this long. |
 | `riptide.clickhouse.batch.queue-capacity` | `40000` | Buffer bound; a full queue drops flows (counted). |
 | `riptide.clickhouse.batch.shutdown-grace-period` | `5s` | How long `stop()` waits for the drain. |
+| `riptide.clickhouse.compress-requests` | `true` | LZ4-compress insert payloads. See below. |
 
 A batch is flushed at `max-rows` rows or after `max-latency`, whichever comes first. The defaults
 follow ClickHouse's guidance of 10k–100k rows per insert at roughly one insert per second;
@@ -410,3 +412,23 @@ users + row policies), Grafana topology, the end-to-end onboarding recipe, and t
 ceiling, see the [Multi-tenancy runbook](../deploy/multi-tenancy.md).
 
 :::
+
+## Insert compression
+
+`riptide.clickhouse.compress-requests` (boolean, default `true`) LZ4-compresses insert
+payloads on the way to ClickHouse. It cuts the bytes on the wire severalfold on flow data,
+which is what you want across a WAN or where egress is metered.
+
+It is not free. Profiling the batch flusher put LZ4 at roughly a fifth of that thread's CPU
+(`ClickHouseLZ4OutputStream.write` plus the LZ4 compressor frames). A collector sitting on
+the same LAN as ClickHouse pushes only single-digit MB/s uncompressed at tens of thousands
+of rows per second — a rounding error on 1 GbE — so turning it off there trades bandwidth
+nobody is paying for against CPU on the one thread that serializes every batch:
+
+```properties
+riptide.clickhouse.compress-requests=false
+```
+
+Leave it on across a WAN, in cloud deployments where egress is billed, or whenever the
+collector and ClickHouse are not on the same network. Response compression is always on and
+is unaffected — it only covers the schema queries at startup.

--- a/src/main/java/org/riptide/config/ClickhouseConfig.java
+++ b/src/main/java/org/riptide/config/ClickhouseConfig.java
@@ -38,6 +38,20 @@ public final class ClickhouseConfig {
         private boolean manageSchema = true;
 
         /**
+         * Client-side LZ4 compression of insert payloads ({@code compressClientRequest}). On by
+         * default, unchanged from when it was hardcoded: it cuts the bytes on the wire severalfold on
+         * flow data, which matters for egress-billed or WAN-separated deployments.
+         *
+         * <p>It is not free. Profiling the flusher thread at ~29k rows/s put LZ4 at roughly a fifth
+         * of its CPU ({@code ClickHouseLZ4OutputStream.write} plus the {@code LZ4SafeUtils} /
+         * {@code LZ4JavaSafeCompressor} frames). A collector on the same LAN as ClickHouse pushes on
+         * the order of single-digit MB/s uncompressed at that rate — a rounding error on 1 GbE — so
+         * turning this off there trades bandwidth nobody is paying for against CPU on the one thread
+         * that serializes every batch. Leave it on across a WAN or where egress is metered.
+         */
+        private boolean compressRequests = true;
+
+        /**
          * Server-side insert coalescing ({@code async_insert}). Historically the pipeline
          * inserted once per flow record, and each insert also feeds the rollup materialized
          * views — without coalescing, that many small inserts collapse ingestion throughput on

--- a/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
+++ b/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
@@ -86,7 +86,10 @@ public class ClickhouseRepository implements FlowRepository {
                 .setUsername(this.username)
                 .setPassword(this.password)
                 .setDefaultDatabase(config.getDatabase())
-                .compressClientRequest(true)
+                // Request compression is the insert path and costs flusher CPU, so it is
+                // configurable (see ClickhouseConfig#compressRequests). Response compression only
+                // affects the schema queries at startup, so it stays on unconditionally.
+                .compressClientRequest(config.isCompressRequests())
                 .compressServerResponse(true);
         if (config.isAsyncInserts()) {
             // Server-side coalescing, now opt-in: client-side batching supersedes it (see

--- a/src/test/java/org/riptide/benchmarks/repository/FieldAccessBenchmark.java
+++ b/src/test/java/org/riptide/benchmarks/repository/FieldAccessBenchmark.java
@@ -25,7 +25,6 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 
 /**
  * How much does the ClickHouse client's reflective POJO field access cost per row?
@@ -50,8 +49,10 @@ import java.util.function.Function;
  *       much of the cost is the per-call access check alone. If this is most of the gap it is a
  *       one-line upstream fix, not a reason to rewrite riptide's insert path.</li>
  *   <li>{@code methodHandle} — unreflected {@link MethodHandle}</li>
- *   <li>{@code direct} — a lambda per field, standing in for generated or hand-written accessors,
- *       i.e. the floor a RowBinaryFormatWriter rewrite could reach</li>
+ *   <li>There is deliberately no "direct call" mode. An earlier revision had one built from a
+ *       lambda wrapping a captured {@link MethodHandle}, which cannot inline to a direct call and so
+ *       measured lambda indirection rather than a floor. {@code methodHandle} is the honest floor
+ *       here; a hand-written accessor would be at or below it.</li>
  * </ul>
  *
  * <p>One invocation reads every field once, so {@code ops/s} is rows/s of field access and the
@@ -63,13 +64,17 @@ import java.util.function.Function;
  *
  * <pre>
  *   mode                     passes/s     ns/row   % of one core @ 29,440 rows/s
- *   reflect (current)       2,513,210        398                          1.17%
- *   reflect+setAccessible   2,828,542        354                          1.04%
- *   MethodHandle            4,154,064        241                          0.71%
+ *   reflect (current)       2,572,855        389                          1.14%
+ *   reflect+setAccessible   2,883,674        347                          1.02%
+ *   MethodHandle            4,149,052        241                          0.71%   <- the floor
  * </pre>
  *
+ * <p>Measured on a POJO populated with values outside the {@code Integer}/{@code Long} caches, so
+ * the figures are not flattered by an all-defaults row: doing that moved the reflective number by
+ * about 2% (2,513,210 → 2,572,855 passes/s), which does not change the conclusion.
+ *
  * <p>So the <em>entire</em> addressable saving from eliminating reflective field access is
- * <strong>~0.46% of one core</strong> at the throughput the collector was measured at, and
+ * <strong>~0.43% of one core</strong> at the throughput the collector was measured at, and
  * {@code setAccessible} alone would account for 0.13%. Hand-writing a
  * {@code RowBinaryFormatWriter} path over 55 columns — with the attendant risk of silent type,
  * null and enum drift against {@code FlowsSchema} — buys under half a percent of a core on a host
@@ -95,11 +100,23 @@ public class FieldAccessBenchmark {
     private Method[] plain;
     private Method[] accessible;
     private MethodHandle[] handles;
-    private List<Function<ClickhouseFlow, Object>> direct;
 
     @Setup(Level.Trial)
     public void setup() throws Exception {
+        // Not an all-defaults instance: null references and small boxed values hit the
+        // Integer/Long caches, so a default row understates the reflective cost in exactly the
+        // direction that flatters the "not worth doing" conclusion. Fill it with values outside the
+        // caches, like a real flow record.
         this.row = new ClickhouseFlow();
+        this.row.setBytes(9_876_543_210L);
+        this.row.setPackets(1_234_567L);
+        this.row.setSrcPort(54_321);
+        this.row.setDstPort(9_999);
+        this.row.setSrcAs(64_512L);
+        this.row.setDstAs(65_001L);
+        this.row.setTenant("tenant-a");
+        this.row.setExporterAddr("198.51.100.7");
+        this.row.setTimestamp(java.time.OffsetDateTime.now(java.time.ZoneOffset.UTC));
 
         // Every zero-arg getter the client's column-to-method matching would find.
         final List<Method> getters = new ArrayList<>();
@@ -129,21 +146,17 @@ public class FieldAccessBenchmark {
             this.handles[i] = lookup.unreflect(this.plain[i]);
         }
 
-        // Lambdas over the same getters: after JIT these are direct calls, so they stand in for
-        // generated accessors without hand-writing 55 method references.
-        this.direct = new ArrayList<>(this.plain.length);
-        for (final Method m : this.plain) {
-            final MethodHandle h = lookup.unreflect(m);
-            this.direct.add(flow -> {
-                try {
-                    return h.invoke(flow);
-                } catch (final Throwable e) {
-                    throw new IllegalStateException(e);
-                }
-            });
-        }
 
-        System.out.printf("%n[setup] ClickhouseFlow getters discovered: %d%n", this.plain.length);
+        // The javadoc extrapolates per-row cost from the column count, so fail loudly if the
+        // discovered getters and the persisted columns ever diverge.
+        final long columns = java.util.Arrays.stream(ClickhouseFlow.class.getDeclaredFields())
+                .filter(f -> !java.lang.reflect.Modifier.isStatic(f.getModifiers()) && !f.isSynthetic())
+                .count();
+        if (this.plain.length < columns) {
+            throw new IllegalStateException("discovered " + this.plain.length
+                    + " getters for " + columns + " persisted columns — the extrapolation is stale");
+        }
+        System.out.printf("%n[setup] ClickhouseFlow getters=%d columns=%d%n", this.plain.length, columns);
     }
 
     @Benchmark
@@ -167,10 +180,4 @@ public class FieldAccessBenchmark {
         }
     }
 
-    @Benchmark
-    public void direct(final Blackhole bh) {
-        for (final Function<ClickhouseFlow, Object> f : this.direct) {
-            bh.consume(f.apply(this.row));
-        }
-    }
 }

--- a/src/test/java/org/riptide/benchmarks/repository/FieldAccessBenchmark.java
+++ b/src/test/java/org/riptide/benchmarks/repository/FieldAccessBenchmark.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.benchmarks.repository;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.riptide.repository.clickhouse.ClickhouseFlow;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+/**
+ * How much does the ClickHouse client's reflective POJO field access cost per row?
+ *
+ * <p>Profiling the batch flusher at ~29k rows/s attributed ~21% of its samples to
+ * {@code DirectMethodHandleAccessor.invoke} and ~7% to {@code AccessibleObject.verifyAccess} —
+ * i.e. roughly a quarter of the thread spent getting values *out of* the POJO rather than
+ * serializing them. {@code POJOFieldSerializer.serialize} declares
+ * {@code InvocationTargetException, IllegalAccessException}, which is only possible if it calls
+ * {@code Method.invoke} per field per row; {@link ClickhouseFlow} has 55 fields, so that is ~55
+ * reflective calls per row.
+ *
+ * <p>Both the POJO path and a hand-written {@code RowBinaryFormatWriter} path do *identical*
+ * serialization work — same bytes, same {@code SerializerUtils}. The only difference is how the
+ * value is read out of the object. So this benchmark measures exactly that delta, over the real
+ * field set, and nothing else:
+ *
+ * <ul>
+ *   <li>{@code reflectNoSetAccessible} — {@code Method.invoke} on a Method left as-is, which is
+ *       what the profile's {@code verifyAccess} frames imply the client does</li>
+ *   <li>{@code reflectSetAccessible} — the same, after {@code setAccessible(true)}; isolates how
+ *       much of the cost is the per-call access check alone. If this is most of the gap it is a
+ *       one-line upstream fix, not a reason to rewrite riptide's insert path.</li>
+ *   <li>{@code methodHandle} — unreflected {@link MethodHandle}</li>
+ *   <li>{@code direct} — a lambda per field, standing in for generated or hand-written accessors,
+ *       i.e. the floor a RowBinaryFormatWriter rewrite could reach</li>
+ * </ul>
+ *
+ * <p>One invocation reads every field once, so {@code ops/s} is rows/s of field access and the
+ * ratios transfer directly to the 55-field row.
+ *
+ * <h2>Result: not worth bypassing the POJO path (measured 2026-07-29)</h2>
+ *
+ * <p>55 getters, on the 10-core dev machine:
+ *
+ * <pre>
+ *   mode                     passes/s     ns/row   % of one core @ 29,440 rows/s
+ *   reflect (current)       2,513,210        398                          1.17%
+ *   reflect+setAccessible   2,828,542        354                          1.04%
+ *   MethodHandle            4,154,064        241                          0.71%
+ * </pre>
+ *
+ * <p>So the <em>entire</em> addressable saving from eliminating reflective field access is
+ * <strong>~0.46% of one core</strong> at the throughput the collector was measured at, and
+ * {@code setAccessible} alone would account for 0.13%. Hand-writing a
+ * {@code RowBinaryFormatWriter} path over 55 columns — with the attendant risk of silent type,
+ * null and enum drift against {@code FlowsSchema} — buys under half a percent of a core on a host
+ * that had ~2.9 cores idle. **Deliberately not done.**
+ *
+ * <p>For scale: LZ4 request compression was ~20% of the same thread, i.e. roughly five times the
+ * whole reflection saving, and it is a config flag rather than a rewrite (see
+ * {@code ClickhouseConfig#compressRequests}). That is why the flag landed and the rewrite did not.
+ *
+ * <p>Note the flusher was only 11.6% of one core when profiled, and that run accepted 29,440 of
+ * 29,867 offered rows — it was generator-limited, so the flusher has never been shown to be a
+ * ceiling at all. Re-run this if the collector is ever demonstrably flusher-bound.
+ */
+@Fork(value = 1)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 5, time = 2)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+public class FieldAccessBenchmark {
+
+    private ClickhouseFlow row;
+    private Method[] plain;
+    private Method[] accessible;
+    private MethodHandle[] handles;
+    private List<Function<ClickhouseFlow, Object>> direct;
+
+    @Setup(Level.Trial)
+    public void setup() throws Exception {
+        this.row = new ClickhouseFlow();
+
+        // Every zero-arg getter the client's column-to-method matching would find.
+        final List<Method> getters = new ArrayList<>();
+        for (final Method m : ClickhouseFlow.class.getMethods()) {
+            if (m.getParameterCount() == 0
+                    && (m.getName().startsWith("get") || m.getName().startsWith("is"))
+                    && !m.getName().equals("getClass")) {
+                getters.add(m);
+            }
+        }
+        if (getters.isEmpty()) {
+            throw new IllegalStateException("no getters discovered on ClickhouseFlow");
+        }
+
+        this.plain = getters.toArray(new Method[0]);
+
+        this.accessible = new Method[this.plain.length];
+        for (int i = 0; i < this.plain.length; i++) {
+            final Method m = ClickhouseFlow.class.getMethod(this.plain[i].getName());
+            m.setAccessible(true);
+            this.accessible[i] = m;
+        }
+
+        final var lookup = MethodHandles.lookup();
+        this.handles = new MethodHandle[this.plain.length];
+        for (int i = 0; i < this.plain.length; i++) {
+            this.handles[i] = lookup.unreflect(this.plain[i]);
+        }
+
+        // Lambdas over the same getters: after JIT these are direct calls, so they stand in for
+        // generated accessors without hand-writing 55 method references.
+        this.direct = new ArrayList<>(this.plain.length);
+        for (final Method m : this.plain) {
+            final MethodHandle h = lookup.unreflect(m);
+            this.direct.add(flow -> {
+                try {
+                    return h.invoke(flow);
+                } catch (final Throwable e) {
+                    throw new IllegalStateException(e);
+                }
+            });
+        }
+
+        System.out.printf("%n[setup] ClickhouseFlow getters discovered: %d%n", this.plain.length);
+    }
+
+    @Benchmark
+    public void reflectNoSetAccessible(final Blackhole bh) throws Exception {
+        for (final Method m : this.plain) {
+            bh.consume(m.invoke(this.row));
+        }
+    }
+
+    @Benchmark
+    public void reflectSetAccessible(final Blackhole bh) throws Exception {
+        for (final Method m : this.accessible) {
+            bh.consume(m.invoke(this.row));
+        }
+    }
+
+    @Benchmark
+    public void methodHandle(final Blackhole bh) throws Throwable {
+        for (final MethodHandle h : this.handles) {
+            bh.consume(h.invoke(this.row));
+        }
+    }
+
+    @Benchmark
+    public void direct(final Blackhole bh) {
+        for (final Function<ClickhouseFlow, Object> f : this.direct) {
+            bh.consume(f.apply(this.row));
+        }
+    }
+}


### PR DESCRIPTION
Split out of #391 so each PR changes one thing (review finding: *"change one variable at a time"*).

### The change

`compressClientRequest` was hardcoded `true`. It is now `riptide.clickhouse.compress-requests`,
**default unchanged**, so no existing deployment moves. LZ4 was ~20% of the batch flusher's CPU, and a
collector on the same LAN as ClickHouse pushes only single-digit MB/s uncompressed — so operators there
can reclaim that CPU. Response compression stays on unconditionally; it only covers the startup schema
queries. Documented in `docs/docs/configuration/clickhouse.md`, which previously listed every other knob
but not this one.

### And a decision *not* to do the bigger thing

`FieldAccessBenchmark` measures what bypassing the ClickHouse client's reflective POJO access could buy.
Both paths do identical serialization — same bytes, same `SerializerUtils` — so only field access differs:

| mode | passes/s | ns/row | % of one core @ 29,440 rows/s |
|---|---|---|---|
| reflect (current) | 2,572,855 | 389 | 1.14% |
| reflect + `setAccessible` | 2,883,674 | 347 | 1.02% |
| MethodHandle | 4,149,052 | 241 | **0.71%** ← the floor |

**The entire addressable saving is ~0.43% of one core**, so hand-mapping 55 columns to a
`RowBinaryFormatWriter` — with the silent type/null/enum drift risk against `FlowsSchema` — is not a
sane trade. Deliberately not done, and the benchmark is kept as the evidence for that.

### Review findings addressed in this branch

- **The `direct` mode is removed, not repaired.** It was a lambda wrapping a captured `MethodHandle`,
  which cannot inline to a direct call, so it measured indirection while the javadoc called it "the
  floor" — and its row was omitted from the results table, meaning the floor claim rested on a number
  the reader could not see. `MethodHandle` is the honest floor and is now labelled so.
- **The benchmarked POJO is no longer all-defaults.** Nulls and small boxed values hit the
  `Integer`/`Long` caches, understating the reflective cost in exactly the direction that flatters the
  conclusion. Filling it with out-of-cache values moved the reflective figure ~2% and the saving from
  0.46% to 0.43%. The conclusion holds, but now on a measurement that did not pick its own baseline.
- **Setup asserts getter count against persisted column count**, so the per-row extrapolation cannot
  drift from the schema unnoticed.

### Caveats

Single fork on a dev laptop, so no run-to-run variance estimate — adequate for a "don't do the rewrite"
decision, not for a performance claim. No `make` target for the JMH tier (pre-existing; recorded in
`deferred-work.md`).

823 tests, `make jar` green.

Refs #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)