### PR TITLE
fix(sbom): scope the release SBOM and resolve the POMs it points at

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,11 +86,14 @@ jobs:
           path: |
             target/*.jar
       # SPDX over the source tree, so the SBOM describes what went into the
-      # build rather than what syft can infer from the finished jar.
+      # build rather than what syft can infer from the finished jar. The scan
+      # is scoped and the POMs resolved by .syft.yaml — without it the report
+      # is mostly undeclared licenses and unknown originators (#402).
       - name: Generate SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           path: .
+          config: .syft.yaml
           format: spdx-json
           artifact-name: riptide-${{ env.VERSION }}.spdx.json
           output-file: target/riptide-${{ env.VERSION }}.spdx.json

--- a/.syft.yaml
+++ b/.syft.yaml
@@ -1,0 +1,24 @@
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Syft configuration for the release SBOM (.github/workflows/release.yml).
+# Passed explicitly via the action's `config` input — do not rely on syft's
+# cwd auto-discovery, which would fail silently and ship a degraded SBOM.
+
+java:
+  # A pom.xml declares dependencies but carries none of their metadata: no
+  # license, no organization, and no version for anything managed by a BOM.
+  # Resolving the POMs is what fills those in. The release job runs `make`
+  # before the SBOM step, so ~/.m2 is already warm and this costs nothing.
+  use-maven-local-repository: true
+  # Fallback for the few POMs a build does not pull into the local repository.
+  use-network: true
+
+# The SBOM describes the release, not the machine that builds it. Both of these
+# trees are cataloged by syft but shipped to nobody, and neither can carry the
+# metadata an SBOM is read for: a package-lock.json has no author field and a
+# workflow file has no license. Left in, they are 94% of the report's "Unknown
+# originator" bucket and 41% of "Undeclared". See #402.
+exclude:
+  - './docs/**'      # docs-site devDependencies (1224 npm packages)
+  - './.github/**'   # our pinned GitHub Actions (44 packages)


### PR DESCRIPTION
Fixes #402.

The `v0.7.1-rc2` SBOM described our CI and docs toolchains more than it described the release, and 87% of it carried no supplier at all. In the HTML report that rendered as a large **Undeclared** slice in *Licenses by Category* and an **Unknown** slice that swallowed *Licenses by Originator*. blitsbom was only rendering what syft emitted, so the fix is in how we invoke syft.

### What was wrong

A `pom.xml` declares dependencies but carries none of their metadata, and syft does not resolve parent POMs or BOMs by default. It saw our dependency list and nothing else: no licenses, and no versions for the 15 entries whose version is managed in a BOM (`spring-boot-starter`, `testcontainers`, …).

At the same time, 1224 of the 1547 packages were `docs/package-lock.json` devDependencies and 44 were our pinned GitHub Actions. A lockfile has no author field and a workflow file has no license, so for those the metadata was not missing but unobtainable. Together they were 94% of the Unknown-originator bucket and 41% of Undeclared.

### The change

A repo-root `.syft.yaml` that scopes the scan to what ships and lets syft read the POMs it is already pointing at. It is passed through the action's `config` input rather than left to syft's cwd auto-discovery, which would fail silently and ship a degraded SBOM; with an explicit `-c` a bad path fails the step instead.

Verified with syft 1.46.0 on the same tree, before → after:

| | baseline | with config |
|---|---|---|
| Undeclared | 8% | **2%** |
| distinct unlicensed names | 67 | **4** |
| Unknown originator | 72% | **42%** |
| ecosystems in the SBOM | maven + npm + github | **maven** |

POM resolution alone takes unlicensed Maven from 141 → 24 and `UNKNOWN` versions from 15 → 8, and it is not slower (5.2s → 4.6s): the release job runs `make` before the SBOM step, so `~/.m2` is already warm and `use-network` is a fallback that rarely fires. Local denominators are inflated by stale jars in my `target/`; the ratios hold.

The deliberate source-tree scan is unchanged — this only drops the two trees that ship to nobody.

`actionlint` clean; zizmor runs in this PR's lint gate.

### Follow-ups, tracked in #402 and not in scope here

- The root `.` entry is still `NOASSERTION`, so the SBOM does not state our own GPL-3.0-or-later.
- `RoaringBitmap`, JetBrains `annotations` and `mavenEcjBootstrapAgent` do declare a license in their POMs, but as free text ("Apache 2") that syft fails to map to an SPDX ID.
- Originator stays ~42% unknown because syft only fills `supplier` from a jar manifest. Best fixed in blitsbom by falling back to the purl namespace, which fixes every report and does not mutate the signed SBOM.
