### PR TITLE
fix(build): record why the remaining discarded futures are intentional

### DIFF
--- a/src/main/java/org/riptide/dns/netty/NettyDnsResolver.java
+++ b/src/main/java/org/riptide/dns/netty/NettyDnsResolver.java
@@ -77,6 +77,10 @@ public class NettyDnsResolver implements DnsResolver, DisposableBean {
         }
     }
 
+    // shutdownGracefully's future is deliberately dropped: awaiting it would add Netty's quiet
+    // period plus timeout (2 s + 15 s by default) to every shutdown, and nothing after this point
+    // depends on the group being fully down — the workers own their own teardown below.
+    @SuppressWarnings("FutureReturnValueIgnored")
     @Override
     public void destroy() throws Exception {
         group.shutdownGracefully();

--- a/src/main/java/org/riptide/flows/listeners/TcpListener.java
+++ b/src/main/java/org/riptide/flows/listeners/TcpListener.java
@@ -103,6 +103,10 @@ public class TcpListener implements Listener {
                                     }
                                 })
                                 .addLast(new SimpleChannelInboundHandler<CompletableFuture<?>>() {
+                                    // handle() is used for its side effect — pushing a parse
+                                    // failure back into the pipeline — so the stage it returns has
+                                    // no consumer by design.
+                                    @SuppressWarnings("FutureReturnValueIgnored")
                                     @Override
                                     protected void channelRead0(final ChannelHandlerContext ctx,
                                                                 final CompletableFuture<?> future) throws Exception {
@@ -115,6 +119,10 @@ public class TcpListener implements Listener {
                                     }
                                 })
                                 .addLast(new ChannelInboundHandlerAdapter() {
+                                    // ctx.close() is fire-and-forget: the connection is already
+                                    // being torn down for a bad packet and there is nothing to do
+                                    // with the close future.
+                                    @SuppressWarnings("FutureReturnValueIgnored")
                                     @Override
                                     public void exceptionCaught(final ChannelHandlerContext ctx, final Throwable cause) {
                                         LOG.warn("Invalid packet: {}", cause.getMessage());

--- a/src/main/java/org/riptide/flows/listeners/UdpListener.java
+++ b/src/main/java/org/riptide/flows/listeners/UdpListener.java
@@ -202,6 +202,9 @@ public class UdpListener implements Listener {
         }
 
         @Override
+        // whenComplete exists to release the retained buffer exactly once and to log a bad
+        // packet; the stage it returns has no consumer, and Netty's read loop must not wait on it.
+        @SuppressWarnings("FutureReturnValueIgnored")
         protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket msg) throws Exception {
             final InetSocketAddress sender = msg.sender();
             final ByteBuf content = ReferenceCountUtil.retain(msg.content());

--- a/src/main/java/org/riptide/geoip/GeoIpEnricher.java
+++ b/src/main/java/org/riptide/geoip/GeoIpEnricher.java
@@ -59,6 +59,7 @@ public class GeoIpEnricher extends Enricher.Single {
     private ScheduledExecutorService scheduler;
 
     @Override
+    @SuppressWarnings("FutureReturnValueIgnored")
     public void start() {
         if (this.config.isUnconfigured()) {
             return;
@@ -70,6 +71,9 @@ public class GeoIpEnricher extends Enricher.Single {
             thread.setDaemon(true);
             return thread;
         });
+        // The handle is dropped rather than kept: refresh() swallows RuntimeException itself so
+        // the schedule cannot die silently, and stop() already fences it with shutdownNow plus
+        // awaitTermination, which cancels it more thoroughly than a stored future would.
         this.scheduler.scheduleAtFixedRate(this::refresh, period, period, TimeUnit.MILLISECONDS);
     }
 
@@ -93,6 +97,7 @@ public class GeoIpEnricher extends Enricher.Single {
     }
 
     /** Re-opens the databases when a file changed, appeared, or vanished; swap is atomic. */
+    @SuppressWarnings("FutureReturnValueIgnored")
     void refresh() {
         try {
             final GeoIpSnapshot current = this.snapshot;
@@ -112,6 +117,8 @@ public class GeoIpEnricher extends Enricher.Single {
             this.lastFailedFingerprint = null;
             this.snapshot = next;
             if (this.scheduler != null) {
+                // Fire-and-forget by construction: `retiring` is the record that this snapshot
+                // still needs closing, and stop() closes whatever shutdownNow() drops.
                 this.retiring.add(current);
                 this.scheduler.schedule(() -> {
                     current.close();


### PR DESCRIPTION
## What does this change?

Follow-up to #438, covering the six `FutureReturnValueIgnored` warnings it deliberately left alone. They were never visible in the CI annotations before, because GitHub caps a check at 10 and the reported list was truncated.

All six turned out to be intentional, so this records the intent at each site rather than restructuring code that is already correct. **No behaviour changes** — the diff is four comments and four `@SuppressWarnings`.

- **`NettyDnsResolver.destroy`** — awaiting `shutdownGracefully` would add Netty's quiet period plus timeout (2 s + 15 s by default) to every shutdown, and nothing after that call depends on the group being fully down.
- **`TcpListener`** (two sites) — `handle()` is used for its side effect, pushing a parse failure back into the pipeline, so the stage it returns has no consumer by design. `ctx.close()` in `exceptionCaught` is fire-and-forget because the connection is already being torn down for a bad packet.
- **`UdpListener`** — `whenComplete` exists to release the retained buffer exactly once and to log a bad packet (the leak fixed in #273). Netty's read loop must not wait on the stage it returns.
- **`GeoIpEnricher`** (two sites) — `refresh()` swallows `RuntimeException` itself, so the schedule cannot die silently, and `stop()` already fences it with `shutdownNow` plus `awaitTermination`; a stored future would cancel *less* thoroughly, not more. The delayed snapshot close is tracked by the `retiring` set, which `stop()` drains for exactly the closes `shutdownNow()` drops.

That last one is why `ConfigFileReloader` was fixed properly in #438 instead of suppressed: there `stop()` had no await to lean on, so keeping the handle was a real improvement.

## How was it verified?

`make jar` green: 956 tests, SpotBugs clean, coverage met.

With #438 merged and this rebased on top, `mvn clean compile` reports **zero** `FutureReturnValueIgnored`, `UnrecognisedJavadocTag` and `DefaultCharset` warnings — the three categories the original CI annotation list contained.

## Anything reviewers should look at closely?

Six suppressions is worth a sceptical read, since suppression can hide a real defect. I checked each against its shutdown path rather than assuming; the `GeoIpEnricher` pair in particular only holds because `stop()` drains `retiring` after `shutdownNow()`, which is easy to miss and would make the delayed close a genuine leak if it were ever removed.

Worth knowing before you expect a clean annotations list: **38 Error Prone warnings remain in main sources**, spread across roughly fifteen other checks — `EffectivelyPrivate` (6), `StatementSwitchToExpressionSwitch` (4), `ObjectEqualsForPrimitives` (4), `NotJavadoc` (4), `EnumOrdinal` (4), `AvoidCommonTypeNames` (4), `StringCaseLocaleUsage` (3), `StringSplitter` (2), `ReferenceEquality` (2) and a tail of singles. Because of the 10-annotation cap, CI will now surface ten of those instead of an empty list. Some look like real bugs worth their own change (`ObjectEqualsForPrimitives`, `ReferenceEquality`, `StringCaseLocaleUsage`); others are style. Happy to work through them if you want the compile path genuinely clean.
