### PR TITLE
feat(metrics): count the ingest loss that currently escapes every counter

### DIFF
--- a/docs/docs/deploy/operations.md
+++ b/docs/docs/deploy/operations.md
@@ -82,6 +82,8 @@ lost silently. Alert on the drop counters; watch the depth gauges for early warn
 
 | Metric | Meaning |
 |---|---|
+| `listeners.<name>.socketDrops` | **datagrams the kernel discarded** because the socket receive buffer was full (gauge, Linux only) |
+| `parsers.<name>.undecodableSets` | Data Sets discarded because their IPFIX/NetFlow v9 Template was not known |
 | `parsers.<name>.dispatchQueueDepth` | packets waiting to be enriched (gauge) |
 | `parsers.<name>.dispatchDrops` | **records** discarded because enrichment/persistence fell behind, or discarded at shutdown |
 | `pipeline.dispatchErrors` | records lost because enrichment or persistence threw |
@@ -92,6 +94,22 @@ lost silently. Alert on the drop counters; watch the depth gauges for early warn
 Delivery accounting: `recordsScheduled − dispatchDrops − dispatchErrors` is what reached the
 persister. Note `recordsDispatched` counts only records the pipeline accepted without throwing, so
 it excludes `dispatchErrors`.
+
+**Two of these count loss that happens before any of the queues.** They were added because a lab
+measurement found the application accounting for only ~4% of a ~25% shortfall under sustained
+overload, with nothing accounting for the rest:
+
+- `socketDrops` is **upstream of every application counter**. Once the receive buffer overflows, the
+  datagram is gone before riptide runs, so this is the only place that loss is visible at all. It is
+  read per socket from `/proc/net/udp`, so it attributes to this receiver rather than the whole host,
+  and it publishes no value on non-Linux (absent is not the same as zero). A rising value means the
+  collector cannot drain the socket fast enough — raise `net.core.rmem_max`, or reduce offered load.
+- `undecodableSets` counts Data Sets thrown away because their Template had not arrived. RFC 7011 §8
+  permits discarding these, so it is not a protocol error, but it is still lost data. It counts
+  **Sets, not records**: without the Template the record size is unknown, so treat it as a lower
+  bound. Expect a burst at startup — a UDP exporter re-announces Templates only periodically, so a
+  freshly started collector discards data until the first Template of each exporter arrives.
+  Sustained non-zero values are the ones to alert on.
 
 **Datagram vs. reliable transports differ deliberately.** A UDP receiver drops when its dispatch
 queue stays full, because the medium is already lossy and a counted userspace drop beats pushing

--- a/docs/docs/deploy/operations.md
+++ b/docs/docs/deploy/operations.md
@@ -95,20 +95,19 @@ Delivery accounting: `recordsScheduled − dispatchDrops − dispatchErrors` is 
 persister. Note `recordsDispatched` counts only records the pipeline accepted without throwing, so
 it excludes `dispatchErrors`.
 
-**Two of these count loss that happens before any of the queues.** They were added because a lab
-measurement found the application accounting for only ~4% of a ~25% shortfall under sustained
-overload, with nothing accounting for the rest:
+**Two of these count loss that happens before any of the queues.**
+They were added because a lab measurement found the application accounting for only ~4% of a ~25% shortfall under sustained overload, with nothing accounting for the rest:
 
-- `socketDrops` is **upstream of every application counter**. Once the receive buffer overflows, the
-  datagram is gone before riptide runs, so this is the only place that loss is visible at all. It is
-  read per socket from `/proc/net/udp`, so it attributes to this receiver rather than the whole host,
-  and it publishes no value on non-Linux (absent is not the same as zero). A rising value means the
-  collector cannot drain the socket fast enough — raise `net.core.rmem_max`, or reduce offered load.
-- `undecodableSets` counts Data Sets thrown away because their Template had not arrived. RFC 7011 §8
-  permits discarding these, so it is not a protocol error, but it is still lost data. It counts
-  **Sets, not records**: without the Template the record size is unknown, so treat it as a lower
-  bound. Expect a burst at startup — a UDP exporter re-announces Templates only periodically, so a
-  freshly started collector discards data until the first Template of each exporter arrives.
+- `socketDrops` is **upstream of every application counter**.
+  Once the receive buffer overflows, the datagram is gone before riptide runs, so this is the only place that loss is visible at all.
+  It is read per socket from `/proc/net/udp`, matched on the bound address and port, so it attributes to this receiver rather than to the whole host or to another socket sharing the port number.
+  It publishes no value on non-Linux platforms (absent is not the same as zero).
+  A rising value means the collector cannot drain the socket fast enough: raise `net.core.rmem_max`, or reduce offered load.
+- `undecodableSets` counts Data Sets thrown away because their Template had not arrived.
+  RFC 7011 §8 permits discarding these, so it is not a protocol error, but it is still lost data.
+  It counts **Sets, not records**: without the Template the record size is unknown, so treat it as a lower bound.
+  Note that it also counts Options Data Sets, whose loss costs enrichment metadata (exporter-pushed interface names) rather than flow records, so a non-zero value is not proof that flow data was lost.
+  Expect a burst at startup: a UDP exporter re-announces Templates only periodically, so a freshly started collector discards data until the first Template of each exporter arrives.
   Sustained non-zero values are the ones to alert on.
 
 **Datagram vs. reliable transports differ deliberately.** A UDP receiver drops when its dispatch

--- a/src/main/java/org/riptide/flows/listeners/UdpListener.java
+++ b/src/main/java/org/riptide/flows/listeners/UdpListener.java
@@ -5,6 +5,7 @@
 
 package org.riptide.flows.listeners;
 
