### PR TITLE
feat(dashboards): add cross-dashboard drill-down links to Flow Forensics

### DIFF
--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-behavioural-anomalies.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-behavioural-anomalies.json
@@ -141,7 +141,7 @@
             "$__all"
           ]
         },
-        "definition": "SELECT DISTINCT exporterAddr ... FROM ${database}.flows"
+        "definition": "SELECT exporterAddr AS __value, if(argMax(exporterName, receivedAt) != '', argMax(exporterName, receivedAt), exporterAddr) AS __text FROM ${database}.flows GROUP BY exporterAddr ORDER BY __text"
       },
       {
         "name": "min_ports",

--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-behavioural-anomalies.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-behavioural-anomalies.json
@@ -126,7 +126,7 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "SELECT DISTINCT exporterAddr AS __value, if(exporterName != '', concat(exporterName, ' (', exporterAddr, ')'), exporterAddr) AS __text FROM ${database}.flows ORDER BY __text"
+          "rawSql": "SELECT exporterAddr AS __value, if(argMax(exporterName, receivedAt) != '', argMax(exporterName, receivedAt), exporterAddr) AS __text FROM ${database}.flows GROUP BY exporterAddr ORDER BY __text"
         },
         "refresh": 1,
         "includeAll": true,
@@ -572,6 +572,23 @@
                 "value": "bytes"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Source"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Slice flows from this source (Flow Forensics)",
+                    "url": "/d/riptide-flow-forensics?${datasource:queryparam}&${database:queryparam}&${tenant:queryparam}&${zone:queryparam}&${exporter:queryparam}&var-src=${__data.fields.Source}&from=${__from}&to=${__to}"
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -645,6 +662,23 @@
               {
                 "id": "unit",
                 "value": "bytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Source"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Slice flows from this source (Flow Forensics)",
+                    "url": "/d/riptide-flow-forensics?${datasource:queryparam}&${database:queryparam}&${tenant:queryparam}&${zone:queryparam}&${exporter:queryparam}&var-src=${__data.fields.Source}&from=${__from}&to=${__to}"
+                  }
+                ]
               }
             ]
           }
@@ -722,6 +756,40 @@
                 "value": "bytes"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Source"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Slice flows from this source (Flow Forensics)",
+                    "url": "/d/riptide-flow-forensics?${datasource:queryparam}&${database:queryparam}&${tenant:queryparam}&${zone:queryparam}&${exporter:queryparam}&var-src=${__data.fields.Source}&from=${__from}&to=${__to}"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Destination"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Slice flows to this service port (Flow Forensics)",
+                    "url": "/d/riptide-flow-forensics?${datasource:queryparam}&${database:queryparam}&${tenant:queryparam}&${zone:queryparam}&${exporter:queryparam}&var-dst=${__data.fields.Destination}&var-dst_port=${__data.fields.Port}&from=${__from}&to=${__to}"
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -795,6 +863,23 @@
               {
                 "id": "unit",
                 "value": "bps"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Target"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Slice flows to this target (Flow Forensics)",
+                    "url": "/d/riptide-flow-forensics?${datasource:queryparam}&${database:queryparam}&${tenant:queryparam}&${zone:queryparam}&${exporter:queryparam}&var-dst=${__data.fields.Target}&from=${__from}&to=${__to}"
+                  }
+                ]
               }
             ]
           }
@@ -882,6 +967,23 @@
               {
                 "id": "unit",
                 "value": "bytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Source"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Slice this conversation (Flow Forensics)",
+                    "url": "/d/riptide-flow-forensics?${datasource:queryparam}&${database:queryparam}&${tenant:queryparam}&${zone:queryparam}&${exporter:queryparam}&var-src=${__data.fields.Source}&var-dst=${__data.fields.Destination}&from=${__from}&to=${__to}"
+                  }
+                ]
               }
             ]
           }

--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-capacity-routing.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-capacity-routing.json
@@ -126,7 +126,7 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "SELECT DISTINCT exporterAddr AS __value, if(exporterName != '', concat(exporterName, ' (', exporterAddr, ')'), exporterAddr) AS __text FROM ${database}.flows ORDER BY __text"
+          "rawSql": "SELECT exporterAddr AS __value, if(argMax(exporterName, receivedAt) != '', argMax(exporterName, receivedAt), exporterAddr) AS __text FROM ${database}.flows GROUP BY exporterAddr ORDER BY __text"
         },
         "refresh": 1,
         "includeAll": true,
