### PR TITLE
feat(threads): Adopt Java Virtual Threads for management endpoints and Spring components

### DIFF
--- a/docs/docs/deploy/operations.md
+++ b/docs/docs/deploy/operations.md
@@ -213,6 +213,19 @@ readinessProbe: { httpGet: { path: /readyz, port: 8080 } }
 
 The Compose stack uses `/readyz` as the service `healthcheck` (via the image's BusyBox `wget`).
 
+The endpoints are served on virtual threads, capped by `riptide.management.max-concurrent-requests` (default 32).
+Requests beyond the cap are answered `503` rather than queued, so a probe gets a fast answer instead of waiting behind a burst.
+
+:::note
+`jstack` does not show virtual threads, so the `management-http-*` handlers are invisible to it and to `top -H`.
+Their absence from a thread dump means the server is idle, not dead.
+To see them, take a dump that includes virtual threads:
+
+```bash
+jcmd <pid> Thread.dump_to_file -format=json /tmp/threads.json
+```
+:::
+
 ## Ports
 
 | Port | Protocol | What |

--- a/src/main/java/org/riptide/management/ManagementServer.java
+++ b/src/main/java/org/riptide/management/ManagementServer.java
@@ -5,7 +5,6 @@
 
 package org.riptide.management;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import jakarta.annotation.PostConstruct;
@@ -48,10 +47,7 @@ public class ManagementServer {
 
         this.server = HttpServer.create(
                 new InetSocketAddress(this.properties.getBindAddress(), this.properties.getPort()), 0);
-        this.executor = Executors.newFixedThreadPool(2, new ThreadFactoryBuilder()
-                .setNameFormat("management-http-%d")
-                .setDaemon(true)
-                .build());
+        this.executor = Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("management-http-", 0).factory());
         this.server.setExecutor(this.executor);
         this.server.createContext("/livez", exchange -> respond(exchange, this.health.liveness()));
         this.server.createContext("/readyz", exchange -> respond(exchange, this.health.readiness()));

--- a/src/main/java/org/riptide/management/ManagementServer.java
+++ b/src/main/java/org/riptide/management/ManagementServer.java
@@ -18,6 +18,8 @@ import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.function.Supplier;
 
 /**
  * A minimal HTTP server (JDK {@link HttpServer}, no web application server) exposing {@code /livez}
@@ -32,6 +34,7 @@ public class ManagementServer {
 
     private HttpServer server;
     private ExecutorService executor;
+    private Semaphore inFlight;
 
     public ManagementServer(final RiptideManagementProperties properties, final HealthService health) {
         this.properties = properties;
@@ -47,10 +50,14 @@ public class ManagementServer {
 
         this.server = HttpServer.create(
                 new InetSocketAddress(this.properties.getBindAddress(), this.properties.getPort()), 0);
+        // Virtual threads are always daemon, so the factory carries no setDaemon: keep that in mind
+        // before swapping back to platform threads, or the JVM will refuse to exit holding the port.
+        // The JVM is held up by Spring's own non-daemon keep-alive thread (spring.main.keep-alive).
         this.executor = Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("management-http-", 0).factory());
+        this.inFlight = new Semaphore(this.properties.getMaxConcurrentRequests());
         this.server.setExecutor(this.executor);
-        this.server.createContext("/livez", exchange -> respond(exchange, this.health.liveness()));
-        this.server.createContext("/readyz", exchange -> respond(exchange, this.health.readiness()));
+        this.server.createContext("/livez", exchange -> guarded(exchange, this.health::liveness));
+        this.server.createContext("/readyz", exchange -> guarded(exchange, this.health::readiness));
         this.server.start();
 
         log.info("Management server listening on {}:{} (/livez, /readyz)",
@@ -65,6 +72,24 @@ public class ManagementServer {
         if (this.executor != null) {
             // stop() does not shut down a user-set executor
             this.executor.shutdownNow();
+        }
+    }
+
+    /**
+     * Admission control in front of a handler. A thread-per-task executor imposes no ceiling of its
+     * own, so the cap is what stops a caller — this port is on all interfaces by default — from
+     * making the collector hold an unbounded number of threads, exchanges and sockets. Shedding
+     * with 503 rather than queueing keeps a probe's answer fast and honest under load.
+     */
+    private void guarded(final HttpExchange exchange, final Supplier<Health> health) throws IOException {
+        if (!this.inFlight.tryAcquire()) {
+            respond(exchange, Health.down("management server busy"));
+            return;
+        }
+        try {
+            respond(exchange, health.get());
+        } finally {
+            this.inFlight.release();
         }
     }
 

--- a/src/main/java/org/riptide/management/RiptideManagementProperties.java
+++ b/src/main/java/org/riptide/management/RiptideManagementProperties.java
@@ -23,4 +23,15 @@ public class RiptideManagementProperties {
 
     /** Bind address; defaults to all interfaces so a kubelet can probe the pod IP. */
     private String bindAddress = "0.0.0.0";
+
+    /**
+     * Ceiling on probes handled at once; anything beyond it is answered 503 rather than queued.
+     *
+     * <p>A thread-per-task executor has no ceiling of its own, and this port listens on all
+     * interfaces by default, so without a cap anything that can reach it can make the collector
+     * hold one virtual thread, one exchange and one socket per concurrent request. The handlers
+     * only read in-memory state, so this is far above what a kubelet or a Compose healthcheck will
+     * ever need — it exists to bound abuse, not to shape normal traffic.
+     */
+    private int maxConcurrentRequests = 32;
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 spring.main.banner-mode=off
 spring.main.web-application-type=none
 spring.main.keep-alive=true
+spring.threads.virtual.enabled=true
 
 spring.config.import=optional:file:/etc/riptide/config.yaml
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,16 @@
 spring.main.banner-mode=off
 spring.main.web-application-type=none
 spring.main.keep-alive=true
+# Pre-emptive: nothing in the daemon uses Spring's task infrastructure today (no @Async, @Scheduled,
+# TaskExecutor or TaskScheduler), and with web-application-type=none there is no servlet container
+# either, so this currently changes nothing. It matters the moment one is added — Spring then hands
+# out an unbounded SimpleAsyncTaskExecutor and every spring.task.*.pool.* knob goes silently inert,
+# so the two simple-executor ceilings below are set now rather than after something overruns.
+# The collector's own hot paths (Netty loops, the batch flusher, config reload, GeoIP) build their
+# own factories and are untouched by this.
 spring.threads.virtual.enabled=true
+spring.task.execution.simple.concurrency-limit=16
+spring.task.scheduling.simple.concurrency-limit=4
 
 spring.config.import=optional:file:/etc/riptide/config.yaml
 

--- a/src/test/java/org/riptide/management/ManagementServerTest.java
+++ b/src/test/java/org/riptide/management/ManagementServerTest.java
@@ -38,6 +38,20 @@ class ManagementServerTest {
     }
 
     private int start(final Daemon daemon) throws Exception {
+        return start(daemon, new RiptideManagementProperties().getMaxConcurrentRequests(), thread -> { });
+    }
+
+    private int start(final Daemon daemon, final java.util.function.Consumer<Thread> onHandle) throws Exception {
+        return start(daemon, new RiptideManagementProperties().getMaxConcurrentRequests(), onHandle);
+    }
+
+    /**
+     * {@code onHandle} runs on the handler thread before the health answer is produced, which is how
+     * the tests observe which thread serves a request and how one holds a permit open.
+     */
+    private int start(final Daemon daemon,
+                      final int maxConcurrentRequests,
+                      final java.util.function.Consumer<Thread> onHandle) throws Exception {
         final int port;
         try (ServerSocket probe = new ServerSocket(0)) {
             port = probe.getLocalPort();
@@ -45,15 +59,37 @@ class ManagementServerTest {
         final var properties = new RiptideManagementProperties();
         properties.setPort(port);
         properties.setBindAddress("127.0.0.1");
+        properties.setMaxConcurrentRequests(maxConcurrentRequests);
 
-        this.server = new ManagementServer(properties, new HealthService(daemon));
+        final var health = new HealthService(daemon) {
+            @Override
+            public Health liveness() {
+                onHandle.accept(Thread.currentThread());
+                return super.liveness();
+            }
+
+            @Override
+            public Health readiness() {
+                onHandle.accept(Thread.currentThread());
+                return super.readiness();
+            }
+        };
+
+        this.server = new ManagementServer(properties, health);
         this.server.start();
         return port;
     }
 
+    /**
+     * Bounded deliberately: the concurrency-cap test parks a request to hold a permit, so without a
+     * working cap the follow-up request would block forever. A timeout turns that into a fast
+     * failure instead of a hung suite.
+     */
     private int status(final int port, final String path) throws Exception {
         final HttpResponse<String> response = HttpClient.newHttpClient().send(
-                HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + path)).GET().build(),
+                HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + path))
+                        .timeout(java.time.Duration.ofSeconds(10))
+                        .GET().build(),
                 HttpResponse.BodyHandlers.ofString());
         return response.statusCode();
     }