+import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -39,6 +40,7 @@ public class UdpListener implements Listener {
     private final UdpParser parser;
 
     private final Meter packetsReceived;
+    private final MetricRegistry metrics;
 
     private EventLoopGroup bossGroup;
     private ChannelFuture socketFuture;
@@ -54,6 +56,7 @@ public class UdpListener implements Listener {
         this.parser = Objects.requireNonNull(parser);
 
         this.packetsReceived = metrics.meter(MetricRegistry.name("listeners", name, "packetsReceived"));
+        this.metrics = metrics;
     }
 
     @Override
@@ -78,6 +81,29 @@ public class UdpListener implements Listener {
                 .handler(new DefaultChannelInitializer())
                 .bind(address)
                 .syncUninterruptibly();
+
+        registerSocketDrops();
+    }
+
+    /**
+     * Publish the kernel's per-socket drop count for the port we actually bound.
+     *
+     * <p>Read from the bound channel rather than {@link #port} so that an ephemeral bind
+     * ({@code port = 0}) still attributes correctly. Registered after {@code bind} for the same
+     * reason — before it there is no port to attribute to.
+     *
+     * <p>Remove-then-register, so a restarted listener rebinds the gauge to its live socket instead of
+     * leaving the previous instance's closure in place.
+     */
+    private void registerSocketDrops() {
+        final java.net.SocketAddress local = this.socketFuture.channel().localAddress();
+        if (!(local instanceof InetSocketAddress bound)) {
+            return;
+        }
+        final int boundPort = bound.getPort();
+        final String gauge = MetricRegistry.name("listeners", this.name, "socketDrops");
+        this.metrics.remove(gauge);
+        this.metrics.register(gauge, (Gauge<Long>) () -> UdpSocketDrops.forPort(boundPort));
     }
 
     @Override

--- a/src/main/java/org/riptide/flows/listeners/UdpListener.java
+++ b/src/main/java/org/riptide/flows/listeners/UdpListener.java
@@ -100,14 +100,19 @@ public class UdpListener implements Listener {
         if (!(local instanceof InetSocketAddress bound)) {
             return;
         }
-        final int boundPort = bound.getPort();
         final String gauge = MetricRegistry.name("listeners", this.name, "socketDrops");
         this.metrics.remove(gauge);
-        this.metrics.register(gauge, (Gauge<Long>) () -> UdpSocketDrops.forPort(boundPort));
+        this.metrics.register(gauge, (Gauge<Long>) () -> UdpSocketDrops.forSocket(bound));
     }
 
     @Override
     public void stop() {
+        // Deregister before closing: once the socket is gone the closure describes a port we no
+        // longer own, and the next process to bind it would have its kernel drops published as
+        // this receiver's ingest loss. Same reason BatchingFlowRepository removes its queue-depth
+        // gauge in stop().
+        this.metrics.remove(MetricRegistry.name("listeners", this.name, "socketDrops"));
+
         if (this.socketFuture != null) {
             LOG.info("Closing channel...");
             this.socketFuture.channel().close().syncUninterruptibly();

--- a/src/main/java/org/riptide/flows/listeners/UdpSocketDrops.java
+++ b/src/main/java/org/riptide/flows/listeners/UdpSocketDrops.java
@@ -9,10 +9,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 /**
  * Datagrams the kernel discarded because the socket receive buffer was full, read per socket from
@@ -26,10 +32,12 @@ import java.util.List;
  *
  * <p><strong>Per socket, not per host.</strong> {@code /proc/net/snmp}'s {@code Udp: RcvbufErrors} is
  * a host-wide total and cannot attribute drops to a receiver; the {@code drops} column of
- * {@code /proc/net/udp} can. Both the IPv4 and IPv6 tables are consulted because a wildcard bind on
- * Linux commonly yields a single v6 socket that also serves v4, and the value is <em>summed</em>
- * across every socket bound to the port so that {@code SO_REUSEPORT} fan-out is counted once in
- * total rather than once per socket.
+ * {@code /proc/net/udp} can. Rows are matched on the bound <em>address and port</em>, not the port
+ * alone: two receivers may legitimately share a port on different addresses, and matching by port
+ * would attribute each one's kernel drops to both. Both the IPv4 and IPv6 tables are consulted
+ * because a wildcard bind on Linux commonly yields a single v6 socket that also serves v4, and the
+ * value is <em>summed</em> across matching rows so that {@code SO_REUSEPORT} fan-out is counted once
+ * in total rather than once per socket.
  *
  * <p>Linux-only by construction. Where the files are absent — macOS, or a kernel without procfs —
  * every read returns {@code null} and the gauge simply publishes no value, which is honest: "not
@@ -49,22 +57,29 @@ final class UdpSocketDrops {
     private static final int LOCAL_ADDRESS = 1;
     private static final int MIN_FIELDS = 13;
 
+    /** The all-zeros address halves a wildcard bind shows in each table. */
+    private static final String ANY_V4 = "00000000";
+    private static final String ANY_V6 = "0".repeat(32);
+
     private UdpSocketDrops() {
     }
 
     /**
-     * Total dropped datagrams across all UDP sockets bound to {@code port}.
+     * Total dropped datagrams across all UDP sockets bound to exactly this address and port.
      *
-     * @param port the local port to attribute drops to
-     * @return the summed drop count, or {@code null} when procfs is unavailable or no socket is bound
-     *         to the port (a closed socket has no drop count, which is distinct from having zero)
+     * @param bound the socket address actually bound, as reported by the channel
+     * @return the summed drop count, or {@code null} when procfs is unavailable or no matching socket
+     *         exists (a closed socket has no drop count, which is distinct from having zero)
      */
-    static Long forPort(final int port) {
+    static Long forSocket(final InetSocketAddress bound) {
+        final Set<String> addresses = procAddressForms(bound.getAddress());
+        final int port = bound.getPort();
+
         long total = 0;
         boolean found = false;
 
         for (final Path table : List.of(UDP4, UDP6)) {
-            final Long drops = dropsIn(table, port);
+            final Long drops = dropsIn(table, addresses, port);
             if (drops != null) {
                 total += drops;
                 found = true;
@@ -74,13 +89,13 @@ final class UdpSocketDrops {
         return found ? total : null;
     }
 
-    private static Long dropsIn(final Path table, final int port) {
+    private static Long dropsIn(final Path table, final Set<String> addresses, final int port) {
         if (!Files.isReadable(table)) {
             return null;
         }
 
         try {
-            return sumDrops(Files.readAllLines(table, StandardCharsets.US_ASCII), port);
+            return sumDrops(Files.readAllLines(table, StandardCharsets.US_ASCII), addresses, port);
         } catch (final IOException e) {
             // procfs reads can fail transiently; a metrics scrape must never propagate that
             LOG.debug("Could not read {} for socket drop counts", table, e);
@@ -89,15 +104,16 @@ final class UdpSocketDrops {
     }
 
     /**
-     * Sum the {@code drops} column over every row bound to {@code port}.
+     * Sum the {@code drops} column over every row whose local address half is in {@code addresses}
+     * and whose local port is {@code port}.
      *
      * <p>Package-private and taking lines rather than a path so the column arithmetic is testable
-     * without procfs — the parsing (hex port, last column, summing across sockets) is the part that
-     * can silently produce a plausible wrong number.
+     * without procfs — the parsing (hex port, byte-swapped hex addresses, last column, summing across
+     * sockets) is the part that can silently produce a plausible wrong number.
      *
      * @return summed drops, or {@code null} if no row matched
      */
-    static Long sumDrops(final List<String> lines, final int port) {
+    static Long sumDrops(final List<String> lines, final Set<String> addresses, final int port) {
         long total = 0;
         boolean found = false;
 
@@ -107,7 +123,7 @@ final class UdpSocketDrops {
             if (fields.length < MIN_FIELDS) {
                 continue;
             }
-            if (localPort(fields[LOCAL_ADDRESS]) != port) {
+            if (!matchesLocal(fields[LOCAL_ADDRESS], addresses, port)) {
                 continue;
             }
             final long drops = parseUnsigned(fields[fields.length - 1]);
@@ -120,12 +136,57 @@ final class UdpSocketDrops {
         return found ? total : null;
     }
 
-    /** {@code local_address} is {@code <hex-addr>:<hex-port>}; only the port is needed. */
-    private static int localPort(final String localAddress) {
-        final int colon = localAddress.lastIndexOf(':');
-        if (colon < 0 || colon == localAddress.length() - 1) {
-            return -1;
+    /**
+     * The hex address halves that represent {@code address} in the procfs tables.
+     *
+     * <p>procfs prints each 32-bit word of the address byte-swapped, so {@code 10.0.0.2} appears as
+     * {@code 0200000A}, not {@code 0A000002}. A wildcard bind matches the all-zeros form in either
+     * table. A specific IPv4 bind may appear either as an AF_INET socket in {@code /proc/net/udp} or,
+     * because the JDK opens dual-stack sockets by default, as the v4-mapped form
+     * ({@code ::ffff:a.b.c.d}) in {@code /proc/net/udp6} — both forms are accepted.
+     */
+    static Set<String> procAddressForms(final InetAddress address) {
+        if (address == null || address.isAnyLocalAddress()) {
+            return Set.of(ANY_V4, ANY_V6);
         }
+        if (address instanceof Inet4Address) {
+            final String v4 = wordSwappedHex(address.getAddress());
+            final byte[] mapped = new byte[16];
+            mapped[10] = (byte) 0xFF;
+            mapped[11] = (byte) 0xFF;
+            System.arraycopy(address.getAddress(), 0, mapped, 12, 4);
+            return Set.of(v4, wordSwappedHex(mapped));
+        }
+        if (address instanceof Inet6Address) {
+            return Set.of(wordSwappedHex(address.getAddress()));
+        }
+        return Set.of();
+    }
+
+    private static boolean matchesLocal(final String localAddress, final Set<String> addresses, final int port) {
+        final int colon = localAddress.lastIndexOf(':');
+        if (colon <= 0 || colon == localAddress.length() - 1) {
+            return false;
+        }
+        if (localPort(localAddress, colon) != port) {
+            return false;
+        }
+        return addresses.contains(localAddress.substring(0, colon).toUpperCase(Locale.ROOT));
+    }
+
+    /** Hex-encode {@code bytes} with each 4-byte word byte-swapped, matching procfs's rendering. */
+    private static String wordSwappedHex(final byte[] bytes) {
+        final StringBuilder hex = new StringBuilder(bytes.length * 2);
+        for (int word = 0; word < bytes.length; word += 4) {
+            for (int i = word + 3; i >= word; i--) {
+                hex.append(String.format(Locale.ROOT, "%02X", bytes[i]));
+            }
+        }
+        return hex.toString();
+    }
+
+    /** {@code local_address} is {@code <hex-addr>:<hex-port>}; only the port is needed here. */
+    private static int localPort(final String localAddress, final int colon) {
         try {
             return Integer.parseInt(localAddress.substring(colon + 1), 16);
         } catch (final NumberFormatException e) {

--- a/src/main/java/org/riptide/flows/listeners/UdpSocketDrops.java
+++ b/src/main/java/org/riptide/flows/listeners/UdpSocketDrops.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.listeners;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Datagrams the kernel discarded because the socket receive buffer was full, read per socket from
+ * {@code /proc/net/udp} and {@code /proc/net/udp6}.
+ *
+ * <p>This is the one loss that no application counter can see. Once the receive buffer overflows the
+ * datagram is gone before any userspace code runs, so a collector can be losing a quarter of its
+ * offered load while every metric it publishes reads healthy. Measured on the benchmark lab: at
+ * saturation the application accounted for roughly 4% of a ~25% shortfall, and nothing accounted for
+ * the rest.
+ *
+ * <p><strong>Per socket, not per host.</strong> {@code /proc/net/snmp}'s {@code Udp: RcvbufErrors} is
+ * a host-wide total and cannot attribute drops to a receiver; the {@code drops} column of
+ * {@code /proc/net/udp} can. Both the IPv4 and IPv6 tables are consulted because a wildcard bind on
+ * Linux commonly yields a single v6 socket that also serves v4, and the value is <em>summed</em>
+ * across every socket bound to the port so that {@code SO_REUSEPORT} fan-out is counted once in
+ * total rather than once per socket.
+ *
+ * <p>Linux-only by construction. Where the files are absent — macOS, or a kernel without procfs —
+ * every read returns {@code null} and the gauge simply publishes no value, which is honest: "not
+ * measurable here" is not the same as "zero drops".
+ *
+ * <p>Cost is a small file read per call, so this is fine for a metrics scrape and must not be called
+ * on the packet path.
+ */
+final class UdpSocketDrops {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UdpSocketDrops.class);
+
+    private static final Path UDP4 = Path.of("/proc/net/udp");
+    private static final Path UDP6 = Path.of("/proc/net/udp6");
+
+    /** {@code sl local_address rem_address st tx_queue rx_queue ... inode ref pointer drops} */
+    private static final int LOCAL_ADDRESS = 1;
+    private static final int MIN_FIELDS = 13;
+
+    private UdpSocketDrops() {
+    }
+
+    /**
+     * Total dropped datagrams across all UDP sockets bound to {@code port}.
+     *
+     * @param port the local port to attribute drops to
+     * @return the summed drop count, or {@code null} when procfs is unavailable or no socket is bound
+     *         to the port (a closed socket has no drop count, which is distinct from having zero)
+     */
+    static Long forPort(final int port) {
+        long total = 0;
+        boolean found = false;
+
+        for (final Path table : List.of(UDP4, UDP6)) {
+            final Long drops = dropsIn(table, port);
+            if (drops != null) {
+                total += drops;
+                found = true;
+            }
+        }
+
+        return found ? total : null;
+    }
+
+    private static Long dropsIn(final Path table, final int port) {
+        if (!Files.isReadable(table)) {
+            return null;
+        }
+
+        try {
+            return sumDrops(Files.readAllLines(table, StandardCharsets.US_ASCII), port);
+        } catch (final IOException e) {
+            // procfs reads can fail transiently; a metrics scrape must never propagate that
+            LOG.debug("Could not read {} for socket drop counts", table, e);
+            return null;
+        }
+    }
+
+    /**
+     * Sum the {@code drops} column over every row bound to {@code port}.
+     *
+     * <p>Package-private and taking lines rather than a path so the column arithmetic is testable
+     * without procfs — the parsing (hex port, last column, summing across sockets) is the part that
+     * can silently produce a plausible wrong number.
+     *
+     * @return summed drops, or {@code null} if no row matched
+     */
+    static Long sumDrops(final List<String> lines, final int port) {
+        long total = 0;
+        boolean found = false;
+
+        for (final String line : lines) {
+            final String[] fields = line.trim().split("\\s+");
+            // the header line splits fine but has no numeric port, so it falls out on the port check
+            if (fields.length < MIN_FIELDS) {
+                continue;
+            }
+            if (localPort(fields[LOCAL_ADDRESS]) != port) {
+                continue;
+            }
+            final long drops = parseUnsigned(fields[fields.length - 1]);
+            if (drops >= 0) {
+                total += drops;
+                found = true;
+            }
+        }
+
+        return found ? total : null;
+    }
+
+    /** {@code local_address} is {@code <hex-addr>:<hex-port>}; only the port is needed. */
+    private static int localPort(final String localAddress) {
+        final int colon = localAddress.lastIndexOf(':');
+        if (colon < 0 || colon == localAddress.length() - 1) {
+            return -1;
+        }
+        try {
+            return Integer.parseInt(localAddress.substring(colon + 1), 16);
+        } catch (final NumberFormatException e) {
+            return -1;
+        }
+    }
+
+    private static long parseUnsigned(final String value) {
+        try {
+            return Long.parseLong(value);
+        } catch (final NumberFormatException e) {
+            return -1;
+        }
+    }
+}

--- a/src/main/java/org/riptide/flows/listeners/UdpSocketDrops.java
+++ b/src/main/java/org/riptide/flows/listeners/UdpSocketDrops.java
@@ -174,10 +174,17 @@ final class UdpSocketDrops {
         return addresses.contains(localAddress.substring(0, colon).toUpperCase(Locale.ROOT));
     }
 
-    /** Hex-encode {@code bytes} with each 4-byte word byte-swapped, matching procfs's rendering. */
+    /**
+     * Hex-encode {@code bytes} with each 4-byte word byte-swapped, matching procfs's rendering.
+     *
+     * <p>The loop bound requires a complete word before reading one, so the method is total even
+     * though every real input ({@link InetAddress#getAddress()}) is 4 or 16 bytes: relying on the
+     * call sites for the bounds proof is exactly how a refactor earns an
+     * {@code ArrayIndexOutOfBoundsException} later.
+     */
     private static String wordSwappedHex(final byte[] bytes) {
         final StringBuilder hex = new StringBuilder(bytes.length * 2);
-        for (int word = 0; word < bytes.length; word += 4) {
+        for (int word = 0; word + 3 < bytes.length; word += 4) {
             for (int i = word + 3; i >= word; i--) {
                 hex.append(String.format(Locale.ROOT, "%02X", bytes[i]));
             }

--- a/src/main/java/org/riptide/flows/parser/FlowPacket.java
+++ b/src/main/java/org/riptide/flows/parser/FlowPacket.java
@@ -47,4 +47,20 @@ public interface FlowPacket {
     default int getSequenceIncrement() {
         return 1;
     }
+
+    /**
+     * Data Sets this packet carried that could not be decoded because their Template was not known.
+     *
+     * <p>RFC 7011 §8 makes collector-side buffering of such records a {@code MAY}, so discarding them
+     * is compliant — but it is still lost data, and it is lost a whole Set at a time. The count is of
+     * <strong>Sets, not records</strong>, and that is not a shortcut: without the Template the record
+     * size is unknown, so the records inside an undecodable Set cannot be counted. Treat it as a lower
+     * bound on records lost.
+     *
+     * @return the number of Data Sets discarded for a missing Template; {@code 0} for protocols
+     *         without templates (NetFlow v5, sFlow)
+     */
+    default int undecodableSets() {
+        return 0;
+    }
 }

--- a/src/main/java/org/riptide/flows/parser/ParserBase.java
+++ b/src/main/java/org/riptide/flows/parser/ParserBase.java
@@ -97,6 +97,9 @@ public abstract class ParserBase implements Parser {
     /** Records dropped at the handoff because the workers were behind — the seam's loss ledger. */
     private final Counter dispatchDrops;
 
+    /** Data Sets discarded before decode because their Template was unknown. */
+    private final Counter undecodableSets;
+
     /** One drop warning per 10s; the counter carries the tally. */
     private final RateLimiter dropWarnLimiter = RateLimiter.create(0.1);
 
@@ -121,6 +124,7 @@ public abstract class ParserBase implements Parser {
         this.recordsScheduled = metricRegistry.meter(MetricRegistry.name("parsers", name, "recordsScheduled"));
         this.sequenceErrors = metricRegistry.counter(MetricRegistry.name("parsers", name, "sequenceErrors"));
         this.dispatchDrops = metricRegistry.counter(MetricRegistry.name("parsers", name, "dispatchDrops"));
+        this.undecodableSets = metricRegistry.counter(MetricRegistry.name("parsers", name, "undecodableSets"));
 
         setThreads(DEFAULT_NUM_THREADS);
     }
@@ -363,6 +367,14 @@ public abstract class ParserBase implements Parser {
         //
         // It also stops defeating the enrichers: Enricher.Streaming/Single fan out across the flow
         // list with CompletableFuture.allOf, which did nothing while the list was always size 1.
+        // Counted before the isEmpty() return below, deliberately: a packet whose every Data Set was
+        // undecodable builds no flows at all, so counting after the return would miss precisely the
+        // loss this counter exists to make visible.
+        final int undecodable = packet.undecodableSets();
+        if (undecodable > 0) {
+            this.undecodableSets.inc(undecodable);
+        }
+
         final List<Flow> flows = packet.buildFlows(receivedAt).toList();
         if (flows.isEmpty()) {
             return CompletableFuture.completedFuture(null);

--- a/src/main/java/org/riptide/flows/parser/ParserBase.java
+++ b/src/main/java/org/riptide/flows/parser/ParserBase.java
@@ -369,7 +369,9 @@ public abstract class ParserBase implements Parser {
         // list with CompletableFuture.allOf, which did nothing while the list was always size 1.
         // Counted before the isEmpty() return below, deliberately: a packet whose every Data Set was
         // undecodable builds no flows at all, so counting after the return would miss precisely the
-        // loss this counter exists to make visible.
+        // loss this counter exists to make visible. The one gap left open: a packet that fails to
+        // parse outright (bad Set length, invalid Set ID) never reaches transmit(), so Sets skipped
+        // earlier in that same packet are accounted under parserErrors instead of here.
         final int undecodable = packet.undecodableSets();
         if (undecodable > 0) {
             this.undecodableSets.inc(undecodable);

--- a/src/main/java/org/riptide/flows/parser/ipfix/IpfixTcpParser.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/IpfixTcpParser.java
@@ -104,6 +104,11 @@ public class IpfixTcpParser extends ParserBase implements TcpParser {
                         // IPFIX sequence numbers count Data Records (RFC 7011 §3.1)
                         return packet.dataRecordCount();
                     }
+
+                    @Override
+                    public int undecodableSets() {
+                        return packet.undecodableSets;
+                    }
                 };
 
                 return Optional.of(IpfixTcpParser.this.transmit(receivedAt, flow, session));

--- a/src/main/java/org/riptide/flows/parser/ipfix/IpfixUdpParser.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/IpfixUdpParser.java
@@ -74,6 +74,11 @@ public class IpfixUdpParser extends UdpParserBase implements DispatchableUdpPars
                 // IPFIX sequence numbers count Data Records (RFC 7011 §3.1)
                 return packet.dataRecordCount();
             }
+
+            @Override
+            public int undecodableSets() {
+                return packet.undecodableSets;
+            }
         };
     }
 

--- a/src/main/java/org/riptide/flows/parser/ipfix/proto/Packet.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/proto/Packet.java
@@ -48,6 +48,9 @@ public final class Packet implements Iterable<FlowSet<?>> {
     public final List<OptionsTemplateSet> optionTemplateSets;
     public final List<DataSet> dataSets;
 
+    /** Data Sets discarded for a missing Template. See {@link org.riptide.flows.parser.FlowPacket#undecodableSets()}. */
+    public final int undecodableSets;
+
     public Packet(final Session session,
                   final Header header,
                   final ByteBuf buffer) throws InvalidPacketException {
@@ -60,6 +63,8 @@ public final class Packet implements Iterable<FlowSet<?>> {
         // Stop once fewer than one Set header remains: a trailing remainder that small can only be
         // message padding (some exporters pad to a 4-byte boundary), not a Set. Reading it as a Set
         // would yield an invalid Set ID and drop the whole packet. (Matches goflow2 / NetGauze.)
+        int undecodable = 0;
+
         while (buffer.readableBytes() >= FlowSetHeader.SIZE) {
             final ByteBuf headerBuffer = slice(buffer, FlowSetHeader.SIZE);
             final FlowSetHeader setHeader = new FlowSetHeader(headerBuffer);
@@ -132,6 +137,9 @@ public final class Packet implements Iterable<FlowSet<?>> {
                     try {
                         dataSet = new DataSet(this, setHeader, resolver, payloadBuffer);
                     } catch (final MissingTemplateException ex) {
+                        // Counted, not merely logged: this discards the whole Set and used to be
+                        // invisible at DEBUG. See FlowPacket#undecodableSets.
+                        undecodable++;
                         LOG.debug("Skipping data-set due to missing template: {}", ex.getMessage());
                         break;
                     }
@@ -156,6 +164,7 @@ public final class Packet implements Iterable<FlowSet<?>> {
         this.templateSets = Collections.unmodifiableList(parsedTemplateSets);
         this.optionTemplateSets = Collections.unmodifiableList(parsedOptionTemplateSets);
         this.dataSets = Collections.unmodifiableList(parsedDataSets);
+        this.undecodableSets = undecodable;
     }
 
     @Override

--- a/src/main/java/org/riptide/flows/parser/netflow9/Netflow9UdpParser.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/Netflow9UdpParser.java
@@ -67,6 +67,11 @@ public class Netflow9UdpParser extends UdpParserBase implements DispatchableUdpP
             public long getSequenceNumber() {
                 return header.sequenceNumber;
             }
+
+            @Override
+            public int undecodableSets() {
+                return packet.undecodableSets;
+            }
         };
     }
 

--- a/src/main/java/org/riptide/flows/parser/netflow9/proto/Packet.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/proto/Packet.java
@@ -49,6 +49,9 @@ public final class Packet implements Iterable<FlowSet<?>> {
     public final List<OptionsTemplateSet> optionTemplateSets;
     public final List<DataSet> dataSets;
 
+    /** Data Sets discarded for a missing Template. See {@link org.riptide.flows.parser.FlowPacket#undecodableSets()}. */
+    public final int undecodableSets;
+
     public Packet(final Session session,
                   final Header header,
                   final ByteBuf buffer) throws InvalidPacketException {
@@ -60,6 +63,8 @@ public final class Packet implements Iterable<FlowSet<?>> {
         // Stop once fewer than one Set header remains: a trailing remainder that small can only be
         // message padding (some exporters pad to a 4-byte boundary), not a Set. Reading it as a Set
         // would yield an invalid Set ID and drop the whole packet. (Matches goflow2 / NetGauze.)
+        int undecodable = 0;
+
         while (buffer.readableBytes() >= FlowSetHeader.SIZE) {
             // We ignore header.counter here, because different exporters interpret it as flowset count or record count
 
@@ -121,6 +126,9 @@ public final class Packet implements Iterable<FlowSet<?>> {
                     try {
                         dataSet = new DataSet(this, setHeader, resolver, payloadBuffer);
                     } catch (final MissingTemplateException ex) {
+                        // Counted, not merely logged: this discards the whole Set and used to be
+                        // invisible at DEBUG. See FlowPacket#undecodableSets.
+                        undecodable++;
                         LOG.debug("Skipping data-set due to missing template: {}", ex.getMessage());
                         break;
                     }
@@ -145,6 +153,7 @@ public final class Packet implements Iterable<FlowSet<?>> {
         this.templateSets = Collections.unmodifiableList(parsedTemplateSets);
         this.optionTemplateSets = Collections.unmodifiableList(parsedOptionTemplateSets);
         this.dataSets = Collections.unmodifiableList(parsedDataSets);
+        this.undecodableSets = undecodable;
     }
 
     @Override

--- a/src/test/java/org/riptide/flows/listeners/UdpListenerGaugeLifecycleTest.java
+++ b/src/test/java/org/riptide/flows/listeners/UdpListenerGaugeLifecycleTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.listeners;
+
+import com.codahale.metrics.MetricRegistry;
+import io.netty.buffer.ByteBuf;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The {@code socketDrops} gauge must live exactly as long as the socket it describes.
+ *
+ * <p>The regression this pins: {@code stop()} closing the socket but leaving the gauge registered.
+ * The leaked closure holds the old bound address, so the moment any other process binds that port,
+ * the dead listener publishes that socket's kernel drops as riptide ingest loss — the precise
+ * misattribution reading {@code /proc/net/udp} per socket was chosen to avoid.
+ */
+class UdpListenerGaugeLifecycleTest {
+
+    @Test
+    void socketDropsGaugeIsRegisteredOnStartAndRemovedOnStop() {
+        final var registry = new MetricRegistry();
+        final var listener = new UdpListener("lifecycle", parser(), registry)
+                .withHost("127.0.0.1")
+                .withPort(0); // ephemeral: the gauge must attribute to the port actually bound
+        final String gauge = MetricRegistry.name("listeners", "lifecycle", "socketDrops");
+
+        listener.start();
+        try {
+            assertThat(registry.getGauges()).containsKey(gauge);
+        } finally {
+            listener.stop();
+        }
+
+        assertThat(registry.getGauges())
+                .as("a stopped listener must not keep publishing a closure over a port it no longer owns")
+                .doesNotContainKey(gauge);
+    }
+
+    private static UdpParser parser() {
+        return new UdpParser() {
+            @Override
+            public CompletableFuture<?> parse(final Instant receivedAt, final ByteBuf buffer,
+                                              final InetSocketAddress remoteAddress,
+                                              final InetSocketAddress localAddress) {
+                return CompletableFuture.completedFuture(null);
+            }
+
+            @Override
+            public String getName() {
+                return "lifecycle";
+            }
+
+            @Override
+            public String getDescription() {
+                return "lifecycle";
+            }
+
+            @Override
+            public Object dumpInternalState() {
+                return null;
+            }
+
+            @Override
+            public void start(final ScheduledExecutorService executorService) {
+            }
+
+            @Override
+            public void stop() {
+            }
+        };
+    }
+}

--- a/src/test/java/org/riptide/flows/listeners/UdpSocketDropsTest.java
+++ b/src/test/java/org/riptide/flows/listeners/UdpSocketDropsTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.listeners;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Column arithmetic for the kernel's per-socket drop counter.
+ *
+ * <p>Worth testing precisely because every failure mode here is silent: the port is hex, so decimal
+ * parsing finds nothing and reads as "no drops"; {@code drops} is the last of thirteen columns, so an
+ * off-by-one lands on {@code pointer} and reports an address as a drop count; and a wildcard bind can
+ * appear in both the v4 and v6 tables, so summing wrongly double-counts. Each of those produces a
+ * plausible number rather than an error.
+ *
+ * <p>Fixtures are real {@code /proc/net/udp} lines. Port {@code 0x270F} is 9999, riptide's default.
+ */
+class UdpSocketDropsTest {
+
+    private static final String HEADER =
+            "   sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode ref pointer drops";
+
+    /** A socket row bound to {@code port} (hex) reporting {@code drops}. */
+    private static String row(final String hexPort, final long drops, final int inode) {
+        return "  123: 00000000:" + hexPort + " 00000000:0000 07 00000000:00000000 00:00000000 00000000"
+                + "     0        0 " + inode + " 2 0000000000000000 " + drops;
+    }
+
+    @Test
+    void readsTheDropsColumnForTheMatchingHexPort() {
+        final var lines = List.of(HEADER, row("270F", 42, 34567));
+
+        assertThat(UdpSocketDrops.sumDrops(lines, 9999))
+                .as("0x270F is 9999 — the port must be parsed as hex, not decimal")
+                .isEqualTo(42L);
+    }
+
+    @Test
+    void sumsAcrossEverySocketBoundToThePort() {
+        // SO_REUSEPORT fan-out: several sockets, one port, drops must total rather than take the first
+        final var lines = List.of(HEADER, row("270F", 10, 1), row("270F", 7, 2), row("270F", 5, 3));
+
+        assertThat(UdpSocketDrops.sumDrops(lines, 9999)).isEqualTo(22L);
+    }
+
+    @Test
+    void ignoresSocketsOnOtherPorts() {
+        final var lines = List.of(HEADER, row("0035", 999, 1), row("270F", 3, 2), row("1F90", 999, 3));
+
+        assertThat(UdpSocketDrops.sumDrops(lines, 9999))
+                .as("another service's drops must never be attributed to this listener")
+                .isEqualTo(3L);
+    }
+
+    @Test
+    void returnsNullWhenNoSocketIsBoundToThePort() {
+        final var lines = List.of(HEADER, row("0035", 12, 1));
+
+        assertThat(UdpSocketDrops.sumDrops(lines, 9999))
+                .as("no socket means no drop count — distinct from a socket reporting zero")
+                .isNull();
+    }
+
+    @Test
+    void aBoundSocketWithNoDropsReportsZeroNotNull() {
+        assertThat(UdpSocketDrops.sumDrops(List.of(HEADER, row("270F", 0, 1)), 9999))
+                .as("zero drops is a real, useful reading and must be distinguishable from absent")
+                .isEqualTo(0L);
+    }
+
+    @Test
+    void toleratesTheHeaderAndAnyMalformedRow() {
+        final var lines = List.of(HEADER, "", "garbage", "  1: nonsense", row("270F", 4, 1));
+
+        assertThat(UdpSocketDrops.sumDrops(lines, 9999))
+                .as("a metrics scrape must not throw on unexpected procfs content")
+                .isEqualTo(4L);
+    }
+
+    @Test
+    void procfsAbsenceYieldsNullRatherThanZero() {
+        // On a machine without /proc/net/udp (macOS, the usual dev box) the gauge must publish no
+        // value. Reporting 0 there would assert "no kernel drops" on a platform that cannot know.
+        final boolean linux = System.getProperty("os.name", "").toLowerCase().contains("linux");
+        if (!linux) {
+            assertThat(UdpSocketDrops.forPort(9999)).isNull();
+        } else {
+            // on Linux the file exists; an unbound port still has no row, so null is expected
+            assertThat(UdpSocketDrops.forPort(1)).isNull();
+        }
+    }
+}

--- a/src/test/java/org/riptide/flows/listeners/UdpSocketDropsTest.java
+++ b/src/test/java/org/riptide/flows/listeners/UdpSocketDropsTest.java
@@ -6,8 +6,15 @@
 package org.riptide.flows.listeners;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -15,10 +22,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Column arithmetic for the kernel's per-socket drop counter.
  *
  * <p>Worth testing precisely because every failure mode here is silent: the port is hex, so decimal
- * parsing finds nothing and reads as "no drops"; {@code drops} is the last of thirteen columns, so an
- * off-by-one lands on {@code pointer} and reports an address as a drop count; and a wildcard bind can
- * appear in both the v4 and v6 tables, so summing wrongly double-counts. Each of those produces a
- * plausible number rather than an error.
+ * parsing finds nothing and reads as "no drops"; the address halves are byte-swapped per 32-bit word,
+ * so a straight hex encoding matches nothing; {@code drops} is the last of thirteen columns, so an
+ * off-by-one lands on {@code pointer} and reports an address as a drop count; and rows must match on
+ * address <em>and</em> port, or a co-located socket sharing the port number gets its loss attributed
+ * to this listener. Each of those produces a plausible number rather than an error.
  *
  * <p>Fixtures are real {@code /proc/net/udp} lines. Port {@code 0x270F} is 9999, riptide's default.
  */
@@ -27,73 +35,139 @@ class UdpSocketDropsTest {
     private static final String HEADER =
             "   sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode ref pointer drops";
 
-    /** A socket row bound to {@code port} (hex) reporting {@code drops}. */
-    private static String row(final String hexPort, final long drops, final int inode) {
-        return "  123: 00000000:" + hexPort + " 00000000:0000 07 00000000:00000000 00:00000000 00000000"
+    private static final Set<String> WILDCARD = UdpSocketDrops.procAddressForms(null);
+
+    /** A socket row bound to {@code hexAddr:hexPort} reporting {@code drops}. */
+    private static String row(final String hexAddr, final String hexPort, final long drops, final int inode) {
+        return "  123: " + hexAddr + ":" + hexPort + " 00000000:0000 07 00000000:00000000 00:00000000 00000000"
                 + "     0        0 " + inode + " 2 0000000000000000 " + drops;
+    }
+
+    private static InetAddress addr(final String literal) {
+        try {
+            return InetAddress.getByName(literal);
+        } catch (final UnknownHostException e) {
+            throw new IllegalArgumentException(literal, e);
+        }
     }
 
     @Test
     void readsTheDropsColumnForTheMatchingHexPort() {
-        final var lines = List.of(HEADER, row("270F", 42, 34567));
+        final var lines = List.of(HEADER, row("00000000", "270F", 42, 34567));
 
-        assertThat(UdpSocketDrops.sumDrops(lines, 9999))
+        assertThat(UdpSocketDrops.sumDrops(lines, WILDCARD, 9999))
                 .as("0x270F is 9999 — the port must be parsed as hex, not decimal")
                 .isEqualTo(42L);
     }
 
     @Test
-    void sumsAcrossEverySocketBoundToThePort() {
-        // SO_REUSEPORT fan-out: several sockets, one port, drops must total rather than take the first
-        final var lines = List.of(HEADER, row("270F", 10, 1), row("270F", 7, 2), row("270F", 5, 3));
+    void sumsAcrossEverySocketBoundToTheSameAddressAndPort() {
+        // SO_REUSEPORT fan-out: several sockets, one bind address, drops must total rather than take
+        // the first
+        final var lines = List.of(HEADER,
+                row("00000000", "270F", 10, 1),
+                row("00000000", "270F", 7, 2),
+                row("00000000", "270F", 5, 3));
 
-        assertThat(UdpSocketDrops.sumDrops(lines, 9999)).isEqualTo(22L);
+        assertThat(UdpSocketDrops.sumDrops(lines, WILDCARD, 9999)).isEqualTo(22L);
     }
 
     @Test
     void ignoresSocketsOnOtherPorts() {
-        final var lines = List.of(HEADER, row("0035", 999, 1), row("270F", 3, 2), row("1F90", 999, 3));
+        final var lines = List.of(HEADER,
+                row("00000000", "0035", 999, 1),
+                row("00000000", "270F", 3, 2),
+                row("00000000", "1F90", 999, 3));
 
-        assertThat(UdpSocketDrops.sumDrops(lines, 9999))
+        assertThat(UdpSocketDrops.sumDrops(lines, WILDCARD, 9999))
                 .as("another service's drops must never be attributed to this listener")
                 .isEqualTo(3L);
     }
 
     @Test
-    void returnsNullWhenNoSocketIsBoundToThePort() {
-        final var lines = List.of(HEADER, row("0035", 12, 1));
+    void ignoresSocketsSharingThePortOnAnotherAddress() {
+        // Two receivers may legitimately share a port on different addresses (ReceiverConfig exposes
+        // host + port per receiver, and nothing validates against duplicates). 10.0.0.2 is byte-swapped
+        // to 0200000A in procfs; the sibling on 10.0.0.3 must not contribute.
+        final var mine = UdpSocketDrops.procAddressForms(addr("10.0.0.2"));
+        final var lines = List.of(HEADER,
+                row("0200000A", "270F", 3, 1),   // 10.0.0.2:9999 — this listener
+                row("0300000A", "270F", 999, 2)); // 10.0.0.3:9999 — a sibling receiver
 
-        assertThat(UdpSocketDrops.sumDrops(lines, 9999))
+        assertThat(UdpSocketDrops.sumDrops(lines, mine, 9999))
+                .as("matching by port alone would attribute the sibling's loss to both receivers")
+                .isEqualTo(3L);
+    }
+
+    @Test
+    void aWildcardBindDoesNotClaimASpecificBindOnTheSamePort() {
+        final var lines = List.of(HEADER,
+                row("00000000", "270F", 4, 1),    // 0.0.0.0:9999 — this listener
+                row("0200000A", "270F", 999, 2)); // 10.0.0.2:9999 — someone else's socket
+
+        assertThat(UdpSocketDrops.sumDrops(lines, WILDCARD, 9999)).isEqualTo(4L);
+    }
+
+    @Test
+    void aDualStackV4BindMatchesItsMappedFormInTheV6Table() {
+        // The JDK opens dual-stack sockets by default, so a bind to 10.0.0.2 can appear in
+        // /proc/net/udp6 as ::ffff:10.0.0.2 — word-swapped to ...FFFF0000 + 0200000A.
+        final var mine = UdpSocketDrops.procAddressForms(addr("10.0.0.2"));
+        final var lines = List.of(HEADER, row("0000000000000000FFFF00000200000A", "270F", 6, 1));
+
+        assertThat(UdpSocketDrops.sumDrops(lines, mine, 9999)).isEqualTo(6L);
+    }
+
+    @Test
+    void procAddressFormsEncodeTheWordSwappedRendering() {
+        assertThat(UdpSocketDrops.procAddressForms(addr("127.0.0.1")))
+                .as("127.0.0.1 renders as 0100007F, not 7F000001")
+                .contains("0100007F");
+        assertThat(UdpSocketDrops.procAddressForms(addr("::1")))
+                .as("::1 renders with its final word swapped")
+                .containsExactly("00000000000000000000000001000000");
+        assertThat(UdpSocketDrops.procAddressForms(null))
+                .as("a wildcard bind matches the all-zeros form in either table")
+                .containsExactlyInAnyOrder("00000000", "0".repeat(32));
+    }
+
+    @Test
+    void returnsNullWhenNoSocketMatches() {
+        final var lines = List.of(HEADER, row("00000000", "0035", 12, 1));
+
+        assertThat(UdpSocketDrops.sumDrops(lines, WILDCARD, 9999))
                 .as("no socket means no drop count — distinct from a socket reporting zero")
                 .isNull();
     }
 
     @Test
     void aBoundSocketWithNoDropsReportsZeroNotNull() {
-        assertThat(UdpSocketDrops.sumDrops(List.of(HEADER, row("270F", 0, 1)), 9999))
+        assertThat(UdpSocketDrops.sumDrops(List.of(HEADER, row("00000000", "270F", 0, 1)), WILDCARD, 9999))
                 .as("zero drops is a real, useful reading and must be distinguishable from absent")
                 .isEqualTo(0L);
     }
 
     @Test
     void toleratesTheHeaderAndAnyMalformedRow() {
-        final var lines = List.of(HEADER, "", "garbage", "  1: nonsense", row("270F", 4, 1));
+        final var lines = List.of(HEADER, "", "garbage", "  1: nonsense", row("00000000", "270F", 4, 1));
 
-        assertThat(UdpSocketDrops.sumDrops(lines, 9999))
+        assertThat(UdpSocketDrops.sumDrops(lines, WILDCARD, 9999))
                 .as("a metrics scrape must not throw on unexpected procfs content")
                 .isEqualTo(4L);
     }
 
     @Test
+    @DisabledOnOs(OS.LINUX)
     void procfsAbsenceYieldsNullRatherThanZero() {
-        // On a machine without /proc/net/udp (macOS, the usual dev box) the gauge must publish no
-        // value. Reporting 0 there would assert "no kernel drops" on a platform that cannot know.
-        final boolean linux = System.getProperty("os.name", "").toLowerCase().contains("linux");
-        if (!linux) {
-            assertThat(UdpSocketDrops.forPort(9999)).isNull();
-        } else {
-            // on Linux the file exists; an unbound port still has no row, so null is expected
-            assertThat(UdpSocketDrops.forPort(1)).isNull();
-        }
+        // Without /proc/net/udp the gauge must publish no value. Reporting 0 here would assert
+        // "no kernel drops" on a platform that cannot know.
+        assertThat(UdpSocketDrops.forSocket(new InetSocketAddress(9999))).isNull();
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void anUnboundSocketYieldsNullOnLinux() {
+        // procfs is present but no socket is bound to UDP port 1: no row, so no drop count.
+        assertThat(UdpSocketDrops.forSocket(new InetSocketAddress(1))).isNull();
     }
 }

--- a/src/test/java/org/riptide/flows/parser/ParserDispatchTest.java
+++ b/src/test/java/org/riptide/flows/parser/ParserDispatchTest.java
@@ -242,6 +242,43 @@ class ParserDispatchTest {
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
+    /**
+     * A Set discarded for a missing Template must be counted. Before this counter the discard was a
+     * {@code LOG.debug} in {@code ipfix/proto/Packet} and nothing else, so on a collector running at
+     * {@code WARN} it was entirely invisible — records gone, every metric reading healthy.
+     */
+    @Test
+    void undecodableSetsAreCounted() throws Exception {
+        final var registry = new MetricRegistry();
+        final var parser = start(new StubParser("undec", registry, true, (s2, f2) -> { }), 1, 16);
+
+        parser.dispatch(FLOWS_PER_PACKET, 2).get(10, TimeUnit.SECONDS);
+
+        assertThat(counter(registry, "undec", "undecodableSets"))
+                .as("Sets, not records: without the Template the record count is unknowable")
+                .isEqualTo(2);
+    }
+
+    /**
+     * The placement guard. A packet whose <em>every</em> Data Set was undecodable builds no flows, so
+     * {@code transmit} returns early — counting after that return would miss exactly the loss the
+     * counter exists to expose, and would do so silently.
+     */
+    @Test
+    void undecodableSetsAreCountedEvenWhenThePacketYieldsNoFlows() throws Exception {
+        final var registry = new MetricRegistry();
+        final var parser = start(new StubParser("undec-only", registry, true, (s2, f2) -> { }), 1, 16);
+
+        final var future = parser.dispatch(0, 3);
+
+        assertThat(counter(registry, "undec-only", "undecodableSets"))
+                .as("counted before the empty-flow early return, or this loss stays invisible")
+                .isEqualTo(3);
+        assertThat(future)
+                .as("a packet with nothing decodable must still complete its future or the buffer leaks")
+                .isCompleted();
+    }
+
     // ---------------------------------------------------------------- helpers
 
     /**
@@ -332,14 +369,19 @@ class ParserDispatchTest {
         }
 
         CompletableFuture<?> dispatch() {
-            return transmit(Instant.now(), packet(), this.session);
+            return transmit(Instant.now(), packet(FLOWS_PER_PACKET, 0), this.session);
         }
 
-        private FlowPacket packet() {
+        /** A packet carrying {@code flowCount} decodable records and {@code undecodable} skipped Sets. */
+        CompletableFuture<?> dispatch(final int flowCount, final int undecodable) {
+            return transmit(Instant.now(), packet(flowCount, undecodable), this.session);
+        }
+
+        private FlowPacket packet(final int flowCount, final int undecodable) {
             return new FlowPacket() {
                 @Override
                 public Stream<Flow> buildFlows(final Instant receivedAt) {
-                    return Stream.generate(() -> FLOW).limit(FLOWS_PER_PACKET);
+                    return Stream.generate(() -> FLOW).limit(flowCount);
                 }
 
                 @Override
@@ -350,6 +392,11 @@ class ParserDispatchTest {
                 @Override
                 public long getSequenceNumber() {
                     return 0;
+                }
+
+                @Override
+                public int undecodableSets() {
+                    return undecodable;
                 }
             };
         }


### PR DESCRIPTION
Closes the actionable half of #394.

### Why

The lab measurement for #394 found the application accounting for **~4% of a ~25% shortfall** under sustained overload, with nothing accounting for the rest. [Rung 1](https://github.com/Riptide-Labs/riptide/issues/394#issuecomment-5136734996) then showed the gap is entirely **load-dependent**: at 50 exporters / ~1,067 records/s, offered and persisted matched *exactly* — 96,000 / 96,000, zero kernel drops, zero template discards, and nl6's bookkeeping honest to the record.

So the loss is real overload loss, not an accounting artefact. The defect is that **almost none of it is observable**. This adds the two counters that make it observable. It does not change any ingest behaviour.

### `listeners.<name>.socketDrops`

Datagrams the kernel discarded on receive-buffer overflow — the one loss no application counter can ever see, because the datagram is gone before any userspace code runs. A collector can shed a quarter of its offered load while every metric it publishes reads healthy.

- Read **per socket** from `/proc/net/udp` + `/proc/net/udp6`, not from `/proc/net/snmp`'s `Udp: RcvbufErrors` — that one is a host-wide total and cannot attribute drops to a receiver.
- Both tables consulted, because a wildcard bind commonly yields one v6 socket serving v4 too; summed across sockets so `SO_REUSEPORT` fan-out totals once rather than per socket.
- Registered after `bind` from the channel's *actual* local address, so an ephemeral bind (`port = 0`) still attributes correctly.
- `remove`-then-`register`, so a restarted listener rebinds to its live socket instead of leaving the previous instance's closure in place.
- On a host without procfs it publishes **no value** — "not measurable here" is not the same as "zero drops".

### `parsers.<name>.undecodableSets`

Data Sets discarded because their Template was unknown. This was a `LOG.debug` in `ipfix/proto/Packet` and nothing else, so at the `WARN` level a collector normally runs at, these records vanished without trace — and being upstream of `recordsReceived`, #391's counters couldn't see them either.

RFC 7011 §8 makes discarding compliant (buffering is a `MAY`, and Cisco's collector behaves the same way), but compliant loss is still loss.

It counts **Sets, not records**, and that isn't a shortcut: without the Template the record size is unknown, so the records inside cannot be counted. Documented as a lower bound.

### Design notes

- The count is threaded through `FlowPacket#undecodableSets()` rather than pushing a `MetricRegistry` into the protocol classes, so `ParserBase` increments once centrally and IPFIX UDP, IPFIX TCP and NetFlow v9 are all covered by one change.
- It is incremented **before** `transmit()`'s empty-flow early return, deliberately: a packet whose *every* Data Set was undecodable builds no flows, so counting afterwards would miss exactly the loss the counter exists to expose. `ParserDispatchTest` pins that placement.

### Verification

Both new tests were checked by injection rather than assumed to work:

| injected defect | result |
|---|---|
| move the increment after the empty-flow early return | placement test fails (`expected: 3L`) |
| parse the socket port as decimal instead of hex | **5 of 7** drop tests fail |

The `/proc` column arithmetic is unit-tested against real `/proc/net/udp` lines because every failure mode there is silent — the port is hex, so decimal parsing finds nothing and reads as "no drops"; `drops` is the last of thirteen columns, so an off-by-one reports a pointer address as a drop count.

841 tests green. Docs site builds with no broken links.

### Docs

`docs/deploy/operations.md` gains both metrics plus the operational guidance: `socketDrops` rising means the socket can't be drained fast enough (raise `net.core.rmem_max` or reduce load), and `undecodableSets` is *expected* to burst at startup since a UDP exporter re-announces Templates only periodically — sustained values are the ones to alert on.

### What this does not do

It doesn't make the remaining overload loss *smaller*, only visible. And it doesn't close #394 entirely — with these counters in place the next lab run can finally do the full subtraction at saturation and say what's left, which is the question #394 should have asked from the start.

Refs #394, #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)