### PR TITLE
feat(deploy): configure a multi receiver in the compose example

### DIFF
--- a/deployment/riptide/compose.yml
+++ b/deployment/riptide/compose.yml
@@ -15,6 +15,10 @@ services:
       RIPTIDE_CLICKHOUSE_USERNAME: default
       RIPTIDE_CLICKHOUSE_PASSWORD: ""
       RIPTIDE_CLICKHOUSE_DATABASE: riptide
+      # One multi receiver parses NetFlow v5/v9, IPFIX and sFlow on the published port
+      RIPTIDE_RECEIVERS_FLOWS_TYPE: multi
+      RIPTIDE_RECEIVERS_FLOWS_HOST: 0.0.0.0
+      RIPTIDE_RECEIVERS_FLOWS_PORT: "9999"
     ports:
       - "9999:9999/udp"
     healthcheck:

--- a/docs/docs/deploy/docker-compose.md
+++ b/docs/docs/deploy/docker-compose.md
@@ -58,11 +58,9 @@ connection and a **Database** variable (auto-populated from databases containing
 selects the riptide database, so they import into any external Grafana without a specifically
 named or `defaultDatabase`-pinned datasource.
 
-Point a NetFlow v5/v9 or IPFIX exporter at UDP `9999` and watch rows arrive in
-`riptide.flows` via ch-ui. Configure [receivers](../configuration/receivers.md) and
-[nodes](../configuration/nodes-and-snmp.md) through environment variables in the compose
-file (see [Plain JAR](plain-jar.md#environment-variables) for the `RIPTIDE_*` scheme) or
-an external config file.
+Point a NetFlow v5/v9, IPFIX or sFlow exporter at UDP `9999` and watch rows arrive in `riptide.flows` via ch-ui.
+The compose file configures a single `multi` [receiver](../configuration/receivers.md) on that port.
+Further settings — more [receivers](../configuration/receivers.md) or the [node inventory](../configuration/nodes-and-snmp.md) for exporter names and SNMP enrichment — go through environment variables in the compose file (see [Plain JAR](plain-jar.md#environment-variables) for the `RIPTIDE_*` scheme) or an external config file.
 
 ## Variants
 


### PR DESCRIPTION
Closes #421.

The compose example published `9999/udp` but the image starts no listeners by default — the container bound nothing and every exported flow was refused with ICMP port-unreachable.

Changes:
- `deployment/riptide/compose.yml`: one `multi` receiver on `0.0.0.0:9999` via environment variables (parses NetFlow v5/v9, IPFIX and sFlow on the single published port).
- `docs/docs/deploy/docker-compose.md`: describe the preconfigured receiver and point to receivers/nodes configuration for further settings.

Verified against a 300-device nl6 fleet sending mixed IPFIX and NetFlow 9 to the compose stack: rows arrive in `riptide.flows` for both protocols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)