### PR TITLE
feat(sbom): assert our own license on the deb and document root

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,9 @@ jobs:
             echo "SHORT_GIT_SHA=$(git rev-parse --short HEAD)"
             echo "BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
           } >> "${GITHUB_ENV}"
+      - name: SBOM assertion fixture tests
+        run: |
+          make sbom-assert-test
       - name: Build with tests
         run: |
           make

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,21 @@ jobs:
           format: spdx-json
           artifact-name: riptide-${{ env.VERSION }}.spdx.json
           output-file: target/riptide-${{ env.VERSION }}.spdx.json
+          # Both uploads happen inside this step, BEFORE the assertion below:
+          # the artifact would persist the unasserted SBOM under the same name
+          # as the release asset, and on a workflow re-run the action finds the
+          # existing release and replaces the corrected asset with a raw one.
+          # The release asset is attached later from target/, post-assertion.
+          upload-artifact: false
+          upload-release-assets: false
+      # Facts syft cannot derive: our own license on the deb entry (a deb control
+      # file has no license field) and on the document root (syft has no flag for
+      # it). Asserted here — before the HTML render and the later signing — so the
+      # machine-readable file, the report, and the signed asset agree. Fails the
+      # release rather than shipping NOASSERTION if the SBOM shape drifts (#406).
+      - name: Assert first-party license facts in the SBOM
+        run: |
+          make sbom-assert SBOM="target/riptide-${VERSION}.spdx.json"
       # The SPDX file is machine-readable and human-hostile; ship the human answer
       # beside it. One self-contained HTML file that works offline — verified to
       # contain no network fetches, only plain <a> links.

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ _bmad-output/
 _bmad/
 openspec/
 .claude/
+__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,8 @@ help:
 	@echo "  oci:          Build OCI container image"
 	@echo "  packages:     Build DEB and RPM packages from the jar (requires Docker)"
 	@echo "  packages-smoke: Install the packages in Debian and Rocky containers and smoke-test them (requires Docker)"
+	@echo "  sbom-assert:  Assert first-party license facts in a release SBOM; SBOM=<path to .spdx.json>"
+	@echo "  sbom-assert-test: Run the SBOM assertion script's fixture tests"
 	@echo "  nix:          Build the flake package from source (requires Nix)"
 	@echo "  nix-check:    Run the flake checks incl. the NixOS module eval (requires Nix)"
 	@echo "  nix-hash:     Regenerate nix/package.nix's mvnHash after a pom change (requires Nix)"
@@ -142,6 +144,18 @@ packages: deps-oci
 .PHONY: packages-smoke
 packages-smoke: deps-oci
 	deployment/package/smoke-test.sh $(PKG_VERSION)
+
+# Sets licenseDeclared on the SBOM entries syft cannot fill for us (the deb and
+# the document root, issue #406). Runs in release.yml between SBOM generation
+# and the HTML report render; fails if the SBOM shape drifted.
+.PHONY: sbom-assert
+sbom-assert:
+	@test -n "$(SBOM)" || { echo "usage: make sbom-assert SBOM=target/riptide-<version>.spdx.json"; exit 1; }
+	python3 deployment/sbom/assert_licenses.py $(SBOM)
+
+.PHONY: sbom-assert-test
+sbom-assert-test:
+	python3 -m unittest discover -s deployment/sbom
 
 .PHONY: deps-nix
 deps-nix:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -66,6 +66,9 @@ disagrees with the version in `pom.xml`, or if that version is a `SNAPSHOT`.
 The release is published immediately — it is not a draft. Write the release
 notes afterwards with `gh release edit vX.Y.Z --notes-file notes.md`.
 
+The attached SBOM contains post-generation first-party license assertions: syft cannot read our license from a deb control file or attach one to the scanned directory, so `make sbom-assert` sets `licenseDeclared: GPL-3.0-or-later` (read from `nfpm.yaml`) on those two entries before the report is rendered and the file is signed.
+A release that fails at the "Assert first-party license facts" step means the SBOM shape drifted (typically after a syft upgrade) and the selectors in `deployment/sbom/assert_licenses.py` no longer match exactly one entry each — fix the selector, never ship `NOASSERTION`.
+
 ### Container image tags
 
 | Tag | Points at |

