### PR TITLE
fix(deps): patch lz4-java and brace-expansion vulnerabilities

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -38,13 +38,14 @@ jobs:
       - name: Build the package
         id: build
         run: |
-          make nix
+          set -o pipefail
+          make nix 2>&1 | tee nix-build.log
       # A stale mvnHash after a pom change is the usual failure here. Surface the expected hash and
       # the one-command fix in the job summary so it is a glance, not a log dig — see #324.
       - name: Explain a hash mismatch
         if: failure() && steps.build.outcome == 'failure'
         run: |
-          got="$(make nix 2>&1 | grep -oE 'got:\s+sha256-[A-Za-z0-9+/=]+' | grep -oE 'sha256-[A-Za-z0-9+/=]+' | head -1 || true)"
+          got="$(grep -oE 'got:\s+sha256-[A-Za-z0-9+/=]+' nix-build.log | grep -oE 'sha256-[A-Za-z0-9+/=]+' | head -1 || true)"
           {
             echo "### Nix build failed"
             if [ -n "${got}" ]; then

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -7174,9 +7174,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/docs/package.json
+++ b/docs/package.json
@@ -42,6 +42,6 @@
   "overrides": {
     "serialize-javascript": "^7.0.5",
     "uuid": "^11.1.1",
-    "brace-expansion": "^5.0.8"
+    "brace-expansion": "^5.0.9"
   }
 }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -49,7 +49,7 @@ maven.buildMavenPackage {
   # Fixed-output hash of the maven dependency set. Regenerate with `make nix-hash` whenever the
   # pom changes; the nix CI job fails the PR if it drifts and prints the expected hash in its
   # job summary.
-  mvnHash = "sha256-yLjrseh4NLBh9ribeNSbknxpZKRx/khNuY2J/F2qX9E=";
+  mvnHash = "sha256-4VUiM5zMaU8vZYaYzbjA+yU7Cz+9WuxL+F6U/+pcU3Y=";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,12 @@
                 <artifactId>jackson-databind</artifactId>
                 <version>2.22.1</version>
             </dependency>
+            <!-- Transitive-CVE pin (Scorecard/osv-scanner finding): lz4-java vulnerability (GHSA-xx22-p4ch-683r) -->
+            <dependency>
+                <groupId>at.yawk.lz4</groupId>
+                <artifactId>lz4-java</artifactId>
+                <version>1.11.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
### Summary

Resolves Scorecard Code Scanning Alert [#120](https://github.com/Riptide-Labs/riptide/security/code-scanning/120) (`GHSA-xx22-p4ch-683r` and `GHSA-rgw5-rvv9-x895`).

### Key Fixes
- **`at.yawk.lz4:lz4-java`**: Pinned to version `1.11.1` in `pom.xml` `<dependencyManagement>` to remediate JNI boundary array validation vulnerability `GHSA-xx22-p4ch-683r` (CVE-2026-59949).
- **`brace-expansion`**: Updated override to `^5.0.9` in `docs/package.json` and regenerated `docs/package-lock.json` to remediate DoS resource exhaustion vulnerability `GHSA-rgw5-rvv9-x895`.

### Verification
- Ran `mvn dependency:tree -Dincludes='*:lz4-java'` to verify resolution to `1.11.1`.
- Ran `npm install` in `docs/` to verify zero remaining npm vulnerabilities.

Assisted-by: Antigravity:gemini-3.6-flash
Signed-off-by: Ronny Trommer <ronny@no42.org>
