### PR TITLE
feat(flows): resolve the sampling rate from v9 sampler options

### DIFF
--- a/docs/docs/configuration/receivers.md
+++ b/docs/docs/configuration/receivers.md
@@ -72,6 +72,38 @@ riptide.receivers.nf9.flow-inactive-timeout-fallback=30s
 
 An IPFIX receiver also takes `transport` (`UDP`, the default, or `TCP`).
 
+## Sampling rate
+
+A sampling exporter states its rate once in a sampler options table and then leaves it out of every flow record.
+For **NetFlow v9**, riptide reads that table and remembers the rate per exporter and observation domain, so no configuration is normally needed.
+
+Most platforms only send the table if asked.
+On Cisco IOS-XE that is `option sampler-table timeout <seconds>` under `flow exporter`; on IOS-XR it is `options sampler-table timeout <seconds>` under `flow exporter-map`.
+The timeout governs how quickly a restarted collector relearns the rate, so a short one is worth setting.
+Until the first table arrives, flows from that exporter are recorded as unsampled.
+
+IPFIX does not yet get this correlation: its rate is read only from the flow record itself, so an IPFIX exporter that advertises out of band needs the fallback below.
+
+For an exporter that never advertises a rate, name it yourself:
+
+```properties
+riptide.receivers.nf9.flow-sampling-interval-fallback=1000
+```
+
+This is a last resort, not an override.
+What the exporter says always wins: a rate on the flow record first, then the rate from its sampler options table, then this setting, then unsampled.
+An exporter that explicitly reports an interval of 1 has said it does not sample, and that answer stands over the fallback.
+Note the fallback applies to the whole receiver, so exporters sharing a port share it.
+
+:::note
+riptide records the sampling rate; it does not scale NetFlow or IPFIX `bytes` and `packets` by it.
+Stored counters are what the exporter reported, and the rate sits alongside them for a query to apply.
+
+Two things to know before writing that query.
+sFlow already scales at ingest (`bytes = frame_length × sampling_rate`) and still reports its rate, so multiplying sFlow rows again double-counts them: filter them out, or restrict the query to NetFlow and IPFIX.
+And the 1-minute rollups carry neither the rate nor a scaled measure, so `SUM(bytes * samplingInterval)` only means anything against the raw `flows` table.
+:::
+
 ## Exporter identity
 
 Flows are attributed to their exporter by **source address plus observation domain**

--- a/src/main/java/org/riptide/flows/Daemon.java
+++ b/src/main/java/org/riptide/flows/Daemon.java
@@ -26,6 +26,8 @@ import org.riptide.flows.parser.sflow.SflowUdpParser;
 import org.riptide.flows.parser.netflow9.Netflow9UdpParser;
 import org.riptide.pipeline.FlowException;
 import org.riptide.pipeline.Pipeline;
