### PR TITLE
fix(build): clear the Error Prone warnings on the compile path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -317,8 +317,14 @@
                     <compilerArgs>
                         <arg>-XDcompilePolicy=simple</arg>
                         <arg>--should-stop=ifError=FLOW</arg>
-                        <!-- These three checks are warning-free or explicitly suppressed; hold them at ERROR so they stay that way. -->
-                        <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/target/generated-.*sources/.* -Xep:EqualsGetClass:ERROR -Xep:NarrowingCompoundAssignment:ERROR -Xep:ExposedPrivateType:ERROR</arg>
+                        <!-- These three checks are warning-free or explicitly suppressed; hold them at ERROR so they stay that way.
+                             UnrecognisedJavadocTag is off because it cannot see straight through Lombok: Lombok copies a
+                             field's Javadoc onto the accessors it generates, and Error Prone then re-parses that copy and
+                             reports every inline {@code}/{@link} in it as an unrecognised tag. The source is valid —
+                             `javac -Xdoclint:all` on the same files reports no malformed tag — and deleting @Data from
+                             ClickhouseConfig takes its seven warnings to zero, which is the whole of the evidence. Turning
+                             it off beats degrading real Javadoc to satisfy a false positive. -->
+                        <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/target/generated-.*sources/.* -Xep:EqualsGetClass:ERROR -Xep:NarrowingCompoundAssignment:ERROR -Xep:ExposedPrivateType:ERROR -Xep:UnrecognisedJavadocTag:OFF</arg>
                         <arg>
                             -Amapstruct.unmappedTargetPolicy=ERROR
                         </arg>

--- a/src/main/java/org/riptide/classification/internal/csv/CsvImporter.java
+++ b/src/main/java/org/riptide/classification/internal/csv/CsvImporter.java
@@ -15,6 +15,7 @@ import org.riptide.classification.Rule;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -33,7 +34,10 @@ public final class CsvImporter {
         // itself refuse ("a header name is missing") before the name comparison can run.
         final CSVParser parser;
         try {
-            parser = format.parse(new InputStreamReader(inputStream));
+            // UTF-8 explicitly: the rules ship in the jar and are read on whatever platform the
+            // collector runs on, so a non-UTF-8 default locale would mangle any non-ASCII
+            // application or organisation name rather than fail visibly.
+            parser = format.parse(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
         } catch (final IllegalArgumentException e) {
             throw new IOException("The rules file's first line is not the expected header '%s'. The header row is required."
                     .formatted(String.join(";", HEADERS)), e);

--- a/src/main/java/org/riptide/config/ConfigFileReloader.java
+++ b/src/main/java/org/riptide/config/ConfigFileReloader.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -80,6 +81,7 @@ public class ConfigFileReloader {
     private volatile boolean stale = false;
 
     private ScheduledExecutorService executor;
+    private ScheduledFuture<?> polling;
     private Path location;
     private byte[] lastAttemptedHash = new byte[0];
     private byte[] lastCommittedHash = new byte[0];
@@ -119,12 +121,19 @@ public class ConfigFileReloader {
         final long millis = this.properties.getReloadInterval().toMillis();
         this.executor = Executors.newSingleThreadScheduledExecutor(
                 runnable -> new Thread(runnable, "ConfigFileReloader"));
-        this.executor.scheduleWithFixedDelay(this::poll, millis, millis, TimeUnit.MILLISECONDS);
+        // The handle is kept and cancelled explicitly rather than discarded. poll() swallows every
+        // Exception itself, so a bad reload cycle cannot silently cancel the schedule and leave
+        // hot-reload dead for the process lifetime — which is the failure this return value exists
+        // to make visible.
+        this.polling = this.executor.scheduleWithFixedDelay(this::poll, millis, millis, TimeUnit.MILLISECONDS);
         log.info("Config hot-reload enabled: watching {} every {}", this.location, this.properties.getReloadInterval());
     }
 
     @PreDestroy
     void stop() {
+        if (this.polling != null) {
+            this.polling.cancel(true);
+        }
         if (this.executor != null) {
             this.executor.shutdownNow();
         }


### PR DESCRIPTION
## What does this change?

Clears every Error Prone annotation on the compile path. Three separate causes hid behind one list.

**`UnrecognisedJavadocTag` (9 warnings) was a false positive, not bad Javadoc.** Lombok copies a field's Javadoc onto the accessors it generates, and Error Prone re-parses that copy and reports every inline `{@code}`/`{@link}` in it as an unrecognised tag. Two things establish that: `javac -Xdoclint:all` on the same files reports no malformed tag at all, and deleting `@Data` from `ClickhouseConfig` takes its seven warnings straight to zero. The check is disabled with that reasoning recorded in the pom, because the alternative is stripping inline tags out of real documentation to satisfy a tool bug.

**`DefaultCharset` in `CsvImporter` was a genuine bug.** The classification rules were read through an `InputStreamReader` with no charset, so the platform default decided how they parse. Those rules ship inside the jar and are read on whatever platform the collector runs on, so a non-UTF-8 default would mangle a non-ASCII application or organisation name rather than fail visibly. Pinned to UTF-8.

**`FutureReturnValueIgnored` in `ConfigFileReloader` was the weakest of the three.** The failure the check warns about — a throwing task silently cancelling the schedule, leaving hot-reload dead for the process lifetime — cannot happen here, because `poll()` already catches `Exception` itself. The handle is now kept and cancelled in `stop()` anyway, which is what the check asks for and makes shutdown explicit rather than leaning on `shutdownNow()`.

## How was it verified?

`make jar` green: 956 tests, SpotBugs clean, coverage met. `mvn clean compile` now reports zero `UnrecognisedJavadocTag`, zero `DefaultCharset`, and nothing in `ConfigFileReloader`.

The Lombok diagnosis was confirmed by experiment rather than inference — I first chased non-ASCII characters (em dashes, ellipses) and tab characters as the cause, and both were wrong. Stripping non-ASCII left all 7 warnings; removing `@Data` removed all 7.

## Anything reviewers should look at closely?

Disabling a check is the part worth a second opinion. The narrower alternatives are worse: rewriting the affected Javadoc to drop `{@code}`/`{@link}` degrades documentation across five config classes to work around a parser bug, and per-file `@SuppressWarnings` would spread the same workaround wider without explaining it once. If you would rather carry the suppression at the class level, say so and I will move it.

**Six `FutureReturnValueIgnored` warnings remain**, in `NettyDnsResolver`, `TcpListener`, `UdpListener` and `GeoIpEnricher`. They were never visible in the CI annotations because GitHub caps a check at 10, so the reported list was truncated — expect them to surface once this merges. They are deliberately out of scope here: most are idiomatic fire-and-forget on Netty shutdown paths where discarding the future is correct, while `GeoIpEnricher`'s scheduled refresh deserves the same treatment `ConfigFileReloader` just received. A follow-up PR covers them.
