### PR TITLE
feat(sbom): conclude Apache-2.0 for the two dependencies that ship no Maven metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ help:
 	@echo "  oci:          Build OCI container image"
 	@echo "  packages:     Build DEB and RPM packages from the jar (requires Docker)"
 	@echo "  packages-smoke: Install the packages in Debian and Rocky containers and smoke-test them (requires Docker)"
-	@echo "  sbom-assert:  Assert first-party license facts in a release SBOM; SBOM=<path to .spdx.json>"
+	@echo "  sbom-assert:  Assert license facts in a release SBOM; SBOM=<path to .spdx.json>"
 	@echo "  sbom-assert-test: Run the SBOM assertion script's fixture tests"
 	@echo "  nix:          Build the flake package from source (requires Nix)"
 	@echo "  nix-check:    Run the flake checks incl. the NixOS module eval (requires Nix)"
@@ -146,8 +146,10 @@ packages-smoke: deps-oci
 	deployment/package/smoke-test.sh $(PKG_VERSION)
 
 # Sets licenseDeclared on the SBOM entries syft cannot fill for us (the deb and
-# the document root, issue #406). Runs in release.yml between SBOM generation
-# and the HTML report render; fails if the SBOM shape drifted.
+# the document root, issue #406) and licenseConcluded on the reviewed allowlist
+# of third-party packages syft cannot identify (issue #405). Runs in release.yml
+# between SBOM generation and the HTML report render; fails if the SBOM shape
+# drifted or an allowlist entry went stale.
 .PHONY: sbom-assert
 sbom-assert:
 	@test -n "$(SBOM)" || { echo "usage: make sbom-assert SBOM=target/riptide-<version>.spdx.json"; exit 1; }

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -68,6 +68,9 @@ notes afterwards with `gh release edit vX.Y.Z --notes-file notes.md`.
 
 The attached SBOM contains post-generation first-party license assertions: syft cannot read our license from a deb control file or attach one to the scanned directory, so `make sbom-assert` sets `licenseDeclared: GPL-3.0-or-later` (read from `nfpm.yaml`) on those two entries before the report is rendered and the file is signed.
 A release that fails at the "Assert first-party license facts" step means the SBOM shape drifted (typically after a syft upgrade) and the selectors in `deployment/sbom/assert_licenses.py` no longer match exactly one entry each — fix the selector, never ship `NOASSERTION`.
+The same step also sets `licenseConcluded` on a reviewed allowlist of third-party packages syft cannot identify (`deployment/sbom/concluded-licenses.json`).
+A failure naming an allowlist entry means a dependency bump or a syft change invalidated it: re-review the new version's license and update the entry (purl, evidence, review date), or remove it if syft now identifies the package.
+Never fix that failure by deleting the check.
 
 ### Container image tags
 

--- a/deployment/sbom/assert_licenses.py
+++ b/deployment/sbom/assert_licenses.py
@@ -2,7 +2,7 @@
 # Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-"""Assert first-party license facts in the release SBOM (issue #406).
