### PR TITLE
fix(config): bind receivers with Spring's Binder instead of Jackson

### DIFF
--- a/docs/docs/configuration/receivers.md
+++ b/docs/docs/configuration/receivers.md
@@ -50,14 +50,17 @@ riptide:
 
 NetFlow v9, IPFIX and `multi` receivers accept fallback flow timeouts.
 An exporter that reports its own active or inactive timeout always wins.
-The fallback fills the gap for exporters whose templates omit the field, which would otherwise leave the flow with no timeout at all.
+The fallback fills the gap for exporters whose templates omit the field.
 
 | Setting | Applies when |
 |---|---|
 | `flow-active-timeout-fallback` | the record carries no active flow timeout |
 | `flow-inactive-timeout-fallback` | the record carries no inactive flow timeout |
 
+**Set both or neither.** riptide derives a flow's delta-switched time only when both timeouts resolve, so supplying one alone leaves the result unchanged from supplying nothing.
+
 Both take a duration, written either with a suffix (`5m`, `30s`) or in ISO-8601 (`PT5M`).
+A bare number is milliseconds, so write `300s` rather than `300` for five minutes.
 
 ```properties
 riptide.receivers.nf9.type=netflow9

--- a/docs/docs/configuration/receivers.md
+++ b/docs/docs/configuration/receivers.md
@@ -9,7 +9,7 @@ Receivers are the flow listeners. None are configured by default — the daemon 
 listeners until you define them. Entries defined in the bundled `application.properties`
 merge with (and cannot be removed by) external configuration.
 
-Each receiver has a free-form name and three settings:
+Each receiver has a free-form name and three core settings:
 
 | Setting | Values |
 |---|---|
@@ -45,6 +45,29 @@ riptide:
       host: 0.0.0.0
       port: 2055
 ```
+
+## Timeout fallbacks
+
+NetFlow v9, IPFIX and `multi` receivers accept fallback flow timeouts.
+An exporter that reports its own active or inactive timeout always wins.
+The fallback fills the gap for exporters whose templates omit the field, which would otherwise leave the flow with no timeout at all.
+
+| Setting | Applies when |
+|---|---|
+| `flow-active-timeout-fallback` | the record carries no active flow timeout |
+| `flow-inactive-timeout-fallback` | the record carries no inactive flow timeout |
+
+Both take a duration, written either with a suffix (`5m`, `30s`) or in ISO-8601 (`PT5M`).
+
+```properties
+riptide.receivers.nf9.type=netflow9
+riptide.receivers.nf9.host=0.0.0.0
+riptide.receivers.nf9.port=2055
+riptide.receivers.nf9.flow-active-timeout-fallback=5m
+riptide.receivers.nf9.flow-inactive-timeout-fallback=30s
+```
+
+An IPFIX receiver also takes `transport` (`UDP`, the default, or `TCP`).
 
 ## Exporter identity
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,9 +26,9 @@
              Jackson 2 module. 2.22.1 patches GHSA-5jmj-h7xm-6q6v (Scorecard/osv-scanner finding).
              Set on the BOM rather than pinning jackson-databind alone so core and annotations move
              with it: Jackson expects databind and core on the same minor, and databind is a direct
-             dependency on paths the daemon takes on every start (DaemonConfig binds
-             riptide.receivers.* through it, see #434, and the MCP components parse JSON-RPC frames
-             and ClickHouse JSONEachRow rows with it). Drop once the managing parent catches up. -->
+             dependency on a reachable path (the MCP components parse JSON-RPC frames and ClickHouse
+             JSONEachRow rows with it). Configuration binding no longer goes through Jackson, see
+             #434. Drop once the managing parent catches up. -->
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <jakarta-xml-bind-api.version>4.0.5</jakarta-xml-bind-api.version>
         <java.version>25</java.version>