--- a/deployment/package/copyright
+++ b/deployment/package/copyright
@@ -1,0 +1,28 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: riptide
+Source: https://github.com/Riptide-Labs/riptide
+Comment: The license short name is the SPDX identifier GPL-3.0-or-later rather
+ than the DEP-5 keyword GPL-3+, deliberately: it matches the LICENSE file, the
+ source headers, nfpm.yaml, and the release SBOM, and the packaging smoke test
+ greps for exactly this string.
+
+Files: *
+Copyright: 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+License: GPL-3.0-or-later
+
+License: GPL-3.0-or-later
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ .
+ On Debian systems, the complete text of the GNU General Public License
+ version 3 can be found in "/usr/share/common-licenses/GPL-3".

--- a/deployment/package/smoke-test.sh
+++ b/deployment/package/smoke-test.sh
@@ -19,6 +19,7 @@ ASSERTIONS='
   java --version | head -1 | grep -q "openjdk 25" || { echo "FAIL: no Java 25 runtime"; exit 1; }
   test -f /usr/share/riptide/riptide.jar
   test -f /usr/lib/systemd/system/riptide.service
+  grep -q "^License: GPL-3.0-or-later" /usr/share/doc/riptide/copyright || { echo "FAIL: copyright file missing or wrong license"; exit 1; }
   [ "$(stat -c "%U:%G %a" /etc/riptide/config.yaml)" = "root:riptide 640" ]
   [ "$(stat -c "%U:%G %a" /etc/riptide/riptide.env)" = "root:riptide 640" ]
   id riptide >/dev/null

