### PR TITLE
feat(release): attach a self-contained SBOM HTML report to every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,20 @@ jobs:
           format: spdx-json
           artifact-name: riptide-${{ env.VERSION }}.spdx.json
           output-file: target/riptide-${{ env.VERSION }}.spdx.json
+      # The SPDX file is machine-readable and human-hostile; ship the human answer
+      # beside it. One self-contained HTML file that works offline — verified to
+      # contain no network fetches, only plain <a> links.
+      - name: Render SBOM HTML report
+        uses: no42-org/blitsbom@3f2e7abc338c05d40a15058eafc318fee310e05f # v0.6.1
+        with:
+          sbom: target/riptide-${{ env.VERSION }}.spdx.json
+          output: target/riptide-${{ env.VERSION }}-sbom-report.html
+          # Digest-pinned for immutability: the action's default resolves a mutable
+          # GHCR tag (report-X.Y.Z). This digest MUST move with the `uses:` pin above —
+          # Dependabot bumps that SHA but cannot see this input, so on every action
+          # bump re-resolve with:
+          #   docker buildx imagetools inspect ghcr.io/no42-org/blitsbom:report-X.Y.Z
+          image: ghcr.io/no42-org/blitsbom@sha256:ff58ce61841db40cd530fd231f999b9fcd413f4df506dca45c7bdf3404087a9f # report-0.6.1
       - name: Login to Registry
         uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
         with:
@@ -128,7 +142,7 @@ jobs:
         run: |
           # cosign 3.x writes the sigstore bundle (sig + cert + Rekor proof in one file);
           # the legacy --output-signature/--output-certificate pair no longer works alone.
-          for artifact in target/*.jar target/*.deb target/*.rpm target/*.spdx.json; do
+          for artifact in target/*.jar target/*.deb target/*.rpm target/*.spdx.json target/*-sbom-report.html; do
             cosign sign-blob --yes --bundle "${artifact}.sigstore.json" "${artifact}"
           done
       # Provenance answers a different question than the cosign signature does:
@@ -153,4 +167,5 @@ jobs:
             target/*.deb
             target/*.rpm
             target/*.spdx.json
+            target/*-sbom-report.html
             target/*.sigstore.json

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -58,6 +58,7 @@ disagrees with the version in `pom.xml`, or if that version is a `SNAPSHOT`.
 | `riptide-flows-X.Y.Z.jar` | GitHub Release |
 | `riptide_X.Y.Z_all.deb`, `riptide-X.Y.Z-1.noarch.rpm` | GitHub Release |
 | `riptide-X.Y.Z.spdx.json` (SBOM) | GitHub Release |
+| `riptide-X.Y.Z-sbom-report.html` (self-contained SBOM report, works offline) | GitHub Release |
 | `*.sigstore.json` (cosign bundles) | GitHub Release |
 | Multi-arch image (`linux/amd64`, `linux/arm64`) | `ghcr.io/riptide-labs/riptide` |
 | Build provenance | attached to the release artifacts and pushed to GHCR |


### PR DESCRIPTION
The SPDX file is machine-readable and human-hostile: the "I just want to look at this" case meant squinting at a 5 MB JSON file. This renders that same file into one self-contained HTML report — searchable dependencies, works offline, no backend — attached beside the raw SBOM as `riptide-X.Y.Z-sbom-report.html`. One new step ([`no42-org/blitsbom`](https://github.com/no42-org/blitsbom), SHA-pinned) plus two globs and a doc row.

### Verified before landing, against the real v0.7.0 SPDX asset

- The digest-pinned generator embedded **all 1,545 components and 24 licenses** from `riptide-0.7.0.spdx.json`.
- **Genuinely offline**: the only external references in the output are two plain `<a>` links — no `script`/`link`/`img` fetches.
- Content confirmed via an *uncompressed* render containing the actual dependencies (netty, clickhouse, spring, guava, caffeine). The default output is gzip+base64-embedded, so a naive grep on it proves nothing — worth knowing before anyone "verifies" it that way.

### Decisions (from the OpenSpec change `add-sbom-html-report`)

| decision | choice |
|---|---|
| sign the report? | **yes** — every asset carries a `.sigstore.json`; one glob in the existing loop |
| attest it? | **no** — the release's rule is *products are attested, metadata is signed*; the `.spdx.json` it derives from isn't attested either |
| generator trust | **digest-pinned** (`@sha256:ff58ce6…`) via the action's `image:` input — GHCR tags are mutable, and this was the one reference in an otherwise fully pinned pipeline whose bytes could change without a diff |
| VEX overlay | out of scope, deliberately |

### The one maintenance coupling, stated plainly

Dependabot bumps the action's `uses:` SHA but **cannot see the `image:` digest input**. The rule is *bump both together*; the re-resolve command lives in a comment directly beside the digest so it's discoverable at the point of edit.

### Honest limits

- `actionlint` clean locally; **zizmor runs in this PR's lint gate** (not installed on the dev box).
- The step is **unexercised until the next tag** — release workflows can't be tested by `make jar`. The local container dry-run above covers the render itself; if you want end-to-end proof before a real release, a prerelease tag (`vX.Y.Z-rc1`) is safe: it's marked `--prerelease` and does not move `latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)