--- a/src/main/java/org/riptide/config/DaemonConfig.java
+++ b/src/main/java/org/riptide/config/DaemonConfig.java
@@ -5,13 +5,16 @@
 
 package org.riptide.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.riptide.pipeline.Identity;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -23,8 +26,6 @@ import java.util.stream.Collectors;
 @ConfigurationProperties("riptide")
 @NoArgsConstructor
 public final class DaemonConfig {
-
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     /**
      * Deprecated flow-placement key. Superseded by {@code riptide.identity.zone}; still
@@ -48,8 +49,32 @@ public final class DaemonConfig {
     public void setReceivers(final Map<String, Map<String, Object>> receivers) {
         this.receivers = receivers.entrySet().stream().map((e) -> Map.entry(
                 e.getKey(),
-                objectMapper.convertValue(e.getValue(), ReceiverConfig.class)
+                bindReceiver(e.getKey(), e.getValue())
         )).collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    /**
+     * Bind one receiver's properties onto the configuration class its {@code type} names.
+     *
+     * <p>Bound with Spring's {@link Binder} rather than a JSON mapper so a receiver accepts what
+     * every other riptide property accepts: {@code flow-active-timeout-fallback} and
+     * {@code flowActiveTimeoutFallback} both bind, and a duration may be written {@code 5m} as well
+     * as {@code PT5M}. A JSON mapper handles neither, which left the {@code Duration} fallbacks
+     * unreachable by any spelling and the rest camelCase-only (#434). The type dispatch a mapper
+     * would drive from an annotation is {@link ReceiverConfig#typeOf}.
+     */
+    private static ReceiverConfig bindReceiver(final String name, final Map<String, Object> properties) {
+        final Binder binder = new Binder(new MapConfigurationPropertySource(
+                properties != null ? properties : Map.of()));
+        final String type = binder.bind("type", String.class).orElse(null);
+        final Class<? extends ReceiverConfig> target = ReceiverConfig.typeOf(type)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "riptide.receivers." + name + ".type "
+                                + (type == null || type.isBlank() ? "is not set" : "is '" + type + "'")
+                                + "; expected one of " + ReceiverConfig.knownTypes()));
+        return binder.bind(ConfigurationPropertyName.EMPTY, Bindable.of(target))
+                .orElseThrow(() -> new IllegalStateException(
+                        "riptide.receivers." + name + " could not be bound to " + target.getSimpleName()));
     }
 
     /**

--- a/src/main/java/org/riptide/config/DaemonConfig.java
+++ b/src/main/java/org/riptide/config/DaemonConfig.java
@@ -11,14 +11,17 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.riptide.pipeline.Identity;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.BindHandler;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.bind.handler.NoUnboundElementsBindHandler;
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
 import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -65,16 +68,48 @@ public final class DaemonConfig {
      */
     private static ReceiverConfig bindReceiver(final String name, final Map<String, Object> properties) {
         final Binder binder = new Binder(new MapConfigurationPropertySource(
-                properties != null ? properties : Map.of()));
+                flatten(properties != null ? properties : Map.of())));
         final String type = binder.bind("type", String.class).orElse(null);
         final Class<? extends ReceiverConfig> target = ReceiverConfig.typeOf(type)
                 .orElseThrow(() -> new IllegalArgumentException(
                         "riptide.receivers." + name + ".type "
                                 + (type == null || type.isBlank() ? "is not set" : "is '" + type + "'")
                                 + "; expected one of " + ReceiverConfig.knownTypes()));
-        return binder.bind(ConfigurationPropertyName.EMPTY, Bindable.of(target))
+        // NoUnboundElementsBindHandler keeps the one useful thing the JSON mapper did: reject a
+        // property that matches no field. Without it a typo binds nothing and says nothing, and a
+        // misspelled `port` leaves the primitive at 0, which the listener happily binds as an
+        // ephemeral port — a receiver that looks healthy and never sees the exporter's traffic.
+        return binder.bind(ConfigurationPropertyName.EMPTY, Bindable.of(target),
+                        new NoUnboundElementsBindHandler(BindHandler.DEFAULT))
                 .orElseThrow(() -> new IllegalStateException(
                         "riptide.receivers." + name + " could not be bound to " + target.getSimpleName()));
