### PR TITLE
refactor(parser): name the session keys and resolvers for what distinguishes them

### DIFF
--- a/src/main/java/org/riptide/flows/parser/ipfix/IpfixUdpParser.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/IpfixUdpParser.java
@@ -84,14 +84,19 @@ public class IpfixUdpParser extends UdpParserBase implements DispatchableUdpPars
 
     @Override
     protected UdpSessionManager.SessionKey buildSessionKey(final InetSocketAddress remoteAddress, final InetSocketAddress localAddress) {
-        return new SessionKey(remoteAddress, localAddress);
+        return new SocketSessionKey(remoteAddress, localAddress);
     }
 
-    public static final class SessionKey implements UdpSessionManager.SessionKey {
+    /**
+     * Keys the session on the full remote <em>socket</em> (address and port) plus the local socket:
+     * an IPFIX UDP Transport Session is per source/destination tuple, so an exporter that moves
+     * source port is a new session. Contrast {@code Netflow9UdpParser.HostSessionKey}.
+     */
+    public static final class SocketSessionKey implements UdpSessionManager.SessionKey {
         private final InetSocketAddress remoteAddress;
         private final InetSocketAddress localAddress;
 
-        public SessionKey(final InetSocketAddress remoteAddress, final InetSocketAddress localAddress) {
+        public SocketSessionKey(final InetSocketAddress remoteAddress, final InetSocketAddress localAddress) {
             this.remoteAddress = remoteAddress;
             this.localAddress = localAddress;
         }
@@ -99,7 +104,7 @@ public class IpfixUdpParser extends UdpParserBase implements DispatchableUdpPars
         @Override
         public boolean equals(final Object o) {
             if (this == o) return true;
-            if (!(o instanceof SessionKey that)) return false;
+            if (!(o instanceof SocketSessionKey that)) return false;
             return Objects.equals(this.localAddress, that.localAddress)
                     && Objects.equals(this.remoteAddress, that.remoteAddress);
         }

--- a/src/main/java/org/riptide/flows/parser/netflow5/Netflow5UdpParser.java
+++ b/src/main/java/org/riptide/flows/parser/netflow5/Netflow5UdpParser.java
@@ -51,6 +51,6 @@ public class Netflow5UdpParser extends UdpParserBase implements DispatchableUdpP
     @Override
     protected UdpSessionManager.SessionKey buildSessionKey(final InetSocketAddress remoteAddress,
                                                            final InetSocketAddress localAddress) {
-        return new Netflow9UdpParser.SessionKey(remoteAddress.getAddress(), localAddress);
+        return new Netflow9UdpParser.HostSessionKey(remoteAddress.getAddress(), localAddress);
     }
 }

--- a/src/main/java/org/riptide/flows/parser/netflow9/Netflow9UdpParser.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/Netflow9UdpParser.java
@@ -77,14 +77,20 @@ public class Netflow9UdpParser extends UdpParserBase implements DispatchableUdpP
 
     @Override
     protected UdpSessionManager.SessionKey buildSessionKey(final InetSocketAddress remoteAddress, final InetSocketAddress localAddress) {
-        return new SessionKey(remoteAddress.getAddress(), localAddress);
+        return new HostSessionKey(remoteAddress.getAddress(), localAddress);
     }
 
-    public static final class SessionKey implements UdpSessionManager.SessionKey {
+    /**
+     * Keys the session on the remote <em>host address</em> plus the local socket, deliberately
+     * ignoring the remote port: NetFlow v9 exporters may hop source ports between packets, and the
+     * templates they announce must survive that. NetFlow v5 and sFlow reuse this key for the same
+     * reason. Contrast {@code IpfixUdpParser.SocketSessionKey}.
+     */
+    public static final class HostSessionKey implements UdpSessionManager.SessionKey {
         private final InetAddress remoteAddress;
         private final InetSocketAddress localAddress;
 
-        public SessionKey(final InetAddress remoteAddress, final InetSocketAddress localAddress) {
+        public HostSessionKey(final InetAddress remoteAddress, final InetSocketAddress localAddress) {
             this.remoteAddress = remoteAddress;
             this.localAddress = localAddress;
         }
@@ -92,7 +98,7 @@ public class Netflow9UdpParser extends UdpParserBase implements DispatchableUdpP
         @Override
         public boolean equals(final Object o) {
             if (this == o) return true;
-            if (!(o instanceof SessionKey that)) return false;
+            if (!(o instanceof HostSessionKey that)) return false;
             return Objects.equals(this.localAddress, that.localAddress)
                     && Objects.equals(this.remoteAddress, that.remoteAddress);
         }

--- a/src/main/java/org/riptide/flows/parser/session/TcpSession.java
+++ b/src/main/java/org/riptide/flows/parser/session/TcpSession.java
@@ -29,10 +29,10 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class TcpSession implements Session {
-    private final class Resolver implements Session.Resolver {
+    private final class DomainResolver implements Session.Resolver {
         private final long observationDomainId;
 
-        private Resolver(final long observationDomainId) {
+        private DomainResolver(final long observationDomainId) {
             this.observationDomainId = observationDomainId;
         }
 
@@ -154,7 +154,7 @@ public class TcpSession implements Session {
 
     @Override
     public Session.Resolver getResolver(final long observationDomainId) {
-        return new Resolver(observationDomainId);
+        return new DomainResolver(observationDomainId);
     }
 
     @Override

--- a/src/main/java/org/riptide/flows/parser/session/UdpSessionManager.java
+++ b/src/main/java/org/riptide/flows/parser/session/UdpSessionManager.java
@@ -344,7 +344,7 @@ public class UdpSessionManager {
 
         @Override
         public Session.Resolver getResolver(final long observationDomainId) {
-            return new Resolver(observationDomainId);
+            return new DomainResolver(observationDomainId);
         }
 
         @Override
@@ -361,16 +361,16 @@ public class UdpSessionManager {
             return tracked.tracker.verify(sequenceNumber, sequenceIncrement);
         }
 
-        private final class Resolver implements Session.Resolver {
+        private final class DomainResolver implements Session.Resolver {
             /**
-             * Built once, not per lookup. A Resolver is bound to one exporter for its lifetime while
+             * Built once, not per lookup. A resolver is bound to one exporter for its lifetime while
              * {@code lookupTemplate}/{@code lookupOptions} run per data record, so rebuilding the key
              * each time cost a DomainKey plus two varargs arrays and a boxed long per record — on the
              * very thread this indexing exists to unload.
              */
             private final DomainKey domain;
 
-            private Resolver(final long observationDomainId) {
+            private DomainResolver(final long observationDomainId) {
                 this.domain = domain(observationDomainId);
             }
 

--- a/src/main/java/org/riptide/flows/parser/sflow/SflowUdpParser.java
+++ b/src/main/java/org/riptide/flows/parser/sflow/SflowUdpParser.java
@@ -55,6 +55,6 @@ public class SflowUdpParser extends UdpParserBase implements DispatchableUdpPars
     @Override
     protected UdpSessionManager.SessionKey buildSessionKey(final InetSocketAddress remoteAddress,
                                                            final InetSocketAddress localAddress) {
-        return new Netflow9UdpParser.SessionKey(remoteAddress.getAddress(), localAddress);
+        return new Netflow9UdpParser.HostSessionKey(remoteAddress.getAddress(), localAddress);
     }
 }

--- a/src/test/java/org/riptide/flows/parser/ParserDispatchTest.java
+++ b/src/test/java/org/riptide/flows/parser/ParserDispatchTest.java
@@ -206,7 +206,7 @@ class ParserDispatchTest {
             @Override
             protected UdpSessionManager.SessionKey buildSessionKey(final InetSocketAddress remote,
                                                                    final InetSocketAddress local) {
-                return new Netflow9UdpParser.SessionKey(remote.getAddress(), local);
+                return new Netflow9UdpParser.HostSessionKey(remote.getAddress(), local);
             }
 
             @Override
@@ -318,7 +318,7 @@ class ParserDispatchTest {
             super(Protocol.IPFIX, name, dispatcher, new Identity("t", "o", "z", "s"), registry);
             this.mayDrop = mayDrop;
             this.session = new UdpSessionManager(Duration.ofMinutes(30), () -> new SequenceNumberTracker(32))
-                    .getSession(new Netflow9UdpParser.SessionKey(REMOTE.getAddress(), LOCAL));
+                    .getSession(new Netflow9UdpParser.HostSessionKey(REMOTE.getAddress(), LOCAL));
         }
 
         @Override

--- a/src/test/java/org/riptide/flows/parser/UdpParserBaseTest.java
+++ b/src/test/java/org/riptide/flows/parser/UdpParserBaseTest.java
@@ -259,7 +259,7 @@ class UdpParserBaseTest {
         @Override
         protected UdpSessionManager.SessionKey buildSessionKey(final InetSocketAddress remoteAddress,
                                                                final InetSocketAddress localAddress) {
-            return new Netflow9UdpParser.SessionKey(remoteAddress.getAddress(), localAddress);
+            return new Netflow9UdpParser.HostSessionKey(remoteAddress.getAddress(), localAddress);
         }
 
         private static FlowPacket packet() {

--- a/src/test/java/org/riptide/flows/parser/session/UdpSessionManagerTest.java
+++ b/src/test/java/org/riptide/flows/parser/session/UdpSessionManagerTest.java
@@ -76,14 +76,14 @@ public class UdpSessionManagerTest {
     }
 
     private void testNetflow9SessionKeys(final InetSocketAddress remote1, final InetSocketAddress local1, final InetSocketAddress remote2, final InetSocketAddress local2, final boolean shouldMatch) {
-        final var sessionKey1 = new Netflow9UdpParser.SessionKey(remote1.getAddress(), local1);
-        final var sessionKey2 = new Netflow9UdpParser.SessionKey(remote2.getAddress(), local2);
+        final var sessionKey1 = new Netflow9UdpParser.HostSessionKey(remote1.getAddress(), local1);
+        final var sessionKey2 = new Netflow9UdpParser.HostSessionKey(remote2.getAddress(), local2);
         testSessionKeys(sessionKey1, sessionKey2, shouldMatch);
     }
 
     private void testIpFixSessionKeys(final InetSocketAddress remote1, final InetSocketAddress local1, final InetSocketAddress remote2, final InetSocketAddress local2, final boolean shouldMatch) {
-        final var sessionKey1 = new IpfixUdpParser.SessionKey(remote1, local1);
-        final var sessionKey2 = new IpfixUdpParser.SessionKey(remote2, local2);
+        final var sessionKey1 = new IpfixUdpParser.SocketSessionKey(remote1, local1);
+        final var sessionKey2 = new IpfixUdpParser.SocketSessionKey(remote2, local2);
         testSessionKeys(sessionKey1, sessionKey2, shouldMatch);
     }
 
@@ -138,7 +138,7 @@ public class UdpSessionManagerTest {
      */
     @Test
     public void optionsRemovalTest() {
-        final var sessionKey = new Netflow9UdpParser.SessionKey(remoteAddress1.getAddress(), localAddress1);
+        final var sessionKey = new Netflow9UdpParser.HostSessionKey(remoteAddress1.getAddress(), localAddress1);
 
         final var udpSessionManager = new UdpSessionManager(Duration.ofMinutes(0), () -> new SequenceNumberTracker(32));
         final var session = udpSessionManager.getSession(sessionKey);
@@ -181,7 +181,7 @@ public class UdpSessionManagerTest {
      */
     @Test
     public void lookupOptionsIsUnaffectedByOtherExporters() {
-        final var sessionKey = new Netflow9UdpParser.SessionKey(remoteAddress1.getAddress(), localAddress1);
+        final var sessionKey = new Netflow9UdpParser.HostSessionKey(remoteAddress1.getAddress(), localAddress1);
         final var manager = new UdpSessionManager(Duration.ofMinutes(5), () -> new SequenceNumberTracker(32));
         final var session = manager.getSession(sessionKey);
 
@@ -203,7 +203,7 @@ public class UdpSessionManagerTest {
         // the same scope names but different values — the shape most likely to leak across
         // exporters if the index were keyed wrongly.
         for (int i = 0; i < 500; i++) {
-            final var otherKey = new Netflow9UdpParser.SessionKey(
+            final var otherKey = new Netflow9UdpParser.HostSessionKey(
                     InetAddress.getLoopbackAddress(), new InetSocketAddress("10.10.10.10", 20000 + i));
             final var other = manager.getSession(otherKey);
             other.addTemplate(observationId1,
@@ -233,7 +233,7 @@ public class UdpSessionManagerTest {
         final var manager = new UdpSessionManager(Duration.ofMinutes(0), () -> new SequenceNumberTracker(32));
 
         for (int i = 0; i < 25; i++) {
-            final var key = new Netflow9UdpParser.SessionKey(
+            final var key = new Netflow9UdpParser.HostSessionKey(
                     InetAddress.getLoopbackAddress(), new InetSocketAddress("10.10.10.10", 30000 + i));
             manager.getSession(key).addTemplate(observationId1,
                     Template.builder(templateId1, Template.Type.TEMPLATE)
@@ -271,7 +271,7 @@ public class UdpSessionManagerTest {
     @Test
     public void concurrentChurnDoesNotLoseTemplatesOrThrow() throws Exception {
         final var manager = new UdpSessionManager(Duration.ofHours(1), () -> new SequenceNumberTracker(32));
-        final var sessionKey = new Netflow9UdpParser.SessionKey(remoteAddress1.getAddress(), localAddress1);
+        final var sessionKey = new Netflow9UdpParser.HostSessionKey(remoteAddress1.getAddress(), localAddress1);
         final var session = manager.getSession(sessionKey);
 
         final var churn = Template.builder(1, Template.Type.TEMPLATE)
@@ -364,7 +364,7 @@ public class UdpSessionManagerTest {
         // two sFlow agents behind ONE UDP source (relay/NAT/shared socket), both
         // sub_agent_id 0: their independent sequence streams must not interleave in
         // a single tracker (which flags spurious errors for gaps within patience)
-        final var sessionKey = new Netflow9UdpParser.SessionKey(remoteAddress1.getAddress(), localAddress1);
+        final var sessionKey = new Netflow9UdpParser.HostSessionKey(remoteAddress1.getAddress(), localAddress1);
         final var manager = new UdpSessionManager(Duration.ofMinutes(30), () -> new SequenceNumberTracker(32));
         final var session = manager.getSession(sessionKey);
 
@@ -380,7 +380,7 @@ public class UdpSessionManagerTest {
 
     @Test
     public void housekeepingEvictsSequenceTrackers() throws Exception {
-        final var sessionKey = new Netflow9UdpParser.SessionKey(remoteAddress1.getAddress(), localAddress1);
+        final var sessionKey = new Netflow9UdpParser.HostSessionKey(remoteAddress1.getAddress(), localAddress1);
         final var manager = new UdpSessionManager(Duration.ofMinutes(0), () -> new SequenceNumberTracker(32));
         final var identity = new ExporterIdentity.Sflow(InetAddress.getByName("10.0.0.1"), 0);
 
@@ -392,7 +392,7 @@ public class UdpSessionManagerTest {
 
     @Test
     public void addOptionsNotifiesTheOptionListener() throws Exception {
-        final var sessionKey = new Netflow9UdpParser.SessionKey(remoteAddress1.getAddress(), localAddress1);
+        final var sessionKey = new Netflow9UdpParser.HostSessionKey(remoteAddress1.getAddress(), localAddress1);
         final var seen = new ArrayList<ExporterIdentity>();
         final var manager = new UdpSessionManager(Duration.ofMinutes(30), () -> new SequenceNumberTracker(32),
                 (identity, scopes, values) -> seen.add(identity));


### PR DESCRIPTION
Addresses the four open CodeQL alerts — three by rename, one by dismissal with evidence.

### Alerts 122–124: `class-name-matches-super-class`

Three nested classes shadowed their supertype's simple name (`SessionKey` twice, `Resolver` once). The renames encode the *semantic* difference instead of restating the type:

| was | now | why this name |
|---|---|---|
| `IpfixUdpParser.SessionKey` | `SocketSessionKey` | an IPFIX UDP Transport Session is per source/destination tuple — the key holds the full remote **socket**, so an exporter that moves source port is a new session |
| `Netflow9UdpParser.SessionKey` | `HostSessionKey` | NetFlow v9 exporters may hop source ports and their templates must survive it — the key deliberately ignores the remote port |
| `UdpSessionManager.Resolver` (private) | `DomainResolver` | bound to one observation domain for its lifetime, which is its whole reason to exist |

Two nice side effects: NetFlow v5 and sFlow borrow the host-keyed key, and their call sites now read as `Netflow9UdpParser.HostSessionKey` — "the host-keyed key" — rather than "the netflow9 parser's key". And each key now carries a short javadoc stating its keying rule and cross-referencing its counterpart, so the port-handling difference is learnable from the declaration instead of by diffing two `equals()` methods.

**Also renamed:** `TcpSession`'s private `Resolver`, which CodeQL has not filed (yet) but is the identical pattern in the sibling class.

Pure rename — no behaviour, no signatures beyond the names. 832 tests green.

### Alert 121: `missing-case-in-switch` — false positive, dismissed with evidence

The alert claims the `reload()` switch in `AsyncReloadingClassificationEngine` "does not have a case for FAILED". The switch at the analyzed commit (`3d5507d`, verified via `git show`) reads:

```java
switch (state) {
    case READY, FAILED -> { ... }
    case RELOADING -> { ... }
}
```

All three `State` constants are covered; `FAILED` sits in the multi-label case. The alert instance is *current* (analyzed at today's `main` HEAD), so this is the query failing to see past the first label of a multi-label arrow case — not stale analysis and not a real gap. Restructuring correct, compiler-verified code to appease a medium-precision query would be the wrong trade, so the alert is dismissed as a false positive with this PR as the paper trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)