+import org.riptide.flows.parser.session.ExporterSamplingTable;
+import org.riptide.flows.parser.session.OptionListener;
 import org.riptide.snmp.ExporterInterfaceTable;
 import org.riptide.pipeline.Source;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -54,8 +56,11 @@ public class Daemon implements ApplicationRunner {
                   @Qualifier("ipfixValueConversionService") final ValueConversionService ipfixValueConversionService,
                   @Qualifier("netflow9ValueConversionService") final ValueConversionService netflow9ValueConversionService,
                   final ExporterInterfaceTable exporterInterfaceTable,
+                  final ExporterSamplingTable exporterSamplingTable,
                   final DaemonConfig config) {
         final var identity = config.resolveIdentity();
+        // One option stream, two readers: interface names and sampler rates.
+        final OptionListener optionListener = OptionListener.of(exporterInterfaceTable, exporterSamplingTable);
 
         this.pipeline = Objects.requireNonNull(pipeline);
         // A packet's records are dispatched as one batch (see ParserBase#transmit), so a failure
@@ -106,8 +111,9 @@ public class Daemon implements ApplicationRunner {
                         final var parser = new Netflow9UdpParser(e.getKey(), dispatcher, identity, metricRegistry, netflow9ValueConversionService)
                                 .withFlowActiveTimeoutFallback(config.getFlowActiveTimeoutFallback())
                                 .withFlowInactiveTimeoutFallback(config.getFlowInactiveTimeoutFallback())
-                                .withFlowSamplingIntervalFallback(config.getFlowSamplingIntervalFallback());
-                        parser.setOptionListener(exporterInterfaceTable);
+                                .withFlowSamplingIntervalFallback(config.getFlowSamplingIntervalFallback())
+                                .withSamplingTable(exporterSamplingTable);
+                        parser.setOptionListener(optionListener);
 
                         return new UdpListener(e.getKey(), parser, metricRegistry)
                                 .withPort(config.getPort())
@@ -123,7 +129,7 @@ public class Daemon implements ApplicationRunner {
                                         .withFlowInactiveTimeoutFallback(config.getFlowInactiveTimeoutFallback())
                                         .withFlowSamplingIntervalFallback(config.getFlowSamplingIntervalFallback());
 
-                                parser.setOptionListener(exporterInterfaceTable);
+                                parser.setOptionListener(optionListener);
 
                                 yield new UdpListener(e.getKey(), parser, metricRegistry)
                                         .withPort(config.getPort())
@@ -135,7 +141,7 @@ public class Daemon implements ApplicationRunner {
                                         .withFlowInactiveTimeoutFallback(config.getFlowInactiveTimeoutFallback())
                                         .withFlowSamplingIntervalFallback(config.getFlowSamplingIntervalFallback());
 
-                                parser.setOptionListener(exporterInterfaceTable);
+                                parser.setOptionListener(optionListener);
 
                                 yield new TcpListener(e.getKey(), parser, metricRegistry)
                                         .withPort(config.getPort())
@@ -169,8 +175,9 @@ public class Daemon implements ApplicationRunner {
                             final var netflow9 = new Netflow9UdpParser(e.getKey() + ":netflow9", dispatcher, identity, metricRegistry, netflow9ValueConversionService)
                                     .withFlowActiveTimeoutFallback(config.getFlowActiveTimeoutFallback())
                                     .withFlowInactiveTimeoutFallback(config.getFlowInactiveTimeoutFallback())
-                                    .withFlowSamplingIntervalFallback(config.getFlowSamplingIntervalFallback());
-                            netflow9.setOptionListener(exporterInterfaceTable);
+                                    .withFlowSamplingIntervalFallback(config.getFlowSamplingIntervalFallback())
+                                    .withSamplingTable(exporterSamplingTable);
+                            netflow9.setOptionListener(optionListener);
                             parsers.add(netflow9);
                         }
 
@@ -179,7 +186,7 @@ public class Daemon implements ApplicationRunner {
                                     .withFlowActiveTimeoutFallback(config.getFlowActiveTimeoutFallback())
                                     .withFlowInactiveTimeoutFallback(config.getFlowInactiveTimeoutFallback())
                                     .withFlowSamplingIntervalFallback(config.getFlowSamplingIntervalFallback());
-                            ipfix.setOptionListener(exporterInterfaceTable);
+                            ipfix.setOptionListener(optionListener);
                             parsers.add(ipfix);
                         }
 

--- a/src/main/java/org/riptide/flows/parser/ipfix/IpFixFlowBuilder.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/IpFixFlowBuilder.java
@@ -242,10 +242,33 @@ public class IpFixFlowBuilder {
                         }).orElse(SamplingAlgorithm.Unassigned);
             }
 
+            /**
+             * What the record carries, then what the selector algorithm implies, then what the
+             * operator configured, then unsampled. Algorithms 0, 8 and 9 have no expressible
+             * interval and yield NaN, which is honest but would land in a Float64 column and
+             * poison any aggregate multiplying by it — so it falls through as unknown instead.
+             */
             @Override
             public double getSamplingInterval() {
-                return Optionals.first(rawFlow.samplingInterval, rawFlow.samplerRandomInterval)
-                        .orElseGet(() -> {
+                // Evaluated in order and lazily: the selector-algorithm derivation divides by
+                // exporter-supplied ranges, so it must not run for a record that already carries
+                // its rate — a degenerate range would then cost the whole packet's batch.
+                final Double onRecord = Optionals.first(
+                                usable(rawFlow.samplingInterval),
+                                usable(rawFlow.samplerRandomInterval))
+                        .orElse(null);
+                if (onRecord != null) {
+                    return onRecord;
+                }
+                final Double derived = usable(fromSelectorAlgorithm());
+                if (derived != null) {
+                    return derived;
+                }
+                return Optionals.first(usable(asDouble(flowSamplingIntervalFallback))).orElse(1.0);
+            }
+
+            /** RFC 5477 selector algorithms, as an interval where one is expressible. */
+            private Double fromSelectorAlgorithm() {
                             switch (rawFlow.selectorAlgorithm) {
                                 case 0, 8, 9 -> {
                                     return Double.NaN;
@@ -269,13 +292,21 @@ public class IpFixFlowBuilder {
                                     final var selectedRangeMax = Optionals.of(rawFlow.hashSelectedRangeMax).orElse(UnsignedLong.MAX_VALUE);
                                     final var outputRangeMin = Optionals.of(rawFlow.hashOutputRangeMin).orElse(UnsignedLong.ZERO);
                                     final var outputRangeMax = Optionals.of(rawFlow.hashOutputRangeMax).orElse(UnsignedLong.MAX_VALUE);
-                                    return (outputRangeMax.minus(outputRangeMin)).dividedBy(selectedRangeMax.minus(selectedRangeMin)).doubleValue();
+                                    final var selectedRange = selectedRangeMax.minus(selectedRangeMin);
+                                    // An exporter is free to send a degenerate range; dividing by it
+                                    // would throw and cost the whole packet, so treat it as unknown.
+                                    if (selectedRange.equals(UnsignedLong.ZERO)) {
+                                        return null;
+                                    }
+                                    return (outputRangeMax.minus(outputRangeMin)).dividedBy(selectedRange).doubleValue();
                                 }
                                 case null, default -> {
-                                    return 1.0;
+                                    // No algorithm, or one this does not model: nothing was
+                                    // derived, so fall through rather than assert "not sampled" —
+                                    // that would outrank a configured fallback with a guess.
+                                    return null;
                                 }
                             }
-                        });
             }
 
             @Override
@@ -318,6 +349,20 @@ public class IpFixFlowBuilder {
                 return FlowProtocol.IPFIX;
             }
         };
+    }
+
+    /**
+     * A rate counts as an answer when it is present and finite, including an explicit 1: an
+     * exporter stating it does not sample has answered, and must not be overridden by a
+     * receiver-wide fallback meant for a different exporter. Absent, 0 (a placeholder) and
+     * non-finite — which is what an inexpressible selector algorithm yields — fall through.
+     */
+    private static Double usable(final Double interval) {
+        return interval != null && Double.isFinite(interval) && interval >= 1.0 ? interval : null;
+    }
+
+    private static Double asDouble(final Long value) {
+        return value != null ? value.doubleValue() : null;
     }
 
     private Stream<IpfixRawFlow> createRawFlows(final Packet packet) {

--- a/src/main/java/org/riptide/flows/parser/netflow9/Netflow9FlowBuilder.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/Netflow9FlowBuilder.java
@@ -12,11 +12,17 @@ import org.riptide.flows.parser.data.Flow;
 import org.riptide.flows.parser.data.Optionals;
 import org.riptide.flows.parser.data.Timeout;
 import org.riptide.flows.parser.netflow9.proto.Packet;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import org.riptide.flows.parser.session.ExporterSamplingTable;
+import org.riptide.flows.parser.session.ExporterSamplingTable.AdvertisedRate;
+import org.riptide.pipeline.ExporterIdentity;
 
 import java.net.InetAddress;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 public class Netflow9FlowBuilder {
@@ -35,18 +41,54 @@ public class Netflow9FlowBuilder {
     @Setter
     private Long flowSamplingIntervalFallback;
 
+    /**
+     * Rates this exporter advertised in a sampler options record. Optional: unset means no
+     * correlation, and the ladder falls through to the configured fallback as before.
+     */
+    @Getter
+    @Setter
+    private ExporterSamplingTable samplingTable;
+
     public Netflow9FlowBuilder(final ValueConversionService conversionService) {
         this.conversionService = Objects.requireNonNull(conversionService);
     }
 
+    /** Without an identity there is no exporter to look a learned rate up for. */
     public Stream<Flow> buildFlows(final Instant receivedAt,
                                    final Packet packet) {
+        return buildFlows(receivedAt, packet, null);
+    }
+
+    /**
+     * The exporter identity is threaded in rather than held on the builder: one UDP parser fronts
+     * every exporter sending to its port, so a builder-scoped rate would be handed to whichever
+     * exporter happened to send next.
+     */
+    public Stream<Flow> buildFlows(final Instant receivedAt,
+                                   final Packet packet,
+                                   final ExporterIdentity identity) {
+        // Resolved lazily and at most once per packet: a record carrying its own rate never asks,
+        // so an exporter that always states it does not register as a permanent lookup miss.
+        final Supplier<Optional<AdvertisedRate>> advertised = Suppliers.memoize(
+                () -> this.samplingTable != null ? this.samplingTable.lookup(identity) : Optional.empty());
         return createRawFlows(packet)
-                .map(rawFlow -> buildFlow(receivedAt, rawFlow));
+                .map(rawFlow -> buildFlow(receivedAt, rawFlow, advertised));
     }
 
     public Flow buildFlow(final Instant receivedAt,
                           final Netflow9RawFlow raw) {
+        return buildFlow(receivedAt, raw, (AdvertisedRate) null);
+    }
+
+    public Flow buildFlow(final Instant receivedAt,
+                          final Netflow9RawFlow raw,
+                          final AdvertisedRate advertisedRate) {
+        return buildFlow(receivedAt, raw, () -> Optional.ofNullable(advertisedRate));
+    }
+
+    private Flow buildFlow(final Instant receivedAt,
+                           final Netflow9RawFlow raw,
+                           final Supplier<Optional<AdvertisedRate>> advertised) {
         final var bootTime = raw.unixSecs.minus(raw.sysUpTime);
 
         return new Flow() {
@@ -228,20 +270,53 @@ public class Netflow9FlowBuilder {
                 return Optionals.of(raw.TOS).orElse(0);
             }
 
+            /**
+             * The mode from a sampler record counts as well as field 35, as it does in the IPFIX
+             * builder. Without it a record carrying only field 49 reports an interval alongside
+             * {@code Unassigned}, which reads as self-contradictory.
+             */
             @Override
             public Flow.SamplingAlgorithm getSamplingAlgorithm() {
-                return switch (raw.SAMPLING_ALGORITHM) {
+                final Integer mode = Optionals.first(raw.SAMPLING_ALGORITHM, raw.FLOW_SAMPLER_MODE)
+                        .or(() -> advertised.get().map(AdvertisedRate::mode))
+                        .orElse(null);
+                return switch (mode) {
                     case 1 -> Flow.SamplingAlgorithm.SystematicCountBasedSampling;
                     case 2 -> Flow.SamplingAlgorithm.RandomNOutOfNSampling;
                     case null, default -> Flow.SamplingAlgorithm.Unassigned;
                 };
             }
 
+            /**
+             * What the exporter put on this record, then what it advertised in its sampler
+             * options table, then what the operator configured, then unsampled. A sampling
+             * exporter usually states its rate only in the options table, so without the middle
+             * rung this reports 1.0 for a router sampling 1:1000.
+             */
             @Override
             public double getSamplingInterval() {
-                return Optionals.of(raw.SAMPLING_INTERVAL).orElse(1.0);
+                return Optionals.first(
+                                usable(raw.SAMPLING_INTERVAL),
+                                usable(raw.FLOW_SAMPLER_RANDOM_INTERVAL))
+                        .or(() -> advertised.get().map(AdvertisedRate::interval).map(Netflow9FlowBuilder::usable))
+                        .or(() -> Optional.ofNullable(usable(asDouble(flowSamplingIntervalFallback))))
+                        .orElse(1.0);
             }
         };
+    }
+
+    /**
+     * A rate counts as an answer when it is present and finite, including an explicit 1: an
+     * exporter stating it does not sample has answered, and must not be overridden by a
+     * receiver-wide fallback meant for a different exporter on the same port. Only absent, 0
+     * (which exporters use as a placeholder) and non-finite fall through to the next rung.
+     */
+    private static Double usable(final Double interval) {
+        return interval != null && Double.isFinite(interval) && interval >= 1.0 ? interval : null;
+    }
+
+    private static Double asDouble(final Long value) {
+        return value != null ? value.doubleValue() : null;
     }
 
     private Stream<Netflow9RawFlow> createRawFlows(Packet packet) {

--- a/src/main/java/org/riptide/flows/parser/netflow9/Netflow9RawFlow.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/Netflow9RawFlow.java
@@ -45,6 +45,10 @@ public class Netflow9RawFlow {
     public Integer PROTOCOL;
     public Integer SAMPLING_ALGORITHM;
     public Double SAMPLING_INTERVAL;
+    // Fields 49/50, the pair a sampler options record carries. Named exactly as
+    // InformationElementProvider registers them, which is how ValueConversionService binds them.
+    public Integer FLOW_SAMPLER_MODE;
+    public Double FLOW_SAMPLER_RANDOM_INTERVAL;
     public InetAddress IPV6_SRC_ADDR;
     public InetAddress IPV4_SRC_ADDR;
     public Long SRC_AS;

--- a/src/main/java/org/riptide/flows/parser/netflow9/Netflow9UdpParser.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/Netflow9UdpParser.java
@@ -8,6 +8,8 @@ package org.riptide.flows.parser.netflow9;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.MoreObjects;
 import io.netty.buffer.ByteBuf;
+import org.riptide.pipeline.ExporterIdentity;
+import org.riptide.flows.parser.session.ExporterSamplingTable;
 import org.riptide.flows.listeners.multi.DispatchableUdpParser;
 import org.riptide.flows.parser.Protocol;
 import org.riptide.flows.parser.UdpParserBase;
@@ -51,11 +53,15 @@ public class Netflow9UdpParser extends UdpParserBase implements DispatchableUdpP
                                final ByteBuf buffer) throws Exception {
         final Header header = new Header(slice(buffer, Header.SIZE));
         final Packet packet = new Packet(session, header, buffer);
+        // The same identity the option tap keys sampler rates by, so a rate learned from this
+        // exporter's options table is found again here.
+        final ExporterIdentity exporter =
+                new ExporterIdentity.NetflowIpfix(session.getRemoteAddress(), header.sourceId);
 
         return new FlowPacket() {
             @Override
             public Stream<Flow> buildFlows(final Instant receivedAt) {
-                return flowBuilder.buildFlows(receivedAt, packet);
+                return flowBuilder.buildFlows(receivedAt, packet, exporter);
             }
 
             @Override
@@ -144,6 +150,12 @@ public class Netflow9UdpParser extends UdpParserBase implements DispatchableUdpP
 
     public Netflow9UdpParser withFlowSamplingIntervalFallback(final Long flowSamplingIntervalFallback) {
         this.flowBuilder.setFlowSamplingIntervalFallback(flowSamplingIntervalFallback);
+        return this;
+    }
+
+    /** Rates learned from sampler options records; see {@link ExporterSamplingTable}. */
+    public Netflow9UdpParser withSamplingTable(final ExporterSamplingTable samplingTable) {
+        this.flowBuilder.setSamplingTable(samplingTable);
         return this;
     }
 }

--- a/src/main/java/org/riptide/flows/parser/session/ExporterSamplingTable.java
+++ b/src/main/java/org/riptide/flows/parser/session/ExporterSamplingTable.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.parser.session;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.primitives.UnsignedLong;
+import org.riptide.flows.parser.ie.Value;
+import org.riptide.flows.parser.ie.values.visitor.UnsignedLongVisitor;
+import org.riptide.pipeline.ExporterIdentity;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Sampling rates pushed by exporters as v9/IPFIX option records. A sampling exporter states its
+ * rate once in a sampler options table and then omits it from every flow record, so without this
+ * the collector records "not sampled" for a router sampling 1:1000.
+ *
+ * <p>Fed by the option tap ({@link OptionListener}) rather than the per-record option merge, for
+ * the same reason {@code ExporterInterfaceTable} is. The sampler table is <em>System</em>-scoped
+ * (verified against {@code netflow9_test_cisco_asr9k_opttpl257.dat}: scope {@code (1, 4)}, fields
+ * 48/50/49/84). {@code lookupOptions} does synthesize a {@code SCOPE:SYSTEM} value for every data
+ * record, so the scope <em>name</em> matches — but it synthesizes the observation domain, while a
+ * real ASR9k writes its agent IP into that scope field. The keys never agree, so the merge cannot
+ * deliver the record and the tap is the only path that reaches it.
+ *
+ * <p>Keyed by {@link ExporterIdentity} alone, which already carries source address plus
+ * observation domain. Deliberately not keyed by {@code FLOW_SAMPLER_ID}: one rate per exporter and
+ * observation domain is the scope goflow2 and NetGauze both settled on, and a second key on a
+ * field many exporters omit from data records buys nothing.
+ */
+@Component
+public class ExporterSamplingTable implements OptionListener {
+
+    /**
+     * The rate, under every name the two protocols use for it. Field 50 first: the ASR9k sampler
+     * table carries {@code FLOW_SAMPLER_RANDOM_INTERVAL} and no field 34 at all, and goflow2
+     * resolves in the same order for the same reason.
+     */
+    private static final List<String> INTERVAL_FIELDS = List.of(
+            "FLOW_SAMPLER_RANDOM_INTERVAL", "samplerRandomInterval",
+            "SAMPLING_INTERVAL", "samplingInterval");
+
+    /**
+     * The sampling mode from the same record. Carried with the rate so a flow resolving one from
+     * the options table can resolve the other too, rather than reporting an interval next to
+     * {@code Unassigned}.
+     */
+    private static final List<String> MODE_FIELDS = List.of(
+            "FLOW_SAMPLER_MODE", "samplerMode",
+            "SAMPLING_ALGORITHM", "samplingAlgorithm");
+
+    /** What an exporter advertised: the interval, and the mode when it stated one. */
+    public record AdvertisedRate(double interval, Integer mode) {
+    }
+
+    /**
+     * Twice the slowest default refresh among the platforms this targets. IOS-XE defaults
+     * {@code option sampler-table timeout} to 600 s, but IOS-XR — the ASR9k this was built against
+     * — defaults {@code options sampler-table timeout} to 1800 s. A TTL shorter than the refresh
+     * expires mid-cycle, and the exporter's flows then flap between its real rate and "unsampled"
+     * with nothing in the data to tell the two apart.
+     */
+    private static final Duration RETENTION = Duration.ofMinutes(60);
+
+    /**
+     * One entry per exporter and observation domain. Bounded because entries arrive from whatever
+     * sends option records, including spoofed sources, and lazy expiry alone would let a burst grow
+     * the map for a whole TTL window.
+     */
+    private static final long MAX_EXPORTERS = 8_192;
+
+    private final Cache<ExporterIdentity, AdvertisedRate> table;
+
+    private final Meter recordsConsumed;
+    private final Meter recordsSkipped;
+    private final Meter lookupsResolved;
+    private final Meter lookupsUnresolved;
+
+    public ExporterSamplingTable(final MetricRegistry metrics) {
+        this.table = CacheBuilder.newBuilder()
+                .expireAfterWrite(RETENTION)
+                .maximumSize(MAX_EXPORTERS)
+                .build();
+        this.recordsConsumed = metrics.meter(MetricRegistry.name("parser", "optionSampling", "consumed"));
+        this.recordsSkipped = metrics.meter(MetricRegistry.name("parser", "optionSampling", "skipped"));
+        this.lookupsResolved = metrics.meter(MetricRegistry.name("parser", "optionSampling", "resolved"));
+        this.lookupsUnresolved = metrics.meter(MetricRegistry.name("parser", "optionSampling", "unresolved"));
+    }
+
+    @Override
+    public void accept(final ExporterIdentity identity, final Collection<Value<?>> scopes, final List<Value<?>> values) {
+        final Double interval = unsigned(values, INTERVAL_FIELDS);
+        if (interval == null) {
+            return; // not a sampler option record (interface/VRF/app tables, …)
+        }
+        if (!isUsableRate(interval)) {
+            // An explicit 1 is kept: it means "not sampling", which is an answer, and dropping it
+            // would let a receiver-wide fallback meant for a different exporter override this one.
+            // 0 is different — an exporter re-advertises 0 when sampling is turned off, so treat it
+            // as a withdrawal and drop what was learned rather than serving it until the TTL runs.
+            this.table.invalidate(identity);
+            this.recordsSkipped.mark();
+            return;
+        }
+        final Double mode = unsigned(values, MODE_FIELDS);
+        this.table.put(identity, new AdvertisedRate(interval, mode != null ? mode.intValue() : null));
+        this.recordsConsumed.mark();
+    }
+
+    /**
+     * The rate this exporter advertised, empty when it has not advertised one (yet).
+     *
+     * <p>A miss is metered, and callers are expected to ask only when they actually need an
+     * answer — metering a lookup whose result is discarded would report a permanent miss for every
+     * exporter that puts its rate on the record. Immediately after start a miss is expected: the
+     * exporter re-sends its options table on its own timer, and nothing can be known before it
+     * arrives. A miss rate that does not settle means this exporter never advertises one, and
+     * needs {@code flow-sampling-interval-fallback} configured instead.
+     */
+    public Optional<AdvertisedRate> lookup(final ExporterIdentity identity) {
+        final AdvertisedRate rate = identity != null ? this.table.getIfPresent(identity) : null;
+        if (rate == null) {
+            this.lookupsUnresolved.mark();
+            return Optional.empty();
+        }
+        this.lookupsResolved.mark();
+        return Optional.of(rate);
+    }
+
+    private static boolean isUsableRate(final double interval) {
+        return Double.isFinite(interval) && interval >= 1.0;
+    }
+
+    private static Double unsigned(final Collection<Value<?>> values, final List<String> names) {
+        for (final String name : names) {
+            for (final Value<?> value : values) {
+                if (name.equals(value.getName())) {
+                    final UnsignedLong u = value.accept(new UnsignedLongVisitor());
+                    if (u != null) {
+                        return u.doubleValue();
+                    }
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/riptide/flows/parser/session/OptionListener.java
+++ b/src/main/java/org/riptide/flows/parser/session/OptionListener.java
@@ -24,4 +24,14 @@ public interface OptionListener {
     };
 
     void accept(ExporterIdentity identity, Collection<Value<?>> scopes, List<Value<?>> values);
+
+    /**
+     * Fans one tap out to several consumers. Option records are a shared stream — one table reads
+     * interface names out of it, another sampling rates — and each consumer already ignores the
+     * records it does not recognize, so the fan-out needs no filtering of its own.
+     */
+    static OptionListener of(final OptionListener... listeners) {
+        final List<OptionListener> targets = List.of(listeners);
+        return (identity, scopes, values) -> targets.forEach(l -> l.accept(identity, scopes, values));
+    }
 }

--- a/src/test/java/org/riptide/flows/netflow9/SamplerOptionsBlackboxTest.java
+++ b/src/test/java/org/riptide/flows/netflow9/SamplerOptionsBlackboxTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.netflow9;
+
+import com.codahale.metrics.MetricRegistry;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.Test;
+import org.riptide.flows.parser.netflow9.proto.Header;
+import org.riptide.flows.parser.netflow9.proto.Packet;
+import org.riptide.flows.parser.session.ExporterSamplingTable;
+import org.riptide.flows.parser.session.SequenceNumberTracker;
+import org.riptide.flows.parser.session.Session;
+import org.riptide.flows.parser.session.TcpSession;
+import org.riptide.flows.parser.ie.values.visitor.BooleanVisitor;
+import org.riptide.flows.parser.ie.values.visitor.DoubleVisitor;
+import org.riptide.flows.parser.ie.values.visitor.DurationVisitor;
+import org.riptide.flows.parser.ie.values.visitor.InetAddressVisitor;
+import org.riptide.flows.parser.ie.values.visitor.InstantVisitor;
+import org.riptide.flows.parser.ie.values.visitor.IntegerVisitor;
+import org.riptide.flows.parser.ie.values.visitor.LongVisitor;
+import org.riptide.flows.parser.ie.values.visitor.StringVisitor;
+import org.riptide.flows.parser.ie.values.visitor.UnsignedLongVisitor;
+import org.riptide.flows.parser.ie.values.visitor.ValueVisitor;
+import org.riptide.pipeline.ExporterIdentity;
+
+import java.util.List;
+
+import java.net.InetAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.riptide.flows.utils.BufferUtils.slice;
+
+/**
+ * Drives a sampler options record through the real v9 parse path (Packet → session.addOptions →
+ * option tap) into the sampling table, the seam the unit tests take on trust.
+ *
+ * <p>The options <em>template</em> is a genuine ASR9k capture; the options <em>data</em> record is
+ * built against it, because the repository has no captured data record for template 257. Field
+ * ids, widths and order therefore come from real hardware and only the values are synthetic.
+ */
+public class SamplerOptionsBlackboxTest {
+
+    private static final Path FOLDER = Paths.get("src/test/resources/flows");
+
+    private static final List<ValueVisitor<?>> VISITORS = List.of(
+            new BooleanVisitor(), new DoubleVisitor(), new DurationVisitor(), new InetAddressVisitor(),
+            new InstantVisitor(), new IntegerVisitor(), new LongVisitor(), new StringVisitor(),
+            new UnsignedLongVisitor());
+
+    /** The observation domain the captured ASR9k fixtures were exported from. */
+    private static final long SOURCE_ID = 2177;
+
+    private final ExporterSamplingTable table = new ExporterSamplingTable(new MetricRegistry());
+
+    private final Session session =
+            new TcpSession(InetAddress.getLoopbackAddress(), () -> new SequenceNumberTracker(32), this.table);
+
+    private void parseV9(final ByteBuf buf) throws Exception {
+        do {
+            new Packet(this.session, new Header(slice(buf, Header.SIZE)), buf);
+        } while (buf.isReadable());
+    }
+
+    /**
+     * One options data record for template 257, whose confirmed layout is
+     * scope System(4), then FLOW_SAMPLER_ID(2), FLOW_SAMPLER_RANDOM_INTERVAL(4),
+     * FLOW_SAMPLER_MODE(1), SAMPLER_NAME(32).
+     */
+    private static ByteBuf samplerOptionsData(final long randomInterval) {
+        final ByteBuf b = Unpooled.buffer();
+        b.writeShort(9).writeShort(1)               // version, count
+                .writeInt(1000)                     // sysUpTime
+                .writeInt(1_700_000_000)            // unixSecs
+                .writeInt(2)                        // sequence
+                .writeInt((int) SOURCE_ID);         // sourceId
+
+        final int recordLength = 4 + 2 + 4 + 1 + 32;
+        b.writeShort(257).writeShort(4 + recordLength + 1); // set id, length incl. header + pad
+        b.writeInt(0);                              // scope: System
+        b.writeShort(1);                            // FLOW_SAMPLER_ID
+        b.writeInt((int) randomInterval);           // FLOW_SAMPLER_RANDOM_INTERVAL
+        b.writeByte(2);                             // FLOW_SAMPLER_MODE (random)
+        b.writeBytes("SAMPLER-1".getBytes(java.nio.charset.StandardCharsets.US_ASCII));
+        b.writeZero(32 - "SAMPLER-1".length());     // SAMPLER_NAME, NUL-padded
+        b.writeZero(1);                             // set padding to a 4-byte boundary
+        return b;
+    }
+
+    @Test
+    public void samplerOptionsRecordReachesTheSamplingTable() throws Exception {
+        parseV9(Unpooled.wrappedBuffer(Files.readAllBytes(FOLDER.resolve("netflow9_test_cisco_asr9k_opttpl257.dat"))));
+        parseV9(samplerOptionsData(1000));
+
+        final var identity = new ExporterIdentity.NetflowIpfix(InetAddress.getLoopbackAddress(), SOURCE_ID);
+        assertThat(this.table.lookup(identity).map(ExporterSamplingTable.AdvertisedRate::interval)).contains(1000.0);
+    }
+
+    /**
+     * The seam between learning and resolving: the identity {@code Netflow9UdpParser} builds for a
+     * data packet must be the identity the option tap stored the rate under. These are constructed
+     * on opposite sides of the codebase, and a mismatch in either component would leave every
+     * lookup missing while both halves still passed their own tests.
+     */
+    @Test
+    public void theIdentityTheParserBuildsFindsTheRateTheTapStored() throws Exception {
+        parseV9(Unpooled.wrappedBuffer(Files.readAllBytes(FOLDER.resolve("netflow9_test_cisco_asr9k_opttpl257.dat"))));
+        parseV9(samplerOptionsData(1000));
+
+        // exactly what Netflow9UdpParser.parse() constructs: session address plus header sourceId
+        final var asTheParserBuildsIt =
+                new ExporterIdentity.NetflowIpfix(this.session.getRemoteAddress(), SOURCE_ID);
+
+        final var builder = new org.riptide.flows.parser.netflow9.Netflow9FlowBuilder(
+                new org.riptide.flows.parser.ie.values.ValueConversionService(
+                        org.riptide.flows.parser.netflow9.Netflow9RawFlow.class, VISITORS));
+        builder.setSamplingTable(this.table);
+
+        final var raw = new org.riptide.flows.parser.netflow9.Netflow9RawFlow();
+        raw.unixSecs = java.time.Instant.EPOCH;
+        raw.sysUpTime = java.time.Duration.ZERO;
+
+        assertThat(builder.buildFlow(java.time.Instant.EPOCH, raw,
+                this.table.lookup(asTheParserBuildsIt).orElse(null)).getSamplingInterval())
+                .isEqualTo(1000.0);
+    }
+
+    /** Nothing is known before the exporter sends its table, which is the documented startup gap. */
+    @Test
+    public void nothingIsKnownBeforeTheOptionsRecordArrives() throws Exception {
+        parseV9(Unpooled.wrappedBuffer(Files.readAllBytes(FOLDER.resolve("netflow9_test_cisco_asr9k_opttpl257.dat"))));
+
+        final var identity = new ExporterIdentity.NetflowIpfix(InetAddress.getLoopbackAddress(), SOURCE_ID);
+        assertThat(this.table.lookup(identity)).isEmpty();
+    }
+
+    /** A refreshed table supersedes the rate, so a re-provisioned sampler is picked up. */
+    @Test
+    public void aRefreshedTableSupersedesTheRate() throws Exception {
+        parseV9(Unpooled.wrappedBuffer(Files.readAllBytes(FOLDER.resolve("netflow9_test_cisco_asr9k_opttpl257.dat"))));
+        parseV9(samplerOptionsData(1000));
+        parseV9(samplerOptionsData(4096));
+
+        final var identity = new ExporterIdentity.NetflowIpfix(InetAddress.getLoopbackAddress(), SOURCE_ID);
+        assertThat(this.table.lookup(identity).map(ExporterSamplingTable.AdvertisedRate::interval)).contains(4096.0);
+    }
+
+    /**
+     * The interface options table shares this tap and must not be read as a sampler record — the
+     * captured ASR9k interface table carries no sampling field at all.
+     */
+    @Test
+    public void theInterfaceOptionsTableIsNotMistakenForASamplerTable() throws Exception {
+        parseV9(Unpooled.wrappedBuffer(Files.readAllBytes(FOLDER.resolve("netflow9_test_cisco_asr9k_opttpl256.dat"))));
+        parseV9(Unpooled.wrappedBuffer(Files.readAllBytes(FOLDER.resolve("netflow9_test_cisco_asr9k_data256.dat"))));
+
+        final var identity = new ExporterIdentity.NetflowIpfix(InetAddress.getLoopbackAddress(), SOURCE_ID);
+        assertThat(this.table.lookup(identity)).isEmpty();
+    }
+}

--- a/src/test/java/org/riptide/flows/parser/SamplingIntervalResolutionTest.java
+++ b/src/test/java/org/riptide/flows/parser/SamplingIntervalResolutionTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.parser;
+
+import com.codahale.metrics.MetricRegistry;
+import org.junit.jupiter.api.Test;
+import org.riptide.flows.parser.ie.Value;
+import org.riptide.flows.parser.ie.values.UnsignedValue;
+import org.riptide.flows.parser.ie.values.ValueConversionService;
+import org.riptide.flows.parser.ie.values.visitor.BooleanVisitor;
+import org.riptide.flows.parser.ie.values.visitor.DoubleVisitor;
+import org.riptide.flows.parser.ie.values.visitor.DurationVisitor;
+import org.riptide.flows.parser.ie.values.visitor.InetAddressVisitor;
+import org.riptide.flows.parser.ie.values.visitor.InstantVisitor;
+import org.riptide.flows.parser.ie.values.visitor.IntegerVisitor;
+import org.riptide.flows.parser.ie.values.visitor.LongVisitor;
+import org.riptide.flows.parser.ie.values.visitor.StringVisitor;
+import org.riptide.flows.parser.ie.values.visitor.UnsignedLongVisitor;
+import org.riptide.flows.parser.ie.values.visitor.ValueVisitor;
+import org.riptide.flows.parser.ipfix.IpFixFlowBuilder;
+import org.riptide.flows.parser.ipfix.IpfixRawFlow;
+import org.riptide.flows.parser.netflow9.Netflow9FlowBuilder;
+import org.riptide.flows.parser.netflow9.Netflow9RawFlow;
+import org.riptide.flows.parser.session.ExporterSamplingTable;
+import org.riptide.flows.parser.session.ExporterSamplingTable.AdvertisedRate;
+import org.riptide.pipeline.ExporterIdentity;
+
+import java.net.InetAddress;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The sampling-rate resolution ladder: what the record carries, then what the exporter advertised
+ * in its sampler options table, then what the operator configured, then unsampled.
+ *
+ * <p>Built by hand rather than through Spring, following the fuzz harness.
+ */
+class SamplingIntervalResolutionTest {
+
+    private static final List<ValueVisitor<?>> VISITORS = List.of(
+            new BooleanVisitor(), new DoubleVisitor(), new DurationVisitor(), new InetAddressVisitor(),
+            new InstantVisitor(), new IntegerVisitor(), new LongVisitor(), new StringVisitor(),
+            new UnsignedLongVisitor());
+
+    private static final ValueConversionService NETFLOW9 =
+            new ValueConversionService(Netflow9RawFlow.class, VISITORS);
+    private static final ValueConversionService IPFIX =
+            new ValueConversionService(IpfixRawFlow.class, VISITORS);
+
+    // ---- NetFlow v9 -------------------------------------------------------------------------
+
+    private static Netflow9RawFlow v9Raw() {
+        final var raw = new Netflow9RawFlow();
+        raw.unixSecs = Instant.EPOCH;
+        raw.sysUpTime = Duration.ZERO;
+        return raw;
+    }
+
+    private static double v9Interval(final Netflow9RawFlow raw, final Double advertised, final Long fallback) {
+        final AdvertisedRate rate = advertised != null ? new AdvertisedRate(advertised, null) : null;
+        final var builder = new Netflow9FlowBuilder(NETFLOW9);
+        builder.setFlowSamplingIntervalFallback(fallback);
+        return builder.buildFlow(Instant.EPOCH, raw, rate).getSamplingInterval();
+    }
+
+    @Test
+    void netflow9PrefersTheRateOnTheRecord() {
+        final var raw = v9Raw();
+        raw.SAMPLING_INTERVAL = 512.0;
+
+        assertThat(v9Interval(raw, 1000.0, 2000L)).isEqualTo(512.0);
+    }
+
+    /** The ASR9k sampler table names the rate field 50, so the record form of it counts too. */
+    @Test
+    void netflow9ReadsTheSamplerRandomIntervalOnTheRecord() {
+        final var raw = v9Raw();
+        raw.FLOW_SAMPLER_RANDOM_INTERVAL = 256.0;
+
+        assertThat(v9Interval(raw, 1000.0, 2000L)).isEqualTo(256.0);
+    }
+
+    /** The case this change exists for: nothing on the record, a rate in the options table. */
+    @Test
+    void netflow9FallsBackToTheAdvertisedRate() {
+        assertThat(v9Interval(v9Raw(), 1000.0, 2000L)).isEqualTo(1000.0);
+    }
+
+    @Test
+    void netflow9FallsBackToConfigurationWhenTheExporterSaysNothing() {
+        assertThat(v9Interval(v9Raw(), null, 2000L)).isEqualTo(2000.0);
+    }
+
+    @Test
+    void netflow9ReportsUnsampledWhenNothingIsKnown() {
+        assertThat(v9Interval(v9Raw(), null, null)).isEqualTo(1.0);
+    }
+
+    /**
+     * An exporter stating 1 has answered "I do not sample", and that answer must stand. One
+     * receiver fronts every exporter on its port while the fallback is per-receiver, so letting a
+     * fallback meant for a silent router override an honest 1 would inflate this exporter by the
+     * whole fallback factor.
+     */
+    @Test
+    void netflow9HonoursAnExplicitlyUnsampledRecordOverTheFallback() {
+        final var raw = v9Raw();
+        raw.SAMPLING_INTERVAL = 1.0;
+
+        assertThat(v9Interval(raw, null, 2000L)).isEqualTo(1.0);
+    }
+
+    /** 0 is a placeholder rather than an answer, so it falls through. */
+    @Test
+    void netflow9TreatsAZeroRecordRateAsNoAnswer() {
+        final var raw = v9Raw();
+        raw.SAMPLING_INTERVAL = 0.0;
+
+        assertThat(v9Interval(raw, null, 2000L)).isEqualTo(2000.0);
+    }
+
+    /** The join this change exists for: a rate in the table reaches the flow the builder makes. */
+    @Test
+    void netflow9ResolvesTheLearnedRateThroughTheSamplingTable() throws Exception {
+        final var table = new ExporterSamplingTable(new MetricRegistry());
+        final var exporter = new ExporterIdentity.NetflowIpfix(InetAddress.getByName("192.0.2.1"), 0);
+        final var other = new ExporterIdentity.NetflowIpfix(InetAddress.getByName("192.0.2.2"), 0);
+        table.accept(exporter, List.of(), List.<Value<?>>of(
+                new UnsignedValue("FLOW_SAMPLER_RANDOM_INTERVAL", 1000),
+                new UnsignedValue("FLOW_SAMPLER_MODE", 2)));
+
+        final var builder = new Netflow9FlowBuilder(NETFLOW9);
+        builder.setSamplingTable(table);
+
+        assertThat(builder.buildFlow(Instant.EPOCH, v9Raw(), table.lookup(exporter).orElse(null))
+                .getSamplingInterval()).isEqualTo(1000.0);
+        assertThat(builder.buildFlow(Instant.EPOCH, v9Raw(), table.lookup(other).orElse(null))
+                .getSamplingInterval()).isEqualTo(1.0);
+        // the mode travels with it, so the pair is not self-contradictory
+        assertThat(builder.buildFlow(Instant.EPOCH, v9Raw(), table.lookup(exporter).orElse(null))
+                .getSamplingAlgorithm())
+                .isEqualTo(org.riptide.flows.parser.data.Flow.SamplingAlgorithm.RandomNOutOfNSampling);
+    }
+
+    /**
+     * The non-goal, pinned: resolving a rate records metadata and nothing else. If volume
+     * correction is ever added it will be a deliberate change to this assertion, not a side effect.
+     */
+    @Test
+    void learningARateLeavesVolumeCountersUntouched() {
+        final var raw = v9Raw();
+        raw.IN_BYTES = 1_500L;
+        raw.IN_PKTS = 10L;
+
+        final var unsampled = new Netflow9FlowBuilder(NETFLOW9).buildFlow(Instant.EPOCH, raw, (AdvertisedRate) null);
+        final var sampled = new Netflow9FlowBuilder(NETFLOW9)
+                .buildFlow(Instant.EPOCH, raw, new AdvertisedRate(1000.0, null));
+
+        assertThat(sampled.getSamplingInterval()).isEqualTo(1000.0);
+        assertThat(unsampled.getSamplingInterval()).isEqualTo(1.0);
+        // only the metadata differs
+        assertThat(sampled.getBytes()).isEqualTo(unsampled.getBytes()).isEqualTo(1_500L);
+        assertThat(sampled.getPackets()).isEqualTo(unsampled.getPackets()).isEqualTo(10L);
+    }
+
+    // ---- IPFIX ------------------------------------------------------------------------------
+
+    private static double ipfixInterval(final IpfixRawFlow raw, final Long fallback) {
+        final var builder = new IpFixFlowBuilder(IPFIX);
+        builder.setFlowSamplingIntervalFallback(fallback);
+        return builder.buildFlow(Instant.EPOCH, raw).getSamplingInterval();
+    }
+
+    /**
+     * Selector algorithms 0, 8 and 9 have no expressible interval. Before this change that reached
+     * the Float64 column as NaN, which would poison any aggregate multiplying by it.
+     */
+    @Test
+    void ipfixInexpressibleSelectorAlgorithmsFallThroughToConfiguration() {
+        for (final int algorithm : new int[]{0, 8, 9}) {
+            final var raw = new IpfixRawFlow();
+            raw.selectorAlgorithm = algorithm;
+
+            assertThat(ipfixInterval(raw, 2000L))
+                    .describedAs("selectorAlgorithm %d", algorithm)
+                    .isEqualTo(2000.0);
+        }
+    }
+
+    @Test
+    void ipfixInexpressibleSelectorAlgorithmsNeverYieldNaN() {
+        for (final int algorithm : new int[]{0, 8, 9}) {
+            final var raw = new IpfixRawFlow();
+            raw.selectorAlgorithm = algorithm;
+
+            final double interval = ipfixInterval(raw, null);
+
+            assertThat(Double.isNaN(interval))
+                    .describedAs("selectorAlgorithm %d produced NaN", algorithm)
+                    .isFalse();
+            assertThat(interval).isEqualTo(1.0);
+        }
+    }
+
+    @Test
+    void ipfixPrefersTheRateOnTheRecord() {
+        final var raw = new IpfixRawFlow();
+        raw.samplingInterval = 512.0;
+
+        assertThat(ipfixInterval(raw, 2000L)).isEqualTo(512.0);
+    }
+
+    @Test
+    void ipfixFallsBackToConfiguration() {
+        assertThat(ipfixInterval(new IpfixRawFlow(), 2000L)).isEqualTo(2000.0);
+    }
+
+}

--- a/src/test/java/org/riptide/flows/parser/session/ExporterSamplingTableTest.java
+++ b/src/test/java/org/riptide/flows/parser/session/ExporterSamplingTableTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.parser.session;
+
+import com.codahale.metrics.MetricRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.riptide.flows.parser.ie.Value;
+import org.riptide.flows.parser.ie.values.UnsignedValue;
+import org.riptide.pipeline.ExporterIdentity;
+
+import java.net.InetAddress;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The sampler options table. Field ids, names and order follow the captured ASR9k template
+ * {@code netflow9_test_cisco_asr9k_opttpl257.dat}: scope System, fields 48/50/49/84.
+ */
+class ExporterSamplingTableTest {
+
+    private ExporterSamplingTable table;
+    private MetricRegistry metrics;
+
+    private static ExporterIdentity exporter(final String address, final long domain) throws Exception {
+        return new ExporterIdentity.NetflowIpfix(InetAddress.getByName(address), domain);
+    }
+
+    /** The shape the ASR9k sampler table sends: a random interval alongside id, mode and name. */
+    private static List<Value<?>> samplerRecord(final long interval) {
+        return List.of(
+                new UnsignedValue("FLOW_SAMPLER_ID", 1),
+                new UnsignedValue("FLOW_SAMPLER_RANDOM_INTERVAL", interval),
+                new UnsignedValue("FLOW_SAMPLER_MODE", 2));
+    }
+
+    @BeforeEach
+    void setUp() {
+        this.metrics = new MetricRegistry();
+        this.table = new ExporterSamplingTable(this.metrics);
+    }
+
+    @Test
+    void learnsTheRateFromASamplerOptionsRecord() throws Exception {
+        final var exporter = exporter("192.0.2.1", 0);
+
+        table.accept(exporter, List.of(), samplerRecord(1000));
+
+        assertThat(table.lookup(exporter).map(ExporterSamplingTable.AdvertisedRate::interval)).contains(1000.0);
+    }
+
+    /** IPFIX names the same thing differently; one table serves both protocols. */
+    @Test
+    void learnsTheRateFromIpfixFieldNames() throws Exception {
+        final var exporter = exporter("192.0.2.1", 0);
+
+        table.accept(exporter, List.of(), List.of(new UnsignedValue("samplerRandomInterval", 512)));
+
+        assertThat(table.lookup(exporter).map(ExporterSamplingTable.AdvertisedRate::interval)).contains(512.0);
+    }
+
+    /**
+     * Field 34 and the 305/306 pair mean different things, and conflating them is what put Nokia
+     * SROS 500x out in Akvorado. Only the interval is read here; a bare packet-space field is not
+     * mistaken for one.
+     */
+    @Test
+    void doesNotTreatUnrelatedSamplingFieldsAsTheInterval() throws Exception {
+        final var exporter = exporter("192.0.2.1", 0);
+
+        table.accept(exporter, List.of(), List.of(
+                new UnsignedValue("samplingPacketSpace", 499),
+                new UnsignedValue("samplingSize", 1)));
+
+        assertThat(table.lookup(exporter)).isEmpty();
+    }
+
+    @Test
+    void ignoresOptionRecordsThatAreNotAboutSampling() throws Exception {
+        final var exporter = exporter("192.0.2.1", 0);
+
+        // the interface table's record, which shares the same option tap
+        table.accept(exporter, List.of(), List.of(new UnsignedValue("INPUT_SNMP", 7)));
+
+        assertThat(table.lookup(exporter)).isEmpty();
+        assertThat(metrics.meter("parser.optionSampling.consumed").getCount()).isZero();
+    }
+
+    /** 0 is a placeholder, not a rate, so nothing is learned from it. */
+    @Test
+    void skipsAZeroRate() throws Exception {
+        final var exporter = exporter("192.0.2.1", 0);
+
+        table.accept(exporter, List.of(), samplerRecord(0));
+
+        assertThat(table.lookup(exporter)).isEmpty();
+        assertThat(metrics.meter("parser.optionSampling.skipped").getCount()).isEqualTo(1);
+    }
+
+    /**
+     * An exporter advertising 1 has stated it does not sample. That is an answer, and keeping it
+     * stops a receiver-wide fallback meant for a different exporter from overriding this one.
+     */
+    @Test
+    void keepsAnExplicitlyUnsampledRate() throws Exception {
+        final var exporter = exporter("192.0.2.1", 0);
+
+        table.accept(exporter, List.of(), samplerRecord(1));
+
+        assertThat(table.lookup(exporter).map(ExporterSamplingTable.AdvertisedRate::interval)).contains(1.0);
+    }
+
+    @Test
+    void keepsExportersApart() throws Exception {
+        final var first = exporter("192.0.2.1", 0);
+        final var second = exporter("192.0.2.2", 0);
+
+        table.accept(first, List.of(), samplerRecord(1000));
+
+        assertThat(table.lookup(first).map(ExporterSamplingTable.AdvertisedRate::interval)).contains(1000.0);
+        assertThat(table.lookup(second)).isEmpty();
+    }
+
+    /** Two observation domains behind one address are two exporters, and may sample differently. */
+    @Test
+    void keepsObservationDomainsApart() throws Exception {
+        final var domainZero = exporter("192.0.2.1", 0);
+        final var domainOne = exporter("192.0.2.1", 1);
+
+        table.accept(domainZero, List.of(), samplerRecord(1000));
+        table.accept(domainOne, List.of(), samplerRecord(100));
+
+        assertThat(table.lookup(domainZero).map(ExporterSamplingTable.AdvertisedRate::interval)).contains(1000.0);
+        assertThat(table.lookup(domainOne).map(ExporterSamplingTable.AdvertisedRate::interval)).contains(100.0);
+    }
+
+    @Test
+    void aLaterRecordSupersedesAnEarlierOne() throws Exception {
+        final var exporter = exporter("192.0.2.1", 0);
+
+        table.accept(exporter, List.of(), samplerRecord(1000));
+        table.accept(exporter, List.of(), samplerRecord(2000));
+
+        assertThat(table.lookup(exporter).map(ExporterSamplingTable.AdvertisedRate::interval)).contains(2000.0);
+    }
+
+    @Test
+    void metersResolvedAndUnresolvedLookups() throws Exception {
+        final var known = exporter("192.0.2.1", 0);
+        final var unknown = exporter("192.0.2.9", 0);
+        table.accept(known, List.of(), samplerRecord(1000));
+
+        table.lookup(known);
+        table.lookup(unknown);
+        table.lookup(null);
+
+        assertThat(metrics.meter("parser.optionSampling.resolved").getCount()).isEqualTo(1);
+        assertThat(metrics.meter("parser.optionSampling.unresolved").getCount()).isEqualTo(2);
+    }
+
+    /** The mode travels with the rate, so a flow resolving one can resolve the other. */
+    @Test
+    void learnsTheSamplingModeAlongsideTheRate() throws Exception {
+        final var exporter = exporter("192.0.2.1", 0);
+
+        table.accept(exporter, List.of(), samplerRecord(1000));
+
+        assertThat(table.lookup(exporter).map(ExporterSamplingTable.AdvertisedRate::mode)).contains(2);
+    }
+
+    /** An exporter re-advertising 0 has turned sampling off; the stale rate must not outlive it. */
+    @Test
+    void aZeroRateWithdrawsWhatWasLearned() throws Exception {
+        final var exporter = exporter("192.0.2.1", 0);
+        table.accept(exporter, List.of(), samplerRecord(1000));
+
+        table.accept(exporter, List.of(), samplerRecord(0));
+
+        assertThat(table.lookup(exporter)).isEmpty();
+    }
+}


### PR DESCRIPTION
## What does this change?

A NetFlow v9 exporter that samples states its rate once in a sampler options table and then omits it from every flow record. `Netflow9FlowBuilder` read only `SAMPLING_INTERVAL` (34) off the data record and returned `1.0` when it was absent, so riptide recorded "not sampled" for a router sampling 1:1000. The configured escape hatch did not work either: `flow-sampling-interval-fallback` travelled all the way into both flow builders and was stored in a field neither ever read.

The rate is now learned from the options record. `ExporterSamplingTable` taps `OptionListener` next to `ExporterInterfaceTable` and keys the rate by `ExporterIdentity`, which already carries source address plus observation domain. `Netflow9FlowBuilder` then resolves through a ladder: what the record carries, then the learned rate, then the configured fallback, then unsampled. The exporter always wins over configuration, matching how the timeout fallbacks already behave.

The tap rather than the per-record merge, because the sampler table is System-scoped. `lookupOptions` does synthesize a `SCOPE:SYSTEM` value for every data record, but it synthesizes the observation domain while a real ASR9k writes its agent IP into that scope field, so the keys never agree and the merge cannot deliver the record.

`ExporterIdentity` is threaded into `buildFlows` rather than held on the builder, since one UDP parser fronts every exporter sending to its port.

Also in scope: a non-finite rate now falls through as unknown, so IPFIX selector algorithms 0, 8 and 9 stop writing `NaN` into a `Float64` column that any future aggregate would multiply by.

Closes #435

### Deliberately not included

**Scaling `bytes`/`packets` by the rate.** Raw counters plus an accurate per-row rate is where Akvorado, goflow2 and ktranslate all stop, and choosing otherwise means resolving riptide's existing split, where sFlow scales at ingest by specification while NetFlow and IPFIX stay raw. A test pins the boundary so it cannot erode by accident.

**The NetFlow v5 header rate.** Started, then pulled back out: `netflow5_test_juniper_mx80.dat` and `jflow-packet.dat` both send mode 0 with a non-zero interval (1000 and 20), so reading the header would flip existing v5 deployments away from 1.0 unannounced and emit `(Unassigned, 1000)` pairs that the `riptide-data-trust` dashboard groups on. Worth its own change.

**IPFIX options correlation.** IPFIX option records populate the table but nothing reads them yet; the docs now say so explicitly rather than implying protocol-neutral behaviour.

## How was it verified?

`make jar` green: 953 tests, SpotBugs clean, coverage met.

29 new tests. The one worth naming is `SamplerOptionsBlackboxTest`, which drives the genuine captured ASR9k options template (`netflow9_test_cisco_asr9k_opttpl257.dat`, scope System, fields 48/50/49/84) plus an options data record built against it through the real parse path into the table. The repo has no captured *data* record for template 257, so field ids, widths and order come from real hardware and only the values are synthetic.

Wire layout was confirmed empirically rather than by inspection: instrumenting the tap showed the crafted record parsing as `FLOW_SAMPLER_ID=1, FLOW_SAMPLER_RANDOM_INTERVAL=1000, FLOW_SAMPLER_MODE=2, SAMPLER_NAME=SAMPLER-1`, and the parser is length-sensitive there, so a wrong set length fails rather than passing silently.

## Anything reviewers should look at closely?

An agent-based review pass over the branch diff (three finders: correctness, integration, tests/docs) ran before this was opened, and it found real defects in the first commit which the second commit fixes. `/code-review` is user-invocation-only, so the canonical pass has **not** run and is still worth doing.

Three findings are worth re-checking independently, since they were mine and I fixed them under my own judgement:

- An explicit interval of `1` was being discarded as "not a real rate", so an exporter stating it does not sample fell through to the fallback. The fallback is per receiver while a receiver fronts many exporters, so a fallback set for one silent router inflated every honestly-unsampled exporter behind it. Now an explicit 1 terminates the ladder; only absent, 0 and non-finite fall through.
- Refactoring the IPFIX selector switch into `Optionals.first` made it eager, so algorithms 5/6/7 divided by an exporter-supplied range on every record. A degenerate range threw `ArithmeticException` and cost the whole packet's batch. Resolution is stepwise again and the divisor is guarded.
- The switch's synthesized `1.0` default outranked the configured fallback, which is a guess beating configuration.

The 20-minute cache TTL is a hardcoded constant with a paragraph of justification and no test. An exporter whose options refresh is slower than that silently reverts to unsampled between refreshes. `ExporterInterfaceTable` derives its TTL from config; this one does not, and that asymmetry is a deliberate "no speculative config" call I am happy to be overruled on.

Design notes, prior-art comparison (goflow2, Akvorado, NetGauze, ktranslate) and the deferred volume-semantics question live in the `resolve-netflow9-sampling-rate` OpenSpec change, which is gitignored and therefore not in this diff.