--- a/deployment/sbom/assert_licenses.py
+++ b/deployment/sbom/assert_licenses.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Assert first-party license facts in the release SBOM (issue #406).
+
+Syft cannot derive our own license for two of the three entries that describe
+what we ship: a deb control file has no license field, and syft has no flag to
+attach a license to the scanned directory. This script sets `licenseDeclared`
+on exactly those two entries after generation. It runs between SBOM generation
+and the HTML report render in the release workflow, so the machine-readable
+file, the human-readable report, and the signed asset are the same corrected
+document.
+
+The license string is read from nfpm.yaml (`license:`) rather than hardcoded,
+so this assertion cannot disagree with what nfpm writes into the RPM header.
+The rpm entry is cross-checked, not rewritten: a mismatch there means the
+sources of truth have drifted and the release must not ship.
+
+Every selector must match exactly one package; zero or multiple matches exit
+non-zero. The silent failure mode — a selector drifting after a syft upgrade
+and NOASSERTION shipping again — is the bug class this script exists to
+remove, so it fails the release instead.
+
+licenseDeclared is the correct SPDX field here: we are the package author,
+and nfpm.yaml/pom.xml/LICENSE are our declaration. licenseConcluded stays
+reserved for third-party review (#405).
+
+Spike outcome (2026-08-04, syft latest): the dpkg cataloger DOES read
+usr/share/doc/riptide/copyright when scanning a .deb archive, but derives the
+noisy expression `GPL-3.0-only AND GPL-3.0-or-later` from the DEP-5 text (the
+GPL-3 full-text reference matches both ids). The assertion here normalizes it,
+which is why it stays unconditional rather than trusting the cataloger.
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def read_license(nfpm_path: Path) -> str:
+    """Extract the `license:` value from nfpm.yaml without a YAML dependency."""
+    matches = re.findall(r"^license:\s*(\S+)\s*$", nfpm_path.read_text(), re.MULTILINE)
+    if len(matches) != 1:
+        sys.exit(f"error: expected exactly one `license:` line in {nfpm_path}, found {len(matches)}")
+    return matches[0]
+
+
+def purl_of(package: dict) -> str:
+    for ref in package.get("externalRefs", []):
+        if ref.get("referenceType") == "purl":
+            return ref.get("referenceLocator", "")
+    return ""
+
+
+def select_one(packages: list, predicate, what: str) -> dict:
+    hits = [p for p in packages if predicate(p)]
+    if len(hits) != 1:
+        sys.exit(f"error: selector for {what} matched {len(hits)} packages, expected exactly 1 "
+                 f"({[p['SPDXID'] for p in hits]})")
+    return hits[0]
+
+
+def root_ids(doc: dict) -> set:
+    """SPDXIDs the document describes — the shorthand field or DESCRIBES relationships."""
+    ids = set(doc.get("documentDescribes") or [])
+    for rel in doc.get("relationships", []):
+        if rel.get("spdxElementId") == "SPDXRef-DOCUMENT" and rel.get("relationshipType") == "DESCRIBES":
+            ids.add(rel.get("relatedSpdxElement"))
+    return ids
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("sbom", type=Path, help="SPDX JSON file to assert, edited in place")
+    parser.add_argument("--nfpm", type=Path, default=Path("nfpm.yaml"),
+                        help="packaging descriptor carrying the license (default: nfpm.yaml)")
+    args = parser.parse_args()
+
+    license_id = read_license(args.nfpm)
+    doc = json.loads(args.sbom.read_text())
+    packages = doc.get("packages", [])
+
+    described = root_ids(doc)
+    root = select_one(packages, lambda p: p["SPDXID"] in described, "the document root")
+    deb = select_one(packages, lambda p: purl_of(p).startswith("pkg:deb/"), "the deb package")
+    rpm = select_one(packages, lambda p: purl_of(p).startswith("pkg:rpm/"), "the rpm package")
+
+    if rpm.get("licenseDeclared") != license_id:
+        sys.exit(f"error: rpm entry declares {rpm.get('licenseDeclared')!r} but {args.nfpm} says "
+                 f"{license_id!r} — the sources of truth have drifted")
+
+    for package in (root, deb):
+        package["licenseDeclared"] = license_id
+
+    args.sbom.write_text(json.dumps(doc, indent=1) + "\n")
+    print(f"asserted licenseDeclared={license_id} on {root['SPDXID']} and {deb['SPDXID']}; "
+          f"rpm entry already declares it")
+
+
+if __name__ == "__main__":
+    main()

--- a/deployment/sbom/fixtures/release.spdx.json
+++ b/deployment/sbom/fixtures/release.spdx.json
@@ -1,0 +1,271 @@
+{
+ "spdxVersion": "SPDX-2.3",
+ "dataLicense": "CC0-1.0",
+ "SPDXID": "SPDXRef-DOCUMENT",
+ "name": ".",
+ "documentNamespace": "https://anchore.com/syft/dir/02a5b57f-57cf-4e50-a609-1b1d13c05afc",
+ "creationInfo": {
+  "licenseListVersion": "3.28",
+  "creators": [
+   "Organization: Anchore, Inc",
+   "Tool: syft-1.42.3"
+  ],
+  "created": "2026-07-31T16:20:27Z"
+ },
+ "packages": [
+  {
+   "name": "riptide",
+   "SPDXID": "SPDXRef-Package-deb-riptide-a76bfce0a1dcac4b",
+   "versionInfo": "0.7.1~rc3",
+   "supplier": "Person: Ronny Trommer (ronny@no42.org)",
+   "originator": "Person: Ronny Trommer (ronny@no42.org)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from DPKG DB: /target/riptide_0.7.1~rc3_all.deb",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "NOASSERTION",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:riptide:riptide:0.7.1\\~rc3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:deb/riptide@0.7.1~rc3?arch=all"
+    }
+   ]
+  },
+  {
+   "name": "riptide",
+   "SPDXID": "SPDXRef-Package-rpm-riptide-ce38dfb77fc323f5",
+   "versionInfo": "0:0.7.1~rc3-1",
+   "supplier": "Organization: Riptide Labs",
+   "originator": "Organization: Riptide Labs",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from RPM DB: /target/riptide-0.7.1~rc3-1.noarch.rpm",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "GPL-3.0-or-later",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:riptidelabs:riptide:0\\:0.7.1\\~rc3-1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:riptide:riptide:0\\:0.7.1\\~rc3-1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:rpm/riptide@0.7.1~rc3-1?arch=noarch&epoch=0&upstream=riptide-0.7.1~rc3-1.src.rpm"
+    }
+   ]
+  },
+  {
+   "name": ".",
+   "SPDXID": "SPDXRef-DocumentRoot-Directory-.",
+   "supplier": "NOASSERTION",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "NOASSERTION",
+   "copyrightText": "NOASSERTION",
+   "primaryPackagePurpose": "FILE"
+  },
+  {
+   "name": "RoaringBitmap",
+   "SPDXID": "SPDXRef-Package-java-archive-RoaringBitmap-71a84c9bba502a29",
+   "versionInfo": "1.0.6",
+   "supplier": "NOASSERTION",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "90ae961996614d0db4a180be926869ff1b6810b6"
+    }
+   ],
+   "sourceInfo": "acquired package info from installed java archive: /target/package/riptide.jar",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "NOASSERTION",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:RoaringBitmap:RoaringBitmap:1.0.6:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:maven/RoaringBitmap/RoaringBitmap@1.0.6"
+    }
+   ]
+  },
+  {
+   "name": "angus-activation",
+   "SPDXID": "SPDXRef-Package-java-archive-angus-activation-04b46fb5d55ee5b1",
+   "versionInfo": "2.0.3",
+   "supplier": "Organization: Eclipse Foundation",
+   "originator": "Organization: Eclipse Foundation",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "7f80607ea5014fef0b1779e6c33d63a88a45a563"
+    }
+   ],
+   "sourceInfo": "acquired package info from installed java archive: /target/package/riptide.jar",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "BSD-3-Clause",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:eclipse-foundation:angus-activation:2.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:eclipse-foundation:angus_activation:2.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:eclipse_foundation:angus-activation:2.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:eclipse_foundation:angus_activation:2.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:org.eclipse.angus:angus-activation:2.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:org.eclipse.angus:angus_activation:2.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:angus-activation:angus-activation:2.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:angus-activation:angus_activation:2.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:angus_activation:angus-activation:2.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:angus_activation:angus_activation:2.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:eclipse-foundation:angus:2.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:eclipse:angus-activation:2.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:eclipse:angus_activation:2.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:eclipse_foundation:angus:2.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:org.eclipse.angus:angus:2.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:angus-activation:angus:2.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:angus:angus-activation:2.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:angus:angus_activation:2.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:angus_activation:angus:2.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:eclipse:angus:2.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:angus:angus:2.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:maven/org.eclipse.angus/angus-activation@2.0.3"
+    }
+   ]
+  }
+ ],
+ "relationships": [
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-.",
+   "relatedSpdxElement": "SPDXRef-Package-java-archive-RoaringBitmap-71a84c9bba502a29",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-.",
+   "relatedSpdxElement": "SPDXRef-Package-java-archive-angus-activation-04b46fb5d55ee5b1",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-.",
+   "relatedSpdxElement": "SPDXRef-Package-deb-riptide-a76bfce0a1dcac4b",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-.",
+   "relatedSpdxElement": "SPDXRef-Package-rpm-riptide-ce38dfb77fc323f5",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DOCUMENT",
+   "relatedSpdxElement": "SPDXRef-DocumentRoot-Directory-.",
+   "relationshipType": "DESCRIBES"
+  }
+ ]
+}