@@ -526,6 +526,47 @@
                 "value": "percent"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ExporterAddr"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "IfIndex"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Interface"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Analyse this interface (Interface Traffic Analysis)",
+                    "url": "/d/riptide-interface-traffic-analysis?${datasource:queryparam}&${database:queryparam}&var-exporter=${__data.fields.ExporterAddr}&var-interface=${__data.fields.IfIndex}&from=${__from}&to=${__to}"
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -550,7 +591,7 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "WITH util AS (\n  SELECT concat(if(exporterName != '', exporterName, exporterAddr), ' - ', ifNull(inputSnmpIfName, concat('if', toString(inputSnmp)))) AS iface, timestamp, sum(bytes) * 8 / 60 AS bps,\n         max(inputSnmpIfSpeed) * 1000000 AS speed_bps\n  FROM ${database}.samples(ival = 60)\n  WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND inputSnmpIfSpeed > 0 AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL 60 SECOND\n  GROUP BY iface, timestamp)\nSELECT iface AS \"Interface\", max(speed_bps) AS \"Link speed\",\n       quantile(0.95)(bps) AS \"p95 load\", max(bps) AS \"Peak load\",\n       round(100 * quantile(0.95)(bps) / nullIf(max(speed_bps), 0), 2) AS \"p95 % of capacity\"\nFROM util GROUP BY iface ORDER BY \"p95 % of capacity\" DESC LIMIT 50",
+          "rawSql": "WITH util AS (\n  SELECT exporterAddr AS eaddr, inputSnmp AS ifidx, concat(if(exporterName != '', exporterName, exporterAddr), ' - ', ifNull(inputSnmpIfName, concat('if', toString(inputSnmp)))) AS iface, timestamp, sum(bytes) * 8 / 60 AS bps,\n         max(inputSnmpIfSpeed) * 1000000 AS speed_bps\n  FROM ${database}.samples(ival = 60)\n  WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND inputSnmpIfSpeed > 0 AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL 60 SECOND\n  GROUP BY eaddr, ifidx, iface, timestamp)\nSELECT iface AS \"Interface\", any(eaddr) AS \"ExporterAddr\", toString(any(ifidx)) AS \"IfIndex\", max(speed_bps) AS \"Link speed\",\n       quantile(0.95)(bps) AS \"p95 load\", max(bps) AS \"Peak load\",\n       round(100 * quantile(0.95)(bps) / nullIf(max(speed_bps), 0), 2) AS \"p95 % of capacity\"\nFROM util GROUP BY iface ORDER BY \"p95 % of capacity\" DESC LIMIT 50",
           "refId": "A",
           "meta": {
             "timezone": "UTC"
@@ -674,6 +715,40 @@
               {
                 "id": "unit",
                 "value": "bytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Endpoint A"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Slice A \u2192 B flows (Flow Forensics)",
+                    "url": "/d/riptide-flow-forensics?${datasource:queryparam}&${database:queryparam}&${tenant:queryparam}&${zone:queryparam}&${exporter:queryparam}&var-src=${__data.fields[\"Endpoint A\"]}&var-dst=${__data.fields[\"Endpoint B\"]}&from=${__from}&to=${__to}"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Endpoint B"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Slice B \u2192 A flows (Flow Forensics)",
+                    "url": "/d/riptide-flow-forensics?${datasource:queryparam}&${database:queryparam}&${tenant:queryparam}&${zone:queryparam}&${exporter:queryparam}&var-src=${__data.fields[\"Endpoint B\"]}&var-dst=${__data.fields[\"Endpoint A\"]}&from=${__from}&to=${__to}"
+                  }
+                ]
               }
             ]
           }

--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-capacity-routing.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-capacity-routing.json
@@ -141,7 +141,7 @@
             "$__all"
           ]
         },
-        "definition": "SELECT DISTINCT exporterAddr ... FROM ${database}.flows"
+        "definition": "SELECT exporterAddr AS __value, if(argMax(exporterName, receivedAt) != '', argMax(exporterName, receivedAt), exporterAddr) AS __text FROM ${database}.flows GROUP BY exporterAddr ORDER BY __text"
       }
     ]
   },
