### PR TITLE
feat(landing): show the latest released version in the hero

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,10 +126,21 @@ docs: deps-docs
 docs-serve: deps-docs
 	cd docs && npm ci && npm run start
 
+# Mirrors the %%VERSION%% substitution docs.yml performs, so local preview shows
+# what the deployed site shows instead of a raw token. Two deliberate differences
+# from CI: sed writes through a redirect rather than -i (GNU and BSD sed disagree
+# on -i, and this target only ever runs on a developer machine), and a missing
+# stable tag falls back to "dev" instead of failing the way a deploy must.
 .PHONY: landing-serve
 landing-serve:
-	@echo "Serving landing page on http://localhost:8080"
-	@python3 -m http.server 8080 --directory landing
+	@rm -rf build/landing
+	@mkdir -p build/landing
+	@cp -R landing/. build/landing/
+	@VERSION=$$(git tag --list 'v*' --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$$' | head -n1 | sed 's/^v//'); \
+		VERSION=$${VERSION:-dev}; \
+		sed "s/%%VERSION%%/$${VERSION}/g" landing/index.html > build/landing/index.html; \
+		echo "Serving landing page (version $${VERSION}) on http://localhost:8080"
+	@python3 -m http.server 8080 --directory build/landing
 
 .PHONY: oci
 oci: deps-oci jar

--- a/landing/css/style.css
+++ b/landing/css/style.css
@@ -231,6 +231,17 @@ a {
     align-items: center;
 }
 
+/* Wraps the hero tagline and the release badge. Carries the 1.5rem gap to the
+   h1 that .tagline-badge used to own, so hero spacing is unchanged when the
+   badge sits alone (as it does in the MCP section). */
+.hero-badges {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 1.5rem;
+}
+
 .tagline-badge {
     display: inline-block;
     padding: 0.25rem 0.75rem;
@@ -243,6 +254,48 @@ a {
     color: var(--accent-cyan);
     margin-bottom: 1.5rem;
     box-shadow: 0 0 15px rgba(0, 242, 254, 0.05);
+}
+
+/* Inside .hero-badges the wrapper owns the spacing; standalone badges elsewhere
+   keep their own margin. */
+.hero-badges .tagline-badge {
+    margin-bottom: 0;
+}
+
+/* Green rather than the tagline's cyan: the version reads as "current", and the
+   contrast keeps two adjacent pills from merging into one visual block. */
+.version-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.25rem 0.75rem;
+    background-color: rgba(16, 185, 129, 0.08);
+    border: 1px solid rgba(16, 185, 129, 0.25);
+    border-radius: 20px;
+    font-size: 0.85rem;
+    font-family: var(--font-heading);
+    font-weight: 500;
+    color: var(--accent-green);
+    box-shadow: 0 0 15px rgba(16, 185, 129, 0.05);
+    transition: var(--transition);
+}
+
+.version-badge:hover {
+    border-color: rgba(16, 185, 129, 0.6);
+    box-shadow: 0 0 15px rgba(16, 185, 129, 0.15);
+}
+
+.version-badge:focus-visible {
+    outline: 2px solid var(--accent-green);
+    outline-offset: 2px;
+}
+
+.version-badge-arrow {
+    transition: var(--transition);
+}
+
+.version-badge:hover .version-badge-arrow {
+    transform: translateX(2px);
 }
 
 .hero-title {

--- a/landing/index.html
+++ b/landing/index.html
@@ -61,7 +61,15 @@ SPDX-License-Identifier: GPL-3.0-or-later
         <section class="hero-section">
             <div class="container hero-container">
                 <div class="hero-content">
-                    <div class="tagline-badge">🌊 High-Performance Flow Telemetry</div>
+                    <!-- %%VERSION%% is substituted at build time from the highest stable v* tag,
+                         by .github/workflows/docs.yml for the deployed site and by `make
+                         landing-serve` for local preview. Never hardcode a version here. -->
+                    <div class="hero-badges">
+                        <span class="tagline-badge">🌊 High-Performance Flow Telemetry</span>
+                        <a href="https://github.com/Riptide-Labs/riptide/releases/tag/v%%VERSION%%" class="version-badge" target="_blank" rel="noopener" aria-label="Riptide v%%VERSION%% release notes">
+                            v%%VERSION%%<span class="version-badge-arrow" aria-hidden="true">↗</span>
+                        </a>
+                    </div>
                     <h1 class="hero-title">Ingest, Enrich, and Analyze Network Flows at Scale</h1>
                     <p class="hero-description">
                         Riptide is an open-source telemetry engine that decodes enterprise network flow protocols, applies dynamic context metadata, and persists millions of records into ClickHouse for instant, real-time traffic analysis.


### PR DESCRIPTION
## What does this change?

Adds a release badge to the landing page hero, beside the existing tagline, showing the latest stable release and linking to its release notes. Modelled on the version strip at https://nl6.eu/, placed in the hero rather than the sticky header.

```
╭────────────────────────────────────╮  ╭──────────╮
│ 🌊 High-Performance Flow Telemetry │  │ v0.7.1 ↗ │ → releases/tag/v0.7.1
╰────────────────────────────────────╯  ╰──────────╯
Ingest, Enrich, and Analyze Network Flows at Scale
```

**No workflow change was needed.** `docs.yml` already resolves the highest stable `v*` tag and substitutes `%%VERSION%%` into `site/index.html` *after* copying the landing tree, and it already redeploys on tag pushes (`tags: ['v*']`) so the value stays current. This adds two more occurrences of the token that the existing `sed` picks up for free.

Three files: `landing/index.html`, `landing/css/style.css`, `Makefile`.

## The Makefile change, and why it does not copy CI

`make landing-serve` previously served `landing/` raw with no substitution. That was tolerable while the only tokens sat inside copy-paste install commands, where `%%VERSION%%` reads as an obvious placeholder. Putting a literal `v%%VERSION%%` directly above the `h1` is the kind of thing someone eventually "fixes" by hardcoding a version, which quietly breaks the always-latest property this PR exists to provide. So the target now builds into `build/landing` (already gitignored) with the same substitution.

Two deliberate differences from CI, both worth a look since they are the non-obvious part of the diff:

- **`sed` writes through a redirect rather than `-i`.** GNU sed takes `sed -i "s/…"` and BSD sed requires `sed -i '' "s/…"`, and each form is a syntax error under the other. Copying CI's line verbatim would work on the ubuntu runner and fail on the developer machines this target actually runs on. Confirmed locally: `sed --version` returns `sed: illegal option -- -`.
- **A missing stable tag falls back to `dev` instead of failing.** `docs.yml:63` hard-fails, which is right for a deploy. Doing that locally would break `landing-serve` on a shallow clone or a fresh fork for no reason.

## How was it verified?

Ran the target's build steps and inspected the output:

- `build/landing/index.html` contains **zero** remaining `%%VERSION%%` tokens.
- Hero renders `<a href="…/releases/tag/v0.7.1" … aria-label="Riptide v0.7.1 release notes">v0.7.1↗</a>`.
- Install commands still substitute: `riptide_0.7.1_all.deb`, `riptide-0.7.1-1.noarch.rpm`.
- `https://github.com/Riptide-Labs/riptide/releases/tag/v0.7.1` returns **200**, so the link is not dead.
- Served the built tree and got 200 with both badge elements present.

The Docs workflow runs on this PR (it touches `landing/**` and `Makefile`), which exercises the CI substitution path itself.

## Anything reviewers should look at closely?

**There are two `.tagline-badge` elements**, the hero one and one in the MCP section at `landing/index.html:309`. Only the hero moves into the new `.hero-badges` flex wrapper. The wrapper takes over the `1.5rem` bottom margin so spacing to the `h1` is unchanged, and the override is scoped to `.hero-badges .tagline-badge` so the standalone MCP badge keeps its own margin. Worth confirming that section still looks right.

**Colour choice.** The version pill uses `--accent-green` rather than the tagline's cyan, so two adjacent pills do not merge into one visual block and the version reads as "current". Easy to change if it clashes.

**Accessibility.** The link carries an `aria-label` of "Riptide v0.7.1 release notes" rather than exposing a bare version number, the `↗` is `aria-hidden`, and there is a `:focus-visible` outline. This is the first `:focus-visible` rule in the stylesheet, so it sets a precedent rather than following one.
