### PR TITLE
fix(release): draft the release until every asset is attached

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,9 +158,16 @@ jobs:
           subject-name: ghcr.io/riptide-labs/riptide
           subject-digest: ${{ steps.build-image.outputs.digest }}
           push-to-registry: true
+      # Draft first, publish after: this repo's releases are immutable, so assets can
+      # only be attached BEFORE publication. The action already drafts stable releases
+      # internally, but publishes prereleases first and uploads after — which an
+      # immutable release rejects (v0.7.1-rc1 failed exactly there, with zero assets).
+      # Drafting unconditionally gives both flavours the same, working order.
       - name: Release ${{ github.ref_name }}
+        id: gh_release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
+          draft: true
           prerelease: ${{ env.PRERELEASE == 'true' }}
           files: |
             target/*.jar
@@ -169,3 +176,11 @@ jobs:
             target/*.spdx.json
             target/*-sbom-report.html
             target/*.sigstore.json
+      - name: Publish the draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ steps.gh_release.outputs.id }}
+        run: |
+          # Publication flips the release immutable; every asset is already attached.
+          gh api -X PATCH "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" -F draft=false >/dev/null
+          echo "published release ${RELEASE_ID} for ${GITHUB_REF_NAME}"


### PR DESCRIPTION
Found by the `v0.7.1-rc1` prerelease smoke test (the point of cutting it): the release job failed at asset upload with **zero assets attached**, because this repo's releases are **immutable** and `softprops/action-gh-release` orders create-vs-upload differently per flavour:

| flavour | action's order | on an immutable repo |
|---|---|---|
| stable | draft → attach assets → publish | ✅ v0.7.0 worked |
| prerelease | **publish → attach assets** | ❌ rc1 failed, 0 assets |

### Fix

`draft: true` unconditionally, then an explicit publish step (`PATCH releases/{id} -F draft=false` using the action's `id` output) after all uploads. Publication is what flips immutability on, and by then everything is attached. Both flavours now share the one order that works.

Nothing in this repo subscribes to release webhook events, so a draft prerelease publishing as `release.published` rather than `release.prereleased` changes no downstream behaviour.

### Cleanup already done

The broken rc was an empty immutable prerelease; the release and its tag were deleted (immutability freezes content, not existence — verified), so `v0.7.1-rc1` is reusable for the retest, which I'll run against this fix once merged.

`actionlint` clean; zizmor runs in this PR's lint gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)