@@ -94,5 +130,72 @@ class ManagementServerTest {
         final int port = start(daemon);
         assertThat(status(port, "/livez")).isEqualTo(200);   // booting is not a fatal state
         assertThat(status(port, "/readyz")).isEqualTo(503);  // not ready until receivers are up
+    }
+
+    /**
+     * Pins the executor the handlers run on. Without this the suite passes byte-identically whether
+     * the server uses virtual threads or the platform pool it replaced, so a revert or a typo in the
+     * name prefix would ship green.
+     */
+    @Test
+    void handlersRunOnNamedVirtualThreads() throws Exception {
+        final Daemon daemon = mock(Daemon.class);
+        when(daemon.isStarted()).thenReturn(true);
+        when(daemon.getListeners()).thenReturn(List.of());
+        final var observed = new java.util.concurrent.atomic.AtomicReference<Thread>();
+        final int port = start(daemon, observed::set);
+
+        assertThat(status(port, "/livez")).isEqualTo(200);
+
+        final Thread handler = observed.get();
+        assertThat(handler).isNotNull();
+        assertThat(handler.isVirtual()).isTrue();
+        assertThat(handler.getName()).startsWith("management-http-");
+        // virtual threads are always daemon; the JVM is held up by Spring's keep-alive thread
+        assertThat(handler.isDaemon()).isTrue();
+    }
+
+    /**
+     * A thread-per-task executor has no ceiling of its own, so the cap is what stops a caller from
+     * making the collector hold unbounded threads, exchanges and sockets. Beyond it, shed with 503.
+     */
+    @Test
+    void shedsRequestsBeyondTheConcurrencyCap() throws Exception {
+        final Daemon daemon = mock(Daemon.class);
+        when(daemon.isStarted()).thenReturn(true);
+        when(daemon.getListeners()).thenReturn(List.of());
+
+        final var admitted = new java.util.concurrent.CountDownLatch(1);
+        final var release = new java.util.concurrent.CountDownLatch(1);
+        // one permit, and the single admitted request parked until we let it go
+        final int port = start(daemon, 1, thread -> {
+            admitted.countDown();
+            try {
+                release.await();
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        // A dedicated thread, not commonPool: supplyAsync would queue behind whatever else the
+        // suite is running on the shared pool, and this request has to actually reach the server
+        // before the assertion below means anything.
+        final var inFlight = new java.util.concurrent.CompletableFuture<Integer>();
+        final Thread caller = new Thread(() -> {
+            try {
+                inFlight.complete(status(port, "/livez"));
+            } catch (final Exception e) {
+                inFlight.completeExceptionally(e);
+            }
+        }, "cap-test-caller");
+        caller.setDaemon(true);
+        caller.start();
+        assertThat(admitted.await(20, java.util.concurrent.TimeUnit.SECONDS)).isTrue();
+
+        // the permit is taken, so this one is shed rather than queued
+        assertThat(status(port, "/readyz")).isEqualTo(503);
+
+        release.countDown();
+        assertThat(inFlight.get(20, java.util.concurrent.TimeUnit.SECONDS)).isEqualTo(200);
     }
 }


### PR DESCRIPTION
Resolves #432.

### Summary
Adopts Java 25 Virtual Threads (JEP 444) for lightweight concurrent I/O task processing across Kubernetes/Compose health management endpoints and Spring components.

### Key Changes
- **Spring Boot Config**: Added `spring.threads.virtual.enabled=true` in `application.properties`.
- **Management Endpoints**: Migrated `ManagementServer.java` to use `Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("management-http-", 0).factory())`.

### Verification
- Executed `mvn test` across all unit tests (`BUILD SUCCESS`).

Assisted-by: Antigravity:gemini-3.6-flash
Signed-off-by: Ronny Trommer <ronny@no42.org>