+"""Assert license facts in the release SBOM (issues #406 and #405).
 
 Syft cannot derive our own license for two of the three entries that describe
 what we ship: a deb control file has no license field, and syft has no flag to
@@ -23,8 +23,21 @@ and NOASSERTION shipping again — is the bug class this script exists to
 remove, so it fails the release instead.
 
 licenseDeclared is the correct SPDX field here: we are the package author,
-and nfpm.yaml/pom.xml/LICENSE are our declaration. licenseConcluded stays
-reserved for third-party review (#405).
+and nfpm.yaml/pom.xml/LICENSE are our declaration.
+
+A second pass (issue #405) sets `licenseConcluded` on third-party packages
+syft cannot identify: jars shipping no Maven metadata get a self-referential
+filename-derived purl, so no POM lookup can ever rescue them. The conclusions
+come from concluded-licenses.json, a reviewed allowlist keyed on the exact
+purl; each entry carries its review evidence, which is mirrored into the
+package's licenseComments so the shipped document explains itself. One purl
+can match several packages (syft catalogues the same jar once per path); all
+matches get the conclusion, zero matches fail. The exact-purl match embeds
+the version, so a dependency bump (or a syft fix that starts deriving real
+coordinates) makes the entry match nothing and fails the release: a bump
+forces a re-review instead of silently carrying a stale conclusion.
+licenseConcluded, never licenseDeclared, keeps third-party review
+distinguishable from first-party declaration.
 
 Spike outcome (2026-08-04, syft latest): the dpkg cataloger DOES read
 usr/share/doc/riptide/copyright when scanning a .deb archive, but derives the
@@ -46,6 +59,39 @@ def read_license(nfpm_path: Path) -> str:
     if len(matches) != 1:
         sys.exit(f"error: expected exactly one `license:` line in {nfpm_path}, found {len(matches)}")
     return matches[0]
+
+
+ALLOWLIST_FIELDS = ("purl", "licenseConcluded", "evidence", "reviewed")
+
+
+def load_allowlist(path: Path) -> list:
+    entries = json.loads(path.read_text())
+    for entry in entries:
+        missing = [f for f in ALLOWLIST_FIELDS if not entry.get(f)]
+        if missing:
+            sys.exit(f"error: allowlist entry {entry.get('purl', '<no purl>')!r} in {path} "
+                     f"is missing {missing} — a conclusion without evidence is not reviewable")
+    return entries
+
+
+def conclude(packages: list, entry: dict, allowlist_path: Path) -> list:
+    # The same jar is catalogued once per path syft finds it at (plain jar, packaged
+    # copy), so one purl legitimately matches several entries; all get the conclusion.
+    hits = [p for p in packages if purl_of(p) == entry["purl"]]
+    if not hits:
+        sys.exit(f"error: allowlist entry {entry['purl']} matched 0 packages — a dependency bump "
+                 f"or a syft change invalidated it; re-review {allowlist_path} and update or "
+                 f"remove the entry")
+    for package in hits:
+        for field in ("licenseDeclared", "licenseConcluded"):
+            current = package.get(field, "NOASSERTION")
+            if current != "NOASSERTION":
+                sys.exit(f"error: {entry['purl']} now carries {field}={current!r} — syft can "
+                         f"identify it, so the allowlist entry in {allowlist_path} is redundant "
+                         f"or wrong; re-review and update or remove it")
+        package["licenseConcluded"] = entry["licenseConcluded"]
+        package["licenseComments"] = f"Concluded by the Riptide release review ({entry['reviewed']}): {entry['evidence']}"
+    return hits
 
 
 def purl_of(package: dict) -> str:
@@ -77,6 +123,8 @@ def main() -> None:
     parser.add_argument("sbom", type=Path, help="SPDX JSON file to assert, edited in place")
     parser.add_argument("--nfpm", type=Path, default=Path("nfpm.yaml"),
                         help="packaging descriptor carrying the license (default: nfpm.yaml)")
+    parser.add_argument("--concluded", type=Path, default=Path(__file__).parent / "concluded-licenses.json",
+                        help="reviewed third-party license allowlist (default: beside this script)")
     args = parser.parse_args()
 
     license_id = read_license(args.nfpm)
@@ -95,9 +143,14 @@ def main() -> None:
     for package in (root, deb):
         package["licenseDeclared"] = license_id
 
+    concluded = [p for entry in load_allowlist(args.concluded)
+                 for p in conclude(packages, entry, args.concluded)]
+
     args.sbom.write_text(json.dumps(doc, indent=1) + "\n")
     print(f"asserted licenseDeclared={license_id} on {root['SPDXID']} and {deb['SPDXID']}; "
           f"rpm entry already declares it")
+    for package in concluded:
+        print(f"concluded {package['licenseConcluded']} on {package['SPDXID']} per allowlist")
 
 
 if __name__ == "__main__":

--- a/deployment/sbom/concluded-licenses.json
+++ b/deployment/sbom/concluded-licenses.json
@@ -1,0 +1,14 @@
+[
+ {
+  "purl": "pkg:maven/annotations/annotations@26.1.0",
+  "licenseConcluded": "Apache-2.0",
+  "evidence": "org.jetbrains:annotations:26.1.0 POM on Maven Central names 'The Apache Software License, Version 2.0'; the jar ships a 46-byte manifest and no META-INF/maven/, so syft derives a self-referential purl from the filename and cannot resolve the real coordinates",
+  "reviewed": "2026-08-04"
+ },
+ {
+  "purl": "pkg:maven/RoaringBitmap/RoaringBitmap@1.0.6",
+  "licenseConcluded": "Apache-2.0",
+  "evidence": "org.roaringbitmap:RoaringBitmap:1.0.6 POM on Maven Central names 'Apache 2'; the jar ships a 46-byte manifest and no META-INF/maven/, so syft derives a self-referential purl from the filename and cannot resolve the real coordinates",
+  "reviewed": "2026-08-04"
+ }
+]

--- a/deployment/sbom/fixtures/release.spdx.json
+++ b/deployment/sbom/fixtures/release.spdx.json
@@ -80,6 +80,60 @@
    "primaryPackagePurpose": "FILE"
   },
   {
+   "name": "annotations",
+   "SPDXID": "SPDXRef-Package-java-archive-annotations-aed61a17fe9b8687",
+   "versionInfo": "26.1.0",
+   "supplier": "NOASSERTION",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed java archive: /pom.xml",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "LicenseRef-The-Apache-Software-License--Version-2.0",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:org.jetbrains:annotations:26.1.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:maven/org.jetbrains/annotations@26.1.0"
+    }
+   ]
+  },
+  {
+   "name": "annotations",
+   "SPDXID": "SPDXRef-Package-java-archive-annotations-8d21f3c47a0be915",
+   "versionInfo": "26.1.0",
+   "supplier": "NOASSERTION",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "c1e9226d7ca6661020c58c94397da0cc3673d5e4"
+    }
+   ],
+   "sourceInfo": "acquired package info from installed java archive: /target/package/riptide.jar",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "NOASSERTION",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:annotations:annotations:26.1.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:maven/annotations/annotations@26.1.0"
+    }
+   ]
+  },
+  {
    "name": "RoaringBitmap",
    "SPDXID": "SPDXRef-Package-java-archive-RoaringBitmap-71a84c9bba502a29",
    "versionInfo": "1.0.6",
@@ -242,6 +296,16 @@
   }
  ],
  "relationships": [
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-.",
+   "relatedSpdxElement": "SPDXRef-Package-java-archive-annotations-aed61a17fe9b8687",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-.",
+   "relatedSpdxElement": "SPDXRef-Package-java-archive-annotations-8d21f3c47a0be915",
+   "relationshipType": "CONTAINS"
+  },
   {
    "spdxElementId": "SPDXRef-DocumentRoot-Directory-.",
    "relatedSpdxElement": "SPDXRef-Package-java-archive-RoaringBitmap-71a84c9bba502a29",

--- a/deployment/sbom/test_assert_licenses.py
+++ b/deployment/sbom/test_assert_licenses.py
@@ -20,8 +20,12 @@ FIXTURE = HERE / "fixtures" / "release.spdx.json"
 REPO_NFPM = HERE.parent.parent / "nfpm.yaml"
 
 
-def run(sbom: Path, nfpm: Path):
-    return subprocess.run([sys.executable, str(SCRIPT), str(sbom), "--nfpm", str(nfpm)],
+ALLOWLIST = HERE / "concluded-licenses.json"
+
+
+def run(sbom: Path, nfpm: Path, concluded: Path = ALLOWLIST):
+    return subprocess.run([sys.executable, str(SCRIPT), str(sbom), "--nfpm", str(nfpm),
+                           "--concluded", str(concluded)],
                           capture_output=True, text=True)
 
 
@@ -49,6 +53,25 @@ class AssertLicensesTest(unittest.TestCase):
         self.assertEqual(rpm["licenseDeclared"], "GPL-3.0-or-later")
         third_party = next(p for i, p in pkgs.items() if "angus" in i)
         self.assertEqual(third_party["licenseDeclared"], "BSD-3-Clause")
+        self.assertEqual(third_party["licenseConcluded"], "NOASSERTION")
+
+    def test_success_concludes_allowlisted_packages_with_evidence(self):
+        result = run(self.sbom, self.nfpm)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        # Only the filename-derived purls are allowlisted; the pom-cataloger entry with
+        # the real annotations coordinates already carries a POM-resolved LicenseRef.
+        pkgs = self.packages()
+        concluded = [p for p in pkgs.values()
+                     if p["name"] in ("annotations", "RoaringBitmap")
+                     and p["licenseDeclared"] == "NOASSERTION"]
+        self.assertEqual(len(concluded), 2)
+        for pkg in concluded:
+            self.assertEqual(pkg["licenseConcluded"], "Apache-2.0")
+            self.assertIn("Maven Central", pkg["licenseComments"])
+        pom_derived = pkgs["SPDXRef-Package-java-archive-annotations-aed61a17fe9b8687"]
+        self.assertEqual(pom_derived["licenseConcluded"], "NOASSERTION")
+        self.assertEqual(pom_derived["licenseDeclared"],
+                         "LicenseRef-The-Apache-Software-License--Version-2.0")
 
     def test_repo_nfpm_matches_fixture_expectation(self):
         # The fixture test above uses a synthetic nfpm.yaml; this guards the real one.
@@ -88,6 +111,54 @@ class AssertLicensesTest(unittest.TestCase):
         result = run(self.sbom, self.nfpm)
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("drifted", result.stderr)
+
+    def test_stale_allowlist_entry_fails(self):
+        # A dependency bump changes the filename-derived purl; the entry must not silently carry over.
+        doc = json.loads(self.sbom.read_text())
+        rb = next(p for p in doc["packages"] if p["name"] == "RoaringBitmap")
+        for ref in rb["externalRefs"]:
+            if ref["referenceType"] == "purl":
+                ref["referenceLocator"] = "pkg:maven/RoaringBitmap/RoaringBitmap@1.0.7"
+        self.sbom.write_text(json.dumps(doc))
+        result = run(self.sbom, self.nfpm)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("pkg:maven/RoaringBitmap/RoaringBitmap@1.0.6", result.stderr)
+        self.assertIn("matched 0", result.stderr)
+        self.assertIn("re-review", result.stderr)
+
+    def test_allowlist_purl_matching_multiple_entries_concludes_all(self):
+        # Real SBOMs carry the same jar once per path syft finds it at (plain jar,
+        # packaged copy); every copy must get the conclusion.
+        doc = json.loads(self.sbom.read_text())
+        rb = next(p for p in doc["packages"] if p["name"] == "RoaringBitmap")
+        clone = json.loads(json.dumps(rb))
+        clone["SPDXID"] += "-clone"
+        doc["packages"].append(clone)
+        self.sbom.write_text(json.dumps(doc))
+        result = run(self.sbom, self.nfpm)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        pkgs = self.packages()
+        self.assertEqual(pkgs[rb["SPDXID"]]["licenseConcluded"], "Apache-2.0")
+        self.assertEqual(pkgs[clone["SPDXID"]]["licenseConcluded"], "Apache-2.0")
+
+    def test_package_gaining_a_derived_license_fails(self):
+        # If a syft upgrade starts identifying the package, the conclusion needs a re-review.
+        doc = json.loads(self.sbom.read_text())
+        rb = next(p for p in doc["packages"] if p["name"] == "RoaringBitmap")
+        rb["licenseDeclared"] = "Apache-2.0"
+        self.sbom.write_text(json.dumps(doc))
+        result = run(self.sbom, self.nfpm)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("licenseDeclared='Apache-2.0'", result.stderr)
+        self.assertIn("re-review", result.stderr)
+
+    def test_allowlist_entry_missing_evidence_fails(self):
+        bad = self.tmp / "concluded.json"
+        bad.write_text(json.dumps([{"purl": "pkg:maven/RoaringBitmap/RoaringBitmap@1.0.6",
+                                    "licenseConcluded": "Apache-2.0", "reviewed": "2026-08-04"}]))
+        result = run(self.sbom, self.nfpm, concluded=bad)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("evidence", result.stderr)
 
     def test_documentDescribes_shorthand_also_finds_root(self):
         doc = json.loads(self.sbom.read_text())


### PR DESCRIPTION
Closes #405. Completes the Undeclared bucket from the #404 audit.

`annotations` 26.1.0 and `RoaringBitmap` 1.0.6 ship a 46-byte manifest and no `META-INF/maven/`, so syft derives self-referential purls from the filename and the POM resolution from #403 can never rescue them. Their Maven Central POMs declare Apache-2.0, re-verified for these exact versions.

**What this does**

- Adds a second pass to `make sbom-assert` (#406's step, no workflow changes): sets `licenseConcluded: Apache-2.0` from a reviewed allowlist, `deployment/sbom/concluded-licenses.json`. Each entry carries its review evidence (POM consulted, verbatim license name, review date), mirrored into the package's `licenseComments` so the shipped SBOM explains its own conclusions.
- `licenseConcluded`, never `licenseDeclared`: we are not the author; this stays distinguishable from #406's first-party assertions.
- Staleness fails the release: entries match the exact purl and conclude every match; zero matches, or a matched package that now carries a derived license, exit non-zero. A dependency bump forces a re-review instead of silently carrying a stale conclusion. `RELEASING.md` documents the ritual.
- 5 new fixture tests (12 total) cover the success path and every failure path, wired into the existing `make sbom-assert-test` gate.

**Notable finding from verification**

The precondition check caught its first bug before merge: against the stale v0.7.0 SBOM I had added a third entry for the pom-cataloger's `pkg:maven/org.jetbrains/annotations@26.1.0`, but on a fresh current-config scan that entry already carries `licenseDeclared: LicenseRef-The-Apache-Software-License--Version-2.0` via #403's POM resolution, and the script rejected the redundant conclusion. The issue's "last two" count was exactly right; the allowlist stays at two entries.

**Evidence**

- `make sbom-assert-test`: 12/12 pass; `make jar`: BUILD SUCCESS.
- Fresh CI-shaped SBOM (local syft 1.50.0, current `.syft.yaml`, one jar + deb + rpm): after `make sbom-assert`, zero undeclared packages out of 154.

Spike results (upstream reports) are recorded on #405: no new syft issue needed (anchore/syft#3127 already requests the Maven Central lookup that would fix this); no library reports (Gradle omits `META-INF/maven/` by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
