### PR TITLE
release: merge v0.7.0 version commits back to main

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.riptide.flows</groupId>
     <artifactId>riptide-flows</artifactId>
-    <version>0.6.7-SNAPSHOT</version>
+    <version>0.7.0</version>
     <name>riptide-flows</name>
     <description>NetFlow analysis engine</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.riptide.flows</groupId>
     <artifactId>riptide-flows</artifactId>
-    <version>0.7.0</version>
+    <version>0.7.1-SNAPSHOT</version>
     <name>riptide-flows</name>
     <description>NetFlow analysis engine</description>
 


### PR DESCRIPTION
Post-release housekeeping per the v0.6.6 pattern (#374): the `release` branch carries the v0.7.0 version commit (tagged) and the 0.7.1-SNAPSHOT bump; merging returns main to snapshot versioning.

Release: https://github.com/Riptide-Labs/riptide/releases/tag/v0.7.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)