+    }
+
+    /**
+     * Collapse the nested maps relaxed binding leaves behind back into one property name per value.
+     *
+     * <p>Spring hands this setter a {@code Map<String, Object>} per receiver, and how a name was
+     * split depends on where it came from: {@code RIPTIDE_RECEIVERS_NF9_FLOW_ACTIVE_TIMEOUT_FALLBACK}
+     * arrives as {@code {flow={active={timeout={fallback=5m}}}}}, while the same setting written in
+     * a properties file arrives whole. Rejoining the path with hyphens yields the canonical
+     * {@code flow-active-timeout-fallback} either way. Every receiver property is a scalar, so a
+     * nested map here is always a split name rather than structure worth preserving.
+     */
+    private static Map<String, Object> flatten(final Map<String, Object> properties) {
+        final Map<String, Object> flat = new LinkedHashMap<>();
+        flatten("", properties, flat);
+        return flat;
+    }
+
+    private static void flatten(final String prefix, final Map<?, ?> properties, final Map<String, Object> flat) {
+        properties.forEach((key, value) -> {
+            final String name = prefix.isEmpty() ? String.valueOf(key) : prefix + "-" + key;
+            if (value instanceof Map<?, ?> nested) {
+                flatten(name, nested, flat);
+            } else {
+                flat.put(name, value);
+            }
+        });
     }
 
     /**

--- a/src/main/java/org/riptide/config/ReceiverConfig.java
+++ b/src/main/java/org/riptide/config/ReceiverConfig.java
@@ -5,27 +5,44 @@
 
 package org.riptide.config;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 import java.time.Duration;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
 
-@JsonTypeInfo(
-        use = JsonTypeInfo.Id.NAME,
-        include = JsonTypeInfo.As.PROPERTY,
-        property = "type",
-        visible = true)
-@JsonSubTypes({
-        @JsonSubTypes.Type(value = ReceiverConfig.Neflow5Config.class, name = "netflow5"),
-        @JsonSubTypes.Type(value = ReceiverConfig.Neflow9Config.class, name = "netflow9"),
-        @JsonSubTypes.Type(value = ReceiverConfig.IpfixConfig.class, name = "ipfix"),
-        @JsonSubTypes.Type(value = ReceiverConfig.SflowConfig.class, name = "sflow"),
-        @JsonSubTypes.Type(value = ReceiverConfig.MultiConfig.class, name = "multi"),
-})
 @Data
 public abstract sealed class ReceiverConfig {
+
+    /**
+     * The values {@code riptide.receivers.<name>.type} accepts, and the configuration each one
+     * binds to. This is the dispatch a JSON mapper would previously have driven from a type
+     * annotation; {@link DaemonConfig} binds against whichever class is named here, and the sealed
+     * hierarchy plus {@link Cases} keeps the consuming side exhaustive.
+     */
+    private static final Map<String, Class<? extends ReceiverConfig>> TYPES = Map.of(
+            "netflow5", Neflow5Config.class,
+            "netflow9", Neflow9Config.class,
+            "ipfix", IpfixConfig.class,
+            "sflow", SflowConfig.class,
+            "multi", MultiConfig.class);
+
+    /** The configuration class a {@code type} selects, empty when the value names no receiver. */
+    public static Optional<Class<? extends ReceiverConfig>> typeOf(final String type) {
+        return type == null
+                ? Optional.empty()
+                : Optional.ofNullable(TYPES.get(type.trim().toLowerCase(Locale.ROOT)));
+    }
+
+    /** The accepted {@code type} values, ordered so an error message reads the same every time. */
+    public static Set<String> knownTypes() {
+        return new TreeSet<>(TYPES.keySet());
+    }
+
     String type;
 
     /// Listening port

--- a/src/test/java/org/riptide/config/DaemonConfigTest.java
+++ b/src/test/java/org/riptide/config/DaemonConfigTest.java
@@ -13,6 +13,8 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.env.SystemEnvironmentPropertySource;
 
 import java.time.Duration;
 import java.util.Map;
@@ -111,6 +113,7 @@ class DaemonConfigTest {
         assertThat(nf9.getHost()).isEqualTo("127.0.0.1");
         assertThat(nf9.getFlowActiveTimeoutFallback()).isEqualTo(Duration.ofMinutes(5));
         assertThat(nf9.getFlowInactiveTimeoutFallback()).isEqualTo(Duration.ofSeconds(30));
+        // Binds, but the flow builders never read it, so it has no runtime effect yet (#435).
         assertThat(nf9.getFlowSamplingIntervalFallback()).isEqualTo(100L);
     }
 
