### PR TITLE
fix(sbom): stop double-counting the inventory and shipping lombok

### DIFF
--- a/.syft.yaml
+++ b/.syft.yaml
@@ -20,5 +20,9 @@ java:
 # workflow file has no license. Left in, they are 94% of the report's "Unknown
 # originator" bucket and 41% of "Undeclared". See #402.
 exclude:
-  - './docs/**'      # docs-site devDependencies (1224 npm packages)
-  - './.github/**'   # our pinned GitHub Actions (44 packages)
+  - './docs/**'            # docs-site devDependencies (1224 npm packages)
+  - './.github/**'         # our pinned GitHub Actions (44 packages)
+  # `make packages` stages a copy of the release jar for nfpm. Scanning both it
+  # and target/*.jar listed every dependency twice: v0.7.1-rc3 reported 276
+  # Maven packages for 127 distinct purls.
+  - './target/package/**'  # nfpm staging copy of the release jar

--- a/pom.xml
+++ b/pom.xml
@@ -264,6 +264,20 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <!-- Lombok is declared <scope>provided</scope>, but repackage
+                         bundles provided-scope dependencies into BOOT-INF/lib
+                         anyway. It is a compile-time annotation processor with
+                         nothing left to do at runtime, and it carries a nested
+                         lombok/launch/mavenEcjBootstrapAgent.jar that syft
+                         catalogs as an unversioned, unlicensed package. -->
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Part of #404. Two independent problems the `v0.7.1-rc3` report exposed once #403 cleared the npm and GitHub Actions noise out of the way. Both fixes are configuration.

### The inventory was counted twice

`v0.7.1-rc3` reports **276 Maven packages for 127 distinct purls**. `make packages` stages a copy of the release jar at `target/package/riptide.jar` for nfpm, and syft cataloged both that and `target/*.jar` — 123 packages each — plus 30 from `pom.xml`. Every dependency appeared twice, which is also why every row in the Undeclared table was doubled.

Excluding the staging copy leaves one row per dependency.

### Lombok was shipping inside the release jar

The `mavenEcjBootstrapAgent UNKNOWN` rows are not a dependency of ours. They are `lombok/launch/mavenEcjBootstrapAgent.jar`, a 3 KB jar nested inside `lombok-1.18.46.jar` that syft descends into and reports as an unversioned, unlicensed package.

The real problem is that lombok is in `BOOT-INF/lib` at all. It is declared `<scope>provided</scope>` (`pom.xml:159`), but `spring-boot-maven-plugin`'s repackage goal bundles provided-scope dependencies regardless, so a compile-time annotation processor with nothing to do at runtime has been riding along in every release.

Lombok's annotations are `SOURCE`/`CLASS` retention and nothing resolves it at runtime, so excluding it from the fat jar is safe. The `annotationProcessorPaths` entry that actually drives code generation (`pom.xml:274`) is untouched.

### Verification

`make jar` clean, then scanning the freshly built artifact:

```
packages in the freshly built jar: 122   (was 124)
  lombok: 0
  mavenEcjBootstrapAgent: 0
  undeclared: RoaringBitmap, annotations, <the jar itself>
```

And on a full tree scan with the new config, `from target/package: 0`.

The three remaining undeclared entries are the ones syft cannot derive, tracked in #405 (Apache-2.0 for the two dependencies that ship no Maven metadata) and #406 (our own GPL-3.0-or-later).