--- a/deployment/sbom/test_assert_licenses.py
+++ b/deployment/sbom/test_assert_licenses.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Fixture tests for assert_licenses.py. Run with:
+    python3 -m unittest discover -s deployment/sbom
+"""
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).parent
+SCRIPT = HERE / "assert_licenses.py"
+FIXTURE = HERE / "fixtures" / "release.spdx.json"
+REPO_NFPM = HERE.parent.parent / "nfpm.yaml"
+
+
+def run(sbom: Path, nfpm: Path):
+    return subprocess.run([sys.executable, str(SCRIPT), str(sbom), "--nfpm", str(nfpm)],
+                          capture_output=True, text=True)
+
+
+class AssertLicensesTest(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp)
+        self.sbom = self.tmp / "release.spdx.json"
+        shutil.copy(FIXTURE, self.sbom)
+        self.nfpm = self.tmp / "nfpm.yaml"
+        self.nfpm.write_text("name: riptide\nlicense: GPL-3.0-or-later\n")
+
+    def packages(self):
+        return {p["SPDXID"]: p for p in json.loads(self.sbom.read_text())["packages"]}
+
+    def test_success_asserts_root_and_deb_and_leaves_the_rest(self):
+        result = run(self.sbom, self.nfpm)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        pkgs = self.packages()
+        self.assertEqual(pkgs["SPDXRef-DocumentRoot-Directory-."]["licenseDeclared"], "GPL-3.0-or-later")
+        deb = next(p for i, p in pkgs.items() if i.startswith("SPDXRef-Package-deb-"))
+        self.assertEqual(deb["licenseDeclared"], "GPL-3.0-or-later")
+        rpm = next(p for i, p in pkgs.items() if i.startswith("SPDXRef-Package-rpm-"))
+        self.assertEqual(rpm["licenseDeclared"], "GPL-3.0-or-later")
+        third_party = next(p for i, p in pkgs.items() if "angus" in i)
+        self.assertEqual(third_party["licenseDeclared"], "BSD-3-Clause")
+
+    def test_repo_nfpm_matches_fixture_expectation(self):
+        # The fixture test above uses a synthetic nfpm.yaml; this guards the real one.
+        result = run(self.sbom, REPO_NFPM)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_selector_no_match_fails(self):
+        doc = json.loads(self.sbom.read_text())
+        doc["packages"] = [p for p in doc["packages"] if not p["SPDXID"].startswith("SPDXRef-Package-deb-")]
+        self.sbom.write_text(json.dumps(doc))
+        result = run(self.sbom, self.nfpm)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("the deb package", result.stderr)
+        self.assertIn("matched 0", result.stderr)
+
+    def test_selector_multiple_match_fails(self):
+        doc = json.loads(self.sbom.read_text())
+        deb = next(p for p in doc["packages"] if p["SPDXID"].startswith("SPDXRef-Package-deb-"))
+        clone = json.loads(json.dumps(deb))
+        clone["SPDXID"] += "-clone"
+        doc["packages"].append(clone)
+        self.sbom.write_text(json.dumps(doc))
+        result = run(self.sbom, self.nfpm)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("matched 2", result.stderr)
+
+    def test_missing_root_fails(self):
+        doc = json.loads(self.sbom.read_text())
+        doc["relationships"] = [r for r in doc["relationships"] if r["relationshipType"] != "DESCRIBES"]
+        self.sbom.write_text(json.dumps(doc))
+        result = run(self.sbom, self.nfpm)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("the document root", result.stderr)
+
+    def test_rpm_drift_fails(self):
+        self.nfpm.write_text("license: Apache-2.0\n")
+        result = run(self.sbom, self.nfpm)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("drifted", result.stderr)
+
+    def test_documentDescribes_shorthand_also_finds_root(self):
+        doc = json.loads(self.sbom.read_text())
+        doc["relationships"] = [r for r in doc["relationships"] if r["relationshipType"] != "DESCRIBES"]
+        doc["documentDescribes"] = ["SPDXRef-DocumentRoot-Directory-."]
+        self.sbom.write_text(json.dumps(doc))
+        result = run(self.sbom, self.nfpm)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -24,6 +24,9 @@ description: |
 contents:
   - src: target/package/riptide.jar
     dst: /usr/share/riptide/riptide.jar
+  # Debian policy for a GPL package; the RPM states the license in its header.
+  - src: deployment/package/copyright
+    dst: /usr/share/doc/riptide/copyright
   - src: deployment/package/riptide.service
     dst: /usr/lib/systemd/system/riptide.service
   # config.yaml may hold inline credentials: root:riptide 0640, never


### PR DESCRIPTION
Closes #406.

Of the three SBOM entries describing what we ship, only the `.rpm` carried our license: nfpm writes it into the RPM header, which syft reads. A deb control file has no license field and syft has no flag to attach a license to the scanned directory, so both read `NOASSERTION` — facts syft cannot derive must be asserted after generation.

## What changed

- `deployment/sbom/assert_licenses.py` + `make sbom-assert`: sets `licenseDeclared: GPL-3.0-or-later` on the document root (located via the `DESCRIBES` relationship, `documentDescribes` shorthand also supported) and the `pkg:deb/` entry. The license string is read from `nfpm.yaml`, so no fifth copy of it exists; the `pkg:rpm/` entry is cross-checked, not rewritten — a mismatch means the sources of truth drifted and the release must not ship.
- Selectors are exact-match and fail-loud: zero or multiple matches exit non-zero and fail the release rather than silently shipping `NOASSERTION` again after a syft upgrade. Fixture tests (7, from a real release SBOM) cover the success path and every failure path, and run in the build gate via `make sbom-assert-test`.
- The step runs in `release.yml` between SBOM generation and the blitsbom HTML render, so the machine-readable file, the human-readable report, and the later-signed asset are the same corrected document.
- The sbom-action's own uploads are disabled (`upload-artifact: false`, `upload-release-assets: false`): both happen inside the generate step *before* the assertion, and on a workflow re-run the action would replace the corrected release asset with a raw one (found in pre-PR review, verified against the pinned action source).
- The deb now ships a DEP-5 `/usr/share/doc/riptide/copyright` (Debian policy for a GPL package), asserted by the packaging smoke test. Spike result recorded on #406: syft *does* read it from a `.deb` archive but derives the noisy `GPL-3.0-only AND GPL-3.0-or-later`, so the assertion stays unconditional and normalizes it.

## Verification

- `make sbom-assert` run against the real v0.7.1-rc3 SBOM asserts both entries and confirms the rpm; fixture tests green; actionlint clean; full `make` build green.
- Release-time evidence (all three first-party entries showing `GPL-3.0-or-later` in the attached SPDX and HTML report) lands with the next tag.

Unblocks #405, which reuses this mechanism for the `licenseConcluded` allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