@@ -166,6 +169,71 @@ class DaemonConfigTest {
                 .hasMessageContaining("riptide.receivers.oops.type")
                 .hasMessageContaining("netflow6")
                 .hasMessageContaining("netflow9");
+    }
+
+    /**
+     * Environment variables are the documented way to configure the container image, and Spring
+     * splits every underscore into a level: the setting arrives as
+     * {@code {flow={active={timeout={fallback=5m}}}}} rather than as one name.
+     */
+    @Test
+    void receiverBindsSettingsSuppliedAsEnvironmentVariables() {
+        final var environment = new StandardEnvironment();
+        environment.getPropertySources().addFirst(new SystemEnvironmentPropertySource(
+                StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME,
+                Map.of(
+                        "RIPTIDE_RECEIVERS_NF9_TYPE", "netflow9",
+                        "RIPTIDE_RECEIVERS_NF9_PORT", "2055",
+                        "RIPTIDE_RECEIVERS_NF9_FLOW_ACTIVE_TIMEOUT_FALLBACK", "5m",
+                        "RIPTIDE_RECEIVERS_NF9_FLOW_INACTIVE_TIMEOUT_FALLBACK", "30s")));
+
+        final var config = Binder.get(environment).bind("riptide", DaemonConfig.class).orElseGet(DaemonConfig::new);
+
+        final var nf9 = (ReceiverConfig.Neflow9Config) config.getReceivers().get("nf9");
+        assertThat(nf9.getPort()).isEqualTo(2055);
+        assertThat(nf9.getFlowActiveTimeoutFallback()).isEqualTo(Duration.ofMinutes(5));
+        assertThat(nf9.getFlowInactiveTimeoutFallback()).isEqualTo(Duration.ofSeconds(30));
+    }
+
+    /**
+     * A misspelled property must not bind silently. A typo in {@code port} would otherwise leave the
+     * primitive at 0, and the listener binds that as an ephemeral port: a receiver that reports
+     * healthy and never sees the exporter's traffic.
+     */
+    @Test
+    void misspelledReceiverPropertyIsRejected() {
+        assertThatThrownBy(() -> bind(Map.of(
+                "riptide.receivers.nf9.type", "netflow9",
+                "riptide.receivers.nf9.prot", "2055")))
+                .rootCause()
+                .hasMessageContaining("prot")
+                .hasMessageContaining("unbound");
+    }
+
+    @Test
+    void misspelledDurationFallbackIsRejected() {
+        assertThatThrownBy(() -> bind(Map.of(
+                "riptide.receivers.nf9.type", "netflow9",
+                "riptide.receivers.nf9.flow-active-timeout", "5m")))
+                .rootCause()
+                .hasMessageContaining("flow-active-timeout");
+    }
+
+    /** Unset optional settings keep their declared defaults rather than being reset by the bind. */
+    @Test
+    void unsetReceiverSettingsKeepTheirDefaults() {
+        final var config = bind(Map.of(
+                "riptide.receivers.all.type", "multi",
+                "riptide.receivers.ipfix.type", "ipfix"));
+
+        final var multi = (ReceiverConfig.MultiConfig) config.getReceivers().get("all");
+        assertThat(multi.isNetflow5()).isTrue();
+        assertThat(multi.isNetflow9()).isTrue();
+        assertThat(multi.isIpfix()).isTrue();
+        assertThat(multi.isSflow()).isTrue();
+        assertThat(multi.getFlowActiveTimeoutFallback()).isNull();
+        final var ipfix = (ReceiverConfig.IpfixConfig) config.getReceivers().get("ipfix");
+        assertThat(ipfix.getTransport()).isEqualTo(ReceiverConfig.IpfixConfig.Transport.UDP);
     }
 
     @Test

--- a/src/test/java/org/riptide/config/DaemonConfigTest.java
+++ b/src/test/java/org/riptide/config/DaemonConfigTest.java
@@ -14,13 +14,16 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
 