@@ -591,7 +591,7 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "WITH util AS (\n  SELECT exporterAddr AS eaddr, inputSnmp AS ifidx, concat(if(exporterName != '', exporterName, exporterAddr), ' - ', ifNull(inputSnmpIfName, concat('if', toString(inputSnmp)))) AS iface, timestamp, sum(bytes) * 8 / 60 AS bps,\n         max(inputSnmpIfSpeed) * 1000000 AS speed_bps\n  FROM ${database}.samples(ival = 60)\n  WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND inputSnmpIfSpeed > 0 AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL 60 SECOND\n  GROUP BY eaddr, ifidx, iface, timestamp)\nSELECT iface AS \"Interface\", any(eaddr) AS \"ExporterAddr\", toString(any(ifidx)) AS \"IfIndex\", max(speed_bps) AS \"Link speed\",\n       quantile(0.95)(bps) AS \"p95 load\", max(bps) AS \"Peak load\",\n       round(100 * quantile(0.95)(bps) / nullIf(max(speed_bps), 0), 2) AS \"p95 % of capacity\"\nFROM util GROUP BY iface ORDER BY \"p95 % of capacity\" DESC LIMIT 50",
+          "rawSql": "WITH util AS (\n  SELECT exporterAddr AS eaddr, inputSnmp AS ifidx, concat(if(exporterName != '', exporterName, exporterAddr), ' - ', ifNull(inputSnmpIfName, concat('if', toString(inputSnmp)))) AS iface, timestamp, sum(bytes) * 8 / 60 AS bps,\n         max(inputSnmpIfSpeed) * 1000000 AS speed_bps\n  FROM ${database}.samples(ival = 60)\n  WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND inputSnmpIfSpeed > 0 AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL 60 SECOND\n  GROUP BY eaddr, ifidx, iface, timestamp)\nSELECT iface AS \"Interface\", eaddr AS \"ExporterAddr\", toString(ifidx) AS \"IfIndex\", max(speed_bps) AS \"Link speed\",\n       quantile(0.95)(bps) AS \"p95 load\", max(bps) AS \"Peak load\",\n       round(100 * quantile(0.95)(bps) / nullIf(max(speed_bps), 0), 2) AS \"p95 % of capacity\"\nFROM util GROUP BY eaddr, ifidx, iface ORDER BY \"p95 % of capacity\" DESC LIMIT 50",
           "refId": "A",
           "meta": {
             "timezone": "UTC"

--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-data-trust.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-data-trust.json
@@ -622,7 +622,25 @@
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Address"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Slice flows from this exporter (Flow Forensics)",
+                    "url": "/d/riptide-flow-forensics?${datasource:queryparam}&${database:queryparam}&${tenant:queryparam}&${zone:queryparam}&var-exporter=${__data.fields.Address}&from=${__from}&to=${__to}"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
       "options": {
         "showHeader": true,

--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-top-10.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-top-10.json
@@ -1106,6 +1106,35 @@
                 "value": 320
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AsNum"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Src AS"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Slice flows from this AS (Flow Forensics)",
+                    "url": "/d/riptide-flow-forensics?${datasource:queryparam}&${database:queryparam}&${tenant:queryparam}&${zone:queryparam}&var-src_as=${__data.fields.AsNum}&from=${__from}&to=${__to}"
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -1127,7 +1156,7 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "WITH top AS (SELECT srcAs AS dim FROM ${database}.flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10),\n     intDiv(toUnixTimestamp($__toTime), 300)\n       - intDiv(toUnixTimestamp($__fromTime) + 300 - 1, 300) + 1 AS nBuckets,\n     arrayResize(groupArray(bps), greatest(nBuckets, length(groupArray(bps))), 0.) AS padded\nSELECT series AS \"Src AS\",\n       arrayMin(padded) AS \"Min\", arrayMax(padded) AS \"Max\", argMax(bps, time) AS \"Last\",\n       arrayAvg(padded) AS \"Average\", arrayReduce('quantile(0.95)', padded) AS \"95th\",\n       sum(bucket_bytes) AS \"Total\"\nFROM (\n    SELECT timestamp AS time, concat(toString(srcAs), ': ', ifNull(srcAsOrg, 'unknown')) AS series,\n           sum(bytes) * 8 / 300 AS bps, sum(bytes) AS bucket_bytes\n    FROM ${database}.samples(ival = 300)\n    WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL 300 SECOND AND srcAs IN (SELECT dim FROM top)\n      AND timestamp < toStartOfInterval(now(), toIntervalSecond(300))\n    GROUP BY time, series\n)\nGROUP BY series\nORDER BY \"Average\" DESC",
+          "rawSql": "WITH top AS (SELECT srcAs AS dim FROM ${database}.flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) GROUP BY dim ORDER BY sum(bytes) DESC LIMIT 10),\n     intDiv(toUnixTimestamp($__toTime), 300)\n       - intDiv(toUnixTimestamp($__fromTime) + 300 - 1, 300) + 1 AS nBuckets,\n     arrayResize(groupArray(bps), greatest(nBuckets, length(groupArray(bps))), 0.) AS padded\nSELECT series AS \"Src AS\", any(as_num) AS \"AsNum\",\n       arrayMin(padded) AS \"Min\", arrayMax(padded) AS \"Max\", argMax(bps, time) AS \"Last\",\n       arrayAvg(padded) AS \"Average\", arrayReduce('quantile(0.95)', padded) AS \"95th\",\n       sum(bucket_bytes) AS \"Total\"\nFROM (\n    SELECT timestamp AS time, concat(toString(srcAs), ': ', ifNull(srcAsOrg, 'unknown')) AS series,\n           sum(bytes) * 8 / 300 AS bps, sum(bytes) AS bucket_bytes, any(srcAs) AS as_num\n    FROM ${database}.samples(ival = 300)\n    WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(flowLocality = '$locality', $locality) AND lastSwitched >= $__fromTime AND deltaSwitched <= $__toTime + INTERVAL 300 SECOND AND srcAs IN (SELECT dim FROM top)\n      AND timestamp < toStartOfInterval(now(), toIntervalSecond(300))\n    GROUP BY time, series\n)\nGROUP BY series\nORDER BY \"Average\" DESC",
           "refId": "A",
           "meta": {
             "timezone": "UTC"

--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-traffic-composition.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-traffic-composition.json
@@ -126,7 +126,7 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "SELECT DISTINCT exporterAddr AS __value, if(exporterName != '', concat(exporterName, ' (', exporterAddr, ')'), exporterAddr) AS __text FROM ${database}.flows ORDER BY __text"
+          "rawSql": "SELECT exporterAddr AS __value, if(argMax(exporterName, receivedAt) != '', argMax(exporterName, receivedAt), exporterAddr) AS __text FROM ${database}.flows GROUP BY exporterAddr ORDER BY __text"
         },
         "refresh": 1,
         "includeAll": true,
@@ -704,6 +704,35 @@
                 "value": "bytes"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ServerAddr"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Server"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Slice flows to this server (Flow Forensics)",
+                    "url": "/d/riptide-flow-forensics?${datasource:queryparam}&${database:queryparam}&${tenant:queryparam}&${zone:queryparam}&${exporter:queryparam}&var-dst=${__data.fields.ServerAddr}&from=${__from}&to=${__to}"
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -728,7 +757,7 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "SELECT transform(dstPort,\n         [53, 67, 68, 123, 161, 162, 389, 514, 636, 1812, 1813, 5353],\n         ['DNS', 'DHCP', 'DHCP', 'NTP', 'SNMP', 'SNMP trap', 'LDAP',\n          'Syslog', 'LDAPS', 'RADIUS auth', 'RADIUS acct', 'mDNS'],\n         'other') AS \"Service\",\n       ifNull(dstAddrHostname, replaceOne(toString(dstAddr), '::ffff:', '')) AS \"Server\",\n       uniqExact(srcAddr) AS \"Clients\", count() AS \"Flows\",\n       sum(bytes) AS \"Bytes\"\nFROM ${database}.flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND $__conditionalAll(flowLocality = '$locality', $locality)\n  AND dstPort IN (53, 67, 68, 123, 161, 162, 389, 514, 636, 1812, 1813, 5353)\nGROUP BY \"Service\", \"Server\" ORDER BY \"Flows\" DESC LIMIT 50",
+          "rawSql": "SELECT transform(dstPort,\n         [53, 67, 68, 123, 161, 162, 389, 514, 636, 1812, 1813, 5353],\n         ['DNS', 'DHCP', 'DHCP', 'NTP', 'SNMP', 'SNMP trap', 'LDAP',\n          'Syslog', 'LDAPS', 'RADIUS auth', 'RADIUS acct', 'mDNS'],\n         'other') AS \"Service\",\n       ifNull(dstAddrHostname, replaceOne(toString(dstAddr), '::ffff:', '')) AS \"Server\", any(replaceOne(toString(dstAddr), '::ffff:', '')) AS \"ServerAddr\",\n       uniqExact(srcAddr) AS \"Clients\", count() AS \"Flows\",\n       sum(bytes) AS \"Bytes\"\nFROM ${database}.flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone) AND $__conditionalAll(exporterAddr IN (${exporter:singlequote}), $exporter) AND $__conditionalAll(flowLocality = '$locality', $locality)\n  AND dstPort IN (53, 67, 68, 123, 161, 162, 389, 514, 636, 1812, 1813, 5353)\nGROUP BY \"Service\", \"Server\" ORDER BY \"Flows\" DESC LIMIT 50",
           "refId": "A",
           "meta": {
             "timezone": "UTC"

--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-traffic-composition.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-traffic-composition.json
@@ -141,7 +141,7 @@
             "$__all"
           ]
         },
-        "definition": "SELECT DISTINCT exporterAddr ... FROM ${database}.flows"
+        "definition": "SELECT exporterAddr AS __value, if(argMax(exporterName, receivedAt) != '', argMax(exporterName, receivedAt), exporterAddr) AS __text FROM ${database}.flows GROUP BY exporterAddr ORDER BY __text"
       },
       {
         "name": "locality",


### PR DESCRIPTION
Adds row-level drill-down links to the dashboards introduced in #408 so a table row can pivot straight into Flow Forensics (or Interface Traffic Analysis) with the time range and shared filters carried over.

## What changed

- **Behavioural Anomalies**: Source/Destination/Target/conversation rows link into Flow Forensics with `var-src`/`var-dst`/`var-dst_port` pre-filled.
- **Capacity & Routing**: the interface headroom table gains hidden `ExporterAddr`/`IfIndex` columns feeding an "Analyse this interface" link into Interface Traffic Analysis; endpoint-pair rows link A→B and B→A slices.
- **Traffic Composition**: infrastructure-service rows link to the serving address via a hidden `ServerAddr` column.
- **Data Trust**: exporter rows link to a per-exporter forensics slice.
- **Top 10**: Src AS rows link via a hidden `AsNum` column.
- The exporter variable on the three new dashboards now dedupes renamed exporters via `argMax(exporterName, receivedAt)`, matching Flow Forensics / Traffic Paths.

## Known caveats from pre-PR review

A medium-effort review confirmed these issues. Items 1 and 5 are fixed in 582d8dd; the rest are left for follow-up or discussion rather than silently shipped:

1. **Headroom table label collision** (`riptide-capacity-routing.json`): outer `GROUP BY iface` with `any(eaddr)`/`any(ifidx)` merges two devices sharing an exporterName + ifName into one row, links to an arbitrary one, and the new inner `GROUP BY eaddr, ifidx` changes p95/Peak semantics for colliding labels. **Fixed in 582d8dd**: the outer query now groups by `(eaddr, ifidx, iface)`.
2. **Multi-address hostnames** (`riptide-traffic-composition.json`): rows group by hostname but `ServerAddr = any(addr)`, so dual-stack/anycast servers drill into a fraction of the row's traffic.
3. **Locality filter lost on drill-down** (`riptide-top-10.json`): Flow Forensics has no locality variable, so locality-scoped rows drill into an all-locality view.
4. **Exporter dropdown lost the `(addr)` suffix**: two exporters with the same name now render identical labels. This converges on the existing convention in the other three dashboards; restoring the suffix should touch all six copies.
5. **Stale `definition` strings**: the three edited exporter variables carried the old `SELECT DISTINCT ...` in `definition` while `rawSql` was updated. **Fixed in 582d8dd**.
6. **Service rows link without a port filter** (`riptide-traffic-composition.json`): needs a port column in the query to scope the slice to the clicked service.
7. **Sticky variables**: the new links pin 5 of forensics' 17 variables; forensics' own internal links enumerate all of them so leftover session filters reset.
8. **`var-src_as=0`** may be dropped by forensics' option list (`WHERE srcAs != 0`), Grafana-version dependent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