+import java.time.Duration;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Binds {@code riptide.identity.*} (and the deprecated {@code riptide.location}) via the
- * Spring {@link Binder} and verifies {@link DaemonConfig#resolveIdentity()}.
+ * Spring {@link Binder} and verifies {@link DaemonConfig#resolveIdentity()}, and covers the
+ * {@code riptide.receivers.*} binding.
  */
 class DaemonConfigTest {
 
@@ -84,6 +87,94 @@ class DaemonConfigTest {
         assertThat(identity.organisation()).isEqualTo("acme-eu");
         assertThat(identity.zone()).isEqualTo("dmz");
         assertThat(identity.system()).isEqualTo("collector-01");
+    }
+
+    /**
+     * The spelling an operator would reach for, matching every other riptide property. Binding
+     * these through a JSON mapper accepted neither the hyphens nor the {@code 5m} duration, so both
+     * of these settings used to fail startup outright (#434).
+     */
+    @Test
+    void receiverBindsKebabCaseKeysAndFriendlyDurations() {
+        final var config = bind(Map.of(
+                "riptide.receivers.nf9.type", "netflow9",
+                "riptide.receivers.nf9.port", "9995",
+                "riptide.receivers.nf9.host", "127.0.0.1",
+                "riptide.receivers.nf9.flow-active-timeout-fallback", "5m",
+                "riptide.receivers.nf9.flow-inactive-timeout-fallback", "30s",
+                "riptide.receivers.nf9.flow-sampling-interval-fallback", "100"));
+
+        final var receiver = config.getReceivers().get("nf9");
+        assertThat(receiver).isInstanceOf(ReceiverConfig.Neflow9Config.class);
+        final var nf9 = (ReceiverConfig.Neflow9Config) receiver;
+        assertThat(nf9.getPort()).isEqualTo(9995);
+        assertThat(nf9.getHost()).isEqualTo("127.0.0.1");
+        assertThat(nf9.getFlowActiveTimeoutFallback()).isEqualTo(Duration.ofMinutes(5));
+        assertThat(nf9.getFlowInactiveTimeoutFallback()).isEqualTo(Duration.ofSeconds(30));
+        assertThat(nf9.getFlowSamplingIntervalFallback()).isEqualTo(100L);
+    }
+
+    /** Relaxed binding: the camelCase spelling that used to be the only one accepted still works. */
+    @Test
+    void receiverBindsCamelCaseKeysAndIsoDurations() {
+        final var config = bind(Map.of(
+                "riptide.receivers.nf9.type", "netflow9",
+                "riptide.receivers.nf9.flowActiveTimeoutFallback", "PT5M"));
+
+        final var nf9 = (ReceiverConfig.Neflow9Config) config.getReceivers().get("nf9");
+        assertThat(nf9.getFlowActiveTimeoutFallback()).isEqualTo(Duration.ofMinutes(5));
+    }
+
+    @Test
+    void everyReceiverTypeBindsToItsConfig() {
+        final var config = bind(Map.of(
+                "riptide.receivers.a.type", "netflow5",
+                "riptide.receivers.b.type", "netflow9",
+                "riptide.receivers.c.type", "ipfix",
+                "riptide.receivers.d.type", "sflow",
+                "riptide.receivers.e.type", "multi"));
+
+        assertThat(config.getReceivers().get("a")).isInstanceOf(ReceiverConfig.Neflow5Config.class);
+        assertThat(config.getReceivers().get("b")).isInstanceOf(ReceiverConfig.Neflow9Config.class);
+        assertThat(config.getReceivers().get("c")).isInstanceOf(ReceiverConfig.IpfixConfig.class);
+        assertThat(config.getReceivers().get("d")).isInstanceOf(ReceiverConfig.SflowConfig.class);
+        assertThat(config.getReceivers().get("e")).isInstanceOf(ReceiverConfig.MultiConfig.class);
+        assertThat(config.getReceivers().get("a").getType()).isEqualTo("netflow5");
+    }
+
+    @Test
+    void ipfixTransportAndMultiToggleBind() {
+        final var config = bind(Map.of(
+                "riptide.receivers.ipfix.type", "ipfix",
+                "riptide.receivers.ipfix.transport", "TCP",
+                "riptide.receivers.all.type", "multi",
+                "riptide.receivers.all.sflow", "false"));
+
+        final var ipfix = (ReceiverConfig.IpfixConfig) config.getReceivers().get("ipfix");
+        assertThat(ipfix.getTransport()).isEqualTo(ReceiverConfig.IpfixConfig.Transport.TCP);
+        final var multi = (ReceiverConfig.MultiConfig) config.getReceivers().get("all");
+        assertThat(multi.isSflow()).isFalse();
+        assertThat(multi.isNetflow9()).isTrue();
+    }
+
+    /** A typo in the type has to name the receiver and the accepted values, not just fail. */
+    @Test
+    void unknownReceiverTypeIsRejectedWithAUsefulMessage() {
+        assertThatThrownBy(() -> bind(Map.of("riptide.receivers.oops.type", "netflow6")))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .rootCause()
+                .hasMessageContaining("riptide.receivers.oops.type")
+                .hasMessageContaining("netflow6")
+                .hasMessageContaining("netflow9");
+    }
+
+    @Test
+    void missingReceiverTypeIsRejectedWithAUsefulMessage() {
+        assertThatThrownBy(() -> bind(Map.of("riptide.receivers.oops.port", "9995")))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .rootCause()
+                .hasMessageContaining("riptide.receivers.oops.type")
+                .hasMessageContaining("is not set");
     }
 
     @Test


### PR DESCRIPTION
## What does this change?

Receiver configuration is bound with Spring's `Binder` instead of a hand-rolled Jackson `ObjectMapper`, so `riptide.receivers.*` accepts what every other riptide property accepts.

Before, `DaemonConfig` handed the raw receiver map to a bare `ObjectMapper`. That mapper has no `JavaTimeModule` and does not match hyphenated keys to camelCase fields, so both spellings of a `Duration` setting failed startup:

| Property as written | Before | After |
| :--- | :--- | :--- |
| `riptide.receivers.nf9.flow-active-timeout-fallback=5m` | startup fails, `Unrecognized field` | binds |
| `riptide.receivers.nf9.flowActiveTimeoutFallback=PT5M` | startup fails, `Duration not supported by default` | binds |
| `riptide.receivers.nf9.flow-sampling-interval-fallback=100` | startup fails, `Unrecognized field` | binds |
| `riptide.receivers.nf9.flowSamplingIntervalFallback=100` | starts | binds |

So the two `Duration` fallbacks were unreachable by any spelling, and the remaining multi-word options only bound in camelCase, contrary to the kebab-case used everywhere else (`riptide.clickhouse.batch.max-rows`, `riptide.management.bind-address`). The fields are live: `Daemon` passes them to the NetFlow 9, IPFIX and sFlow parsers.

The polymorphic dispatch Jackson drove from `@JsonTypeInfo` becomes `ReceiverConfig.typeOf`, so those annotations come off the type and an unrecognised `type` now fails with a message that names the receiver and the accepted values rather than a Jackson stack trace.

This also removes the last `ObjectMapper` outside the MCP components, so the pom's note on the Jackson pin is updated to match.

Closes #434

## How was it verified?

`make jar` is green: 920 tests, SpotBugs clean, coverage met.

Nine new tests in `DaemonConfigTest` cover what this path never had: kebab and camel spellings, `5m` and `PT5M` durations, every `type` binding to its subtype, the IPFIX `transport` and `multi` per-protocol toggles, and both error messages.

Against the packaged jar, the three configurations that previously refused to start now all reach `Started RiptideApplication`, and a bad type reports:

```
riptide.receivers.oops.type is 'netflow6'; expected one of [ipfix, multi, netflow5, netflow9, sflow]
```

## Anything reviewers should look at closely?

The receiver timeout fallbacks are documented for the first time, because until now they could not be set at all. I verified the semantics in the flow builders before writing them up: the exporter's own value always wins and the fallback only fills the gap (`Optionals.first(raw.FLOW_ACTIVE_TIMEOUT, flowActiveTimeoutFallback)`).

`flow-sampling-interval-fallback` is deliberately left out of the docs. It binds, and the value travels all the way from config through `Daemon` and the parsers into `Netflow9FlowBuilder` / `IpFixFlowBuilder`, where both store it in a field that is never read. It is a no-op today, so documenting it would advertise behaviour that does not exist. Tracked separately in #435 rather than fixed here, since wiring it changes flow volume estimation and deserves its own change and tests.

Binding at `ConfigurationPropertyName.EMPTY` against a `MapConfigurationPropertySource` is the one piece worth a second opinion. I probed it before committing: root binding works, and relaxed matching means `flow-active-timeout-fallback`, `flowActiveTimeoutFallback` and `flow_active_timeout_fallback` all reach the same field.
