### PR TITLE
feat(metrics): expose the metric registry at /metrics

### DIFF
--- a/docs/docs/deploy/operations.md
+++ b/docs/docs/deploy/operations.md
@@ -170,12 +170,10 @@ Template cardinality is the more useful of the two for capacity work — it is w
 per-record cost of the parse path. For the drop and depth metrics, see
 [Ingest loss counters](#ingest-loss-counters) above.
 
-:::warning
+:::tip
 
-Riptide does not export metrics yet: there is no reporter and no scrape endpoint, and the management
-port serves only `/livez` and `/readyz`. These gauges are registered in the metrics registry, but
-nothing publishes them — so rebaselining a dashboard is something to do when metric export lands,
-not today.
+These gauges, and every other metric on this page, are published on the management port at
+`GET /metrics` in Prometheus text format. See [Metrics endpoint](#metrics-endpoint) below.
 
 :::
 
@@ -189,13 +187,15 @@ application web server).
 |---|---|
 | `GET /livez` | **Liveness** — the receiver event loops are alive. Returns `200` while booting and once running; `503` only if a started receiver's socket has died. **Never** checks ClickHouse. |
 | `GET /readyz` | **Readiness** — all configured receivers are bound and listening (`200`), else `503`. |
+| `GET /metrics` | **Metrics** — the full metric registry in Prometheus text format. See below. |
 
 Configure via `riptide.management.*`:
 
 ```properties
-riptide.management.enabled=true       # set false to disable the endpoints entirely
+riptide.management.enabled=true         # set false to disable the endpoints entirely
 riptide.management.port=8080
 riptide.management.bind-address=0.0.0.0
+riptide.management.metrics-enabled=true # set false to serve probes but not /metrics
 ```
 
 **Readiness deliberately excludes ClickHouse.** There is no write buffer and a single collector has
@@ -215,6 +215,36 @@ The Compose stack uses `/readyz` as the service `healthcheck` (via the image's B
 
 The endpoints are served on virtual threads, capped by `riptide.management.max-concurrent-requests` (default 32).
 Requests beyond the cap are answered `503` rather than queued, so a probe gets a fast answer instead of waiting behind a burst.
+
+## Metrics endpoint
+
+`GET /metrics` renders the whole metric registry in [Prometheus text exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/) 0.0.4.
+
+```bash
+curl -s http://localhost:8080/metrics
+```
+
+Registry names contain dots; Prometheus metric names may not.
+Characters outside `[a-zA-Z0-9_:]` are replaced with `_`, so `enrichment.optionInterfaces.consumed` is scraped as `enrichment_optionInterfaces_consumed`.
+Counters are **not** given the conventional `_total` suffix, so a name you find in the source is the name you search for in Grafana.
+
+Type mapping:
+
+| Registry type | Exposed as |
+|---|---|
+| Gauge (numeric) | `gauge`. Non-numeric gauges are skipped — they have no valid representation, and emitting one would break the entire scrape rather than one series. |
+| Counter | `counter` |
+| Meter | `counter`, plus `_rate_1m` and `_rate_5m` gauges carrying Dropwizard's own moving averages |
+| Histogram | `summary` with p50/p95/p99 and `_count` |
+| Timer | `summary` named `<name>_seconds` with p50/p95/p99 and `_count`. Durations are converted from nanoseconds to seconds, the unit Prometheus tooling assumes. |
+
+The endpoint shares the probes' concurrency cap rather than having its own.
+Rendering walks the whole registry, so it is the more expensive handler and has more reason to be bounded, not less.
+A scrape that loses the race is shed with `503`, which Prometheus records as a failed scrape.
+
+Set `riptide.management.metrics-enabled=false` to serve probes without exposing metric names and values.
+The two are separate settings because they have different exposure profiles: probes answer up/down, while metrics describe your exporters and throughput.
+With it disabled the path is not registered at all, so a scrape gets `404`.
 
 :::note
 `jstack` does not show virtual threads, so the `management-http-*` handlers are invisible to it and to `top -H`.

--- a/src/main/java/org/riptide/management/ManagementServer.java
+++ b/src/main/java/org/riptide/management/ManagementServer.java
@@ -5,6 +5,7 @@
 
 package org.riptide.management;
 
+import com.codahale.metrics.MetricRegistry;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import jakarta.annotation.PostConstruct;
@@ -23,7 +24,8 @@ import java.util.function.Supplier;
 
 /**
  * A minimal HTTP server (JDK {@link HttpServer}, no web application server) exposing {@code /livez}
- * and {@code /readyz} on the management port for Kubernetes probes and Docker Compose health checks.
+ * and {@code /readyz} on the management port for Kubernetes probes and Docker Compose health checks,
+ * and {@code /metrics} in Prometheus text format.
  */
 @Slf4j
 @Component
@@ -31,14 +33,17 @@ public class ManagementServer {
 
     private final RiptideManagementProperties properties;
     private final HealthService health;
+    private final MetricRegistry metrics;
 
     private HttpServer server;
     private ExecutorService executor;
     private Semaphore inFlight;
 
-    public ManagementServer(final RiptideManagementProperties properties, final HealthService health) {
+    public ManagementServer(final RiptideManagementProperties properties, final HealthService health,
+                            final MetricRegistry metrics) {
         this.properties = properties;
         this.health = health;
+        this.metrics = metrics;
     }
 
     @PostConstruct
@@ -58,10 +63,14 @@ public class ManagementServer {
         this.server.setExecutor(this.executor);
         this.server.createContext("/livez", exchange -> guarded(exchange, this.health::liveness));
         this.server.createContext("/readyz", exchange -> guarded(exchange, this.health::readiness));
+        if (this.properties.isMetricsEnabled()) {
+            this.server.createContext("/metrics", this::metrics);
+        }
         this.server.start();
 
-        log.info("Management server listening on {}:{} (/livez, /readyz)",
-                this.properties.getBindAddress(), this.properties.getPort());
+        log.info("Management server listening on {}:{} (/livez, /readyz{})",
+                this.properties.getBindAddress(), this.properties.getPort(),
+                this.properties.isMetricsEnabled() ? ", /metrics" : "");
     }
 
     @PreDestroy
@@ -93,13 +102,37 @@ public class ManagementServer {
         }
     }
 
+    /**
+     * Prometheus scrape endpoint. Shares the probes' concurrency cap rather than carrying its own:
+     * rendering walks the whole registry, so it is the more expensive of the two handlers and has
+     * more reason to be bounded, not less. A scrape that loses the race is shed with 503, which
+     * Prometheus records as a failed scrape rather than retrying into the contention.
+     */
+    private void metrics(final HttpExchange exchange) throws IOException {
+        if (!this.inFlight.tryAcquire()) {
+            respond(exchange, 503, "text/plain; charset=utf-8", "management server busy\n");
+            return;
+        }
+        try {
+            respond(exchange, 200, "text/plain; version=0.0.4; charset=utf-8",
+                    PrometheusExposition.render(this.metrics));
+        } finally {
+            this.inFlight.release();
+        }
+    }
+
     private static void respond(final HttpExchange exchange, final Health health) throws IOException {
-        final byte[] body = ((health.up() ? "ok" : "unavailable") + ": " + health.detail() + "\n")
-                .getBytes(StandardCharsets.UTF_8);
-        exchange.getResponseHeaders().set("Content-Type", "text/plain; charset=utf-8");
-        exchange.sendResponseHeaders(health.up() ? 200 : 503, body.length);
+        respond(exchange, health.up() ? 200 : 503, "text/plain; charset=utf-8",
+                (health.up() ? "ok" : "unavailable") + ": " + health.detail() + "\n");
+    }
+
+    private static void respond(final HttpExchange exchange, final int status,
+                                final String contentType, final String body) throws IOException {
+        final byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", contentType);
+        exchange.sendResponseHeaders(status, bytes.length);
         try (OutputStream os = exchange.getResponseBody()) {
-            os.write(body);
+            os.write(bytes);
         }
     }
 }

--- a/src/main/java/org/riptide/management/PrometheusExposition.java
+++ b/src/main/java/org/riptide/management/PrometheusExposition.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.management;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.Timer;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Renders a Dropwizard {@link MetricRegistry} as Prometheus text exposition format 0.0.4.
+ *
+ * <p>Hand-written rather than pulled from a bridge library on purpose. The registry uses five
+ * metric types and the format is a dozen lines of rules, whereas the available Dropwizard-to-
+ * Prometheus bridges track the Prometheus Java client's own major versions and would add three
+ * artifacts to a dependency tree this project deliberately keeps small.
+ *
+ * <p>Metric names are emitted as they appear in the registry, with characters Prometheus does not
+ * allow replaced by {@code _}. Counters are <em>not</em> given the conventional {@code _total}
+ * suffix: an operator reading {@code MetricRegistry.name(...)} in the source should be able to
+ * search for that same string in Grafana. Prometheus accepts the shorter form.
+ *
+ * <p>Timer durations are converted from Dropwizard's nanoseconds to seconds, which is the unit
+ * Prometheus tooling assumes.
+ */
+final class PrometheusExposition {
+
+    private PrometheusExposition() {
+    }
+
+    static String render(final MetricRegistry registry) {
+        final StringBuilder out = new StringBuilder(4096);
+
+        for (final Map.Entry<String, Gauge> entry : registry.getGauges().entrySet()) {
+            // Non-numeric gauges (riptide has string-valued ones) have no Prometheus
+            // representation; skipping beats inventing one.
+            if (entry.getValue().getValue() instanceof Number value) {
+                final String name = sanitize(entry.getKey());
+                type(out, name, "gauge");
+                sample(out, name, value.doubleValue());
+            }
+        }
+
+        for (final Map.Entry<String, Counter> entry : registry.getCounters().entrySet()) {
+            final String name = sanitize(entry.getKey());
+            type(out, name, "counter");
+            sample(out, name, entry.getValue().getCount());
+        }
+
+        for (final Map.Entry<String, Meter> entry : registry.getMeters().entrySet()) {
+            final String name = sanitize(entry.getKey());
+            final Meter meter = entry.getValue();
+            type(out, name, "counter");
+            sample(out, name, meter.getCount());
+            // Dropwizard's own moving averages. Prometheus would normally derive a rate from the
+            // counter, but exporting these costs nothing and they are what riptide's existing
+            // meters were created to show.
+            type(out, name + "_rate_1m", "gauge");
+            sample(out, name + "_rate_1m", meter.getOneMinuteRate());
+            type(out, name + "_rate_5m", "gauge");
+            sample(out, name + "_rate_5m", meter.getFiveMinuteRate());
+        }
+
+        for (final Map.Entry<String, Histogram> entry : registry.getHistograms().entrySet()) {
+            final String name = sanitize(entry.getKey());
+            final Histogram histogram = entry.getValue();
+            type(out, name, "summary");
+            quantiles(out, name, histogram.getSnapshot(), 1.0d);
+            sample(out, name + "_count", histogram.getCount());
+        }
+
+        for (final Map.Entry<String, Timer> entry : registry.getTimers().entrySet()) {
+            final String name = sanitize(entry.getKey()) + "_seconds";
+            final Timer timer = entry.getValue();
+            type(out, name, "summary");
+            quantiles(out, name, timer.getSnapshot(), 1.0d / TimeUnit.SECONDS.toNanos(1L));
+            sample(out, name + "_count", timer.getCount());
+        }
+
+        return out.toString();
+    }
+
+    private static void quantiles(final StringBuilder out, final String name,
+                                  final Snapshot snapshot, final double scale) {
+        quantile(out, name, "0.5", snapshot.getMedian() * scale);
+        quantile(out, name, "0.95", snapshot.get95thPercentile() * scale);
+        quantile(out, name, "0.99", snapshot.get99thPercentile() * scale);
+    }
+
+    private static void quantile(final StringBuilder out, final String name,
+                                 final String q, final double value) {
+        out.append(name).append("{quantile=\"").append(q).append("\"} ").append(value).append('\n');
+    }
+
+    private static void type(final StringBuilder out, final String name, final String type) {
+        out.append("# TYPE ").append(name).append(' ').append(type).append('\n');
+    }
+
+    private static void sample(final StringBuilder out, final String name, final double value) {
+        out.append(name).append(' ').append(value).append('\n');
+    }
+
+    /** Prometheus metric names are {@code [a-zA-Z_:][a-zA-Z0-9_:]*}; the registry uses dots. */
+    private static String sanitize(final String name) {
+        final StringBuilder sanitized = new StringBuilder(name.length());
+        for (int i = 0; i < name.length(); i++) {
+            final char c = name.charAt(i);
+            final boolean valid = c == '_' || c == ':'
+                    || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+                    || (i > 0 && c >= '0' && c <= '9');
+            sanitized.append(valid ? c : '_');
+        }
+        return sanitized.toString();
+    }
+}

--- a/src/main/java/org/riptide/management/RiptideManagementProperties.java
+++ b/src/main/java/org/riptide/management/RiptideManagementProperties.java
@@ -18,6 +18,16 @@ public class RiptideManagementProperties {
     /** Serve the management HTTP endpoints ({@code /livez}, {@code /readyz}). */
     private boolean enabled = true;
 
+    /**
+     * Serve {@code /metrics} in Prometheus text format on the management port.
+     *
+     * <p>Separate from {@link #enabled} because the two have different exposure profiles: probes
+     * answer up/down, while the metric names and values describe the deployment's exporters and
+     * throughput. An operator who wants health checks reachable but metrics scraped only from a
+     * private network can turn this off without losing the probes.
+     */
+    private boolean metricsEnabled = true;
+
     /** Management HTTP port. */
     private int port = 8080;
 

--- a/src/main/java/org/riptide/snmp/DefaultSnmpService.java
+++ b/src/main/java/org/riptide/snmp/DefaultSnmpService.java
@@ -5,22 +5,47 @@
 
 package org.riptide.snmp;
 
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.riptide.secrets.SecretResolvers;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.Optional;
 
 @Service
 @Slf4j
-@RequiredArgsConstructor
 public class DefaultSnmpService implements SnmpService {
 
-    @NonNull
     private final SecretResolvers secretResolvers;
+
+    /**
+     * Walk accounting. This is the layer where a walk actually happens: {@link CachingSnmpService}
+     * fronts it, so every increment here is a real table walk against a real agent rather than a
+     * cache hit. That distinction is the whole point of metering here and not there.
+     *
+     * <p>One walk is roughly ⌈interfaces / 10⌉ GETBULK round trips, because {@code TableUtils}
+     * defaults to ten rows per PDU and {@link SnmpUtils} does not override it. The walk rate is
+     * therefore the honest measure of what riptide costs an exporter's CPU.
+     */
+    private final Meter walks;
+    private final Timer walkDuration;
+    private final Meter walksSucceeded;
+    private final Meter walksTimedOut;
+    private final Meter walksFailed;
+
+    public DefaultSnmpService(final SecretResolvers secretResolvers, final MetricRegistry metrics) {
+        this.secretResolvers = Objects.requireNonNull(secretResolvers);
+        Objects.requireNonNull(metrics);
+        this.walks = metrics.meter(MetricRegistry.name("snmp", "walks"));
+        this.walkDuration = metrics.timer(MetricRegistry.name("snmp", "walkDuration"));
+        this.walksSucceeded = metrics.meter(MetricRegistry.name("snmp", "walks", "succeeded"));
+        this.walksTimedOut = metrics.meter(MetricRegistry.name("snmp", "walks", "timedOut"));
+        this.walksFailed = metrics.meter(MetricRegistry.name("snmp", "walks", "failed"));
+    }
 
     @Override
     public Optional<IfInfo> getIfInfo(final SnmpEndpoint snmpEndpoint, final int ifIndex) {
@@ -29,13 +54,20 @@ public class DefaultSnmpService implements SnmpService {
 
     @Override
     public IfInfoLookup lookupIfInfo(final SnmpEndpoint snmpEndpoint, final int ifIndex) {
-        try {
+        this.walks.mark();
+        try (var ignored = this.walkDuration.time()) {
             final var walk = SnmpUtils.getIfInfoMap(snmpEndpoint, this.secretResolvers);
+            switch (walk.outcome()) {
+                case OK -> this.walksSucceeded.mark();
+                case TIMEOUT -> this.walksTimedOut.mark();
+                case ERROR -> this.walksFailed.mark();
+            }
             return new IfInfoLookup(Optional.ofNullable(walk.rows().get(ifIndex)),
                     walk.outcome() == SnmpUtils.WalkOutcome.TIMEOUT);
         } catch (IOException | IllegalArgumentException e) {
             // IllegalArgumentException: an unresolvable secret reference must degrade to an
             // unenriched flow, never fail the pipeline and drop the batch.
+            this.walksFailed.mark();
             log.warn("Error fetching value from {} at index {}: {}", snmpEndpoint, ifIndex, e.getMessage());
             return new IfInfoLookup(Optional.empty(), false);
         }

--- a/src/test/java/org/riptide/management/ManagementServerTest.java
+++ b/src/test/java/org/riptide/management/ManagementServerTest.java
@@ -5,6 +5,7 @@
 
 package org.riptide.management;
 
+import com.codahale.metrics.MetricRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.riptide.flows.Daemon;
@@ -29,6 +30,7 @@ import static org.mockito.Mockito.when;
 class ManagementServerTest {
 
     private ManagementServer server;
+    private final MetricRegistry registry = new MetricRegistry();
 
     @AfterEach
     void tearDown() {
@@ -75,7 +77,7 @@ class ManagementServerTest {
             }
         };
 
-        this.server = new ManagementServer(properties, health);
+        this.server = new ManagementServer(properties, health, this.registry);
         this.server.start();
         return port;
     }
@@ -92,6 +94,59 @@ class ManagementServerTest {
                         .GET().build(),
                 HttpResponse.BodyHandlers.ofString());
         return response.statusCode();
+    }
+
+    private HttpResponse<String> get(final int port, final String path) throws Exception {
+        return HttpClient.newHttpClient().send(
+                HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + path))
+                        .timeout(java.time.Duration.ofSeconds(10))
+                        .GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    @Test
+    void metricsEndpointServesTheRegistry() throws Exception {
+        // registered before start so the handler renders whatever the registry holds at scrape time
+        this.registry.meter(MetricRegistry.name("snmp", "walks")).mark(3);
+        this.registry.counter(MetricRegistry.name("flows", "dropped")).inc(7);
+
+        final Daemon daemon = mock(Daemon.class);
+        lenient().when(daemon.isStarted()).thenReturn(true);
+        final int port = start(daemon);
+
+        final HttpResponse<String> response = get(port, "/metrics");
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.headers().firstValue("Content-Type"))
+                .hasValue("text/plain; version=0.0.4; charset=utf-8");
+        // registry names carry dots, which Prometheus does not allow in metric names
+        assertThat(response.body())
+                .contains("# TYPE snmp_walks counter")
+                .contains("snmp_walks 3.0")
+                .contains("# TYPE flows_dropped counter")
+                .contains("flows_dropped 7.0");
+    }
+
+    @Test
+    void metricsEndpointCanBeDisabledWithoutLosingProbes() throws Exception {
+        final Daemon daemon = mock(Daemon.class);
+        when(daemon.isStarted()).thenReturn(true);
+        when(daemon.getListeners()).thenReturn(List.of());
+
+        final int port;
+        try (ServerSocket probe = new ServerSocket(0)) {
+            port = probe.getLocalPort();
+        }
+        final var properties = new RiptideManagementProperties();
+        properties.setPort(port);
+        properties.setBindAddress("127.0.0.1");
+        properties.setMetricsEnabled(false);
+
+        this.server = new ManagementServer(properties, new HealthService(daemon), this.registry);
+        this.server.start();
+
+        assertThat(status(port, "/livez")).isEqualTo(200);
+        // no context registered, so the JDK server answers 404 rather than an empty scrape
+        assertThat(status(port, "/metrics")).isEqualTo(404);
     }
 
     @Test

--- a/src/test/java/org/riptide/management/PrometheusExpositionTest.java
+++ b/src/test/java/org/riptide/management/PrometheusExpositionTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.management;
+
+import com.codahale.metrics.MetricRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PrometheusExpositionTest {
+
+    @Test
+    void registryNamesAreSanitisedIntoValidMetricNames() {
+        final var registry = new MetricRegistry();
+        registry.counter("enrichment.optionInterfaces.consumed").inc();
+
+        // dots are legal in a registry name and illegal in a Prometheus one
+        assertThat(PrometheusExposition.render(registry))
+                .contains("enrichment_optionInterfaces_consumed 1.0")
+                .doesNotContain("enrichment.optionInterfaces");
+    }
+
+    @Test
+    void aNameStartingWithADigitDoesNotProduceAnInvalidMetric() {
+        final var registry = new MetricRegistry();
+        registry.counter("1minute.thing").inc();
+
+        // Prometheus names may not begin with a digit, but may contain them
+        assertThat(PrometheusExposition.render(registry)).contains("_minute_thing 1.0");
+    }
+
+    @Test
+    void timerDurationsAreExportedInSecondsNotNanoseconds() {
+        final var registry = new MetricRegistry();
+        final var timer = registry.timer("snmp.walkDuration");
+        timer.update(250, TimeUnit.MILLISECONDS);
+
+        final String rendered = PrometheusExposition.render(registry);
+
+        // Dropwizard snapshots are nanoseconds; Prometheus tooling assumes seconds. A single
+        // 250 ms sample must therefore surface as 0.25, not 2.5E8.
+        assertThat(rendered)
+                .contains("# TYPE snmp_walkDuration_seconds summary")
+                .contains("snmp_walkDuration_seconds{quantile=\"0.5\"} 0.25")
+                .contains("snmp_walkDuration_seconds_count 1.0");
+    }
+
+    @Test
+    void nonNumericGaugesAreSkippedRatherThanRenderedAsGarbage() {
+        final var registry = new MetricRegistry();
+        registry.gauge("build.version", () -> () -> "0.7.1");
+        registry.gauge("queue.depth", () -> () -> 42);
+
+        final String rendered = PrometheusExposition.render(registry);
+
+        assertThat(rendered).contains("queue_depth 42.0");
+        // a string-valued gauge has no Prometheus representation; emitting the name with an
+        // unparseable value would break the whole scrape, not just that series
+        assertThat(rendered).doesNotContain("build_version");
+    }
+
+    @Test
+    void metersExportBothTheCountAndTheirMovingRates() {
+        final var registry = new MetricRegistry();
+        registry.meter("snmp.walks").mark(5);
+
+        assertThat(PrometheusExposition.render(registry))
+                .contains("# TYPE snmp_walks counter")
+                .contains("snmp_walks 5.0")
+                .contains("# TYPE snmp_walks_rate_1m gauge")
+                .contains("# TYPE snmp_walks_rate_5m gauge");
+    }
+
+    @Test
+    void anEmptyRegistryRendersEmptyRatherThanFailing() {
+        assertThat(PrometheusExposition.render(new MetricRegistry())).isEmpty();
+    }
+}

--- a/src/test/java/org/riptide/snmp/SnmpTest.java
+++ b/src/test/java/org/riptide/snmp/SnmpTest.java
@@ -7,6 +7,8 @@ package org.riptide.snmp;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import com.codahale.metrics.MetricRegistry;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Map;
@@ -278,7 +280,7 @@ public class SnmpTest {
     @Test
     public void unresolvableSecretRefDegradesToEmptyInsteadOfThrowing() {
         // a broken secret reference must yield an unenriched flow, never fail the pipeline
-        final SnmpService snmpService = new DefaultSnmpService(SECRET_RESOLVERS);
+        final SnmpService snmpService = new DefaultSnmpService(SECRET_RESOLVERS, new MetricRegistry());
         final SnmpEndpoint snmpEndpoint = communityV2c(new IPAddressString("127.0.0.1"), getNextPort(), "env://RIPTIDE_TEST_MISSING_VAR");
 
         assertThat(snmpService.getIfInfo(snmpEndpoint, 1)).isInstanceOf(Optional.class).isEmpty();
@@ -294,7 +296,7 @@ public class SnmpTest {
         snmpCacheConfig.setNegativeRetentionMs(0);
         snmpCacheConfig.setDeadEndpointRetentionMs(0);
 
-        final SnmpService snmpCache = new CachingSnmpService(new DefaultSnmpService(SECRET_RESOLVERS), snmpCacheConfig);
+        final SnmpService snmpCache = new CachingSnmpService(new DefaultSnmpService(SECRET_RESOLVERS, new MetricRegistry()), snmpCacheConfig);
         final SnmpEndpoint snmpEndpoint = communityV2c(new IPAddressString("127.0.0.1"), port, TestSnmpAgent.COMMUNITY);
 
         assertThat(snmpCache.getIfInfo(snmpEndpoint, 1)).isInstanceOf(Optional.class).isEmpty();
@@ -315,6 +317,42 @@ public class SnmpTest {
         assertThat(snmpCache.getIfInfo(snmpEndpoint, 1).get().name()).isEqualTo("eth0");
         assertThat(snmpCache.getIfInfo(snmpEndpoint, 2)).isInstanceOf(Optional.class).isPresent();
         assertThat(snmpCache.getIfInfo(snmpEndpoint, 2).get().name()).isEqualTo("lo0");
+    }
+
+    /**
+     * The walk meter is the baseline instrument for #443: it must count table walks actually issued
+     * against an agent, not enrichment lookups. Metering the delegate rather than the cache is what
+     * makes that true, and this pins it — two ifIndexes served from cache must not inflate the count.
+     */
+    @Test
+    public void walkMeterCountsWalksNotCacheHits(@TempDir Path temporaryFolder) throws IOException {
+        final int port = getNextPort();
+        final MetricRegistry metrics = new MetricRegistry();
+        final SnmpCacheConfig snmpCacheConfig = new SnmpCacheConfig();
+        snmpCacheConfig.setRetentionMs(600000);
+
+        currentAgent = new TestSnmpAgent("127.0.0.1/" + port, temporaryFolder);
+        currentAgent.start();
+        currentAgent.registerIfTable();
+
+        final SnmpService snmpCache =
+                new CachingSnmpService(new DefaultSnmpService(SECRET_RESOLVERS, metrics), snmpCacheConfig);
+        final SnmpEndpoint snmpEndpoint = communityV2c(new IPAddressString("127.0.0.1"), port, TestSnmpAgent.COMMUNITY);
+
+        assertThat(snmpCache.getIfInfo(snmpEndpoint, 1)).isPresent();
+        assertThat(metrics.meter(MetricRegistry.name("snmp", "walks")).getCount()).isEqualTo(1L);
+
+        // repeat lookup of the same ifIndex: served from cache, no walk
+        assertThat(snmpCache.getIfInfo(snmpEndpoint, 1)).isPresent();
+        assertThat(metrics.meter(MetricRegistry.name("snmp", "walks")).getCount()).isEqualTo(1L);
+
+        // a *different* ifIndex on the same agent walks the whole table again — this is the waste
+        // #443 exists to remove, and the meter is what will show it disappearing
+        assertThat(snmpCache.getIfInfo(snmpEndpoint, 2)).isPresent();
+        assertThat(metrics.meter(MetricRegistry.name("snmp", "walks")).getCount()).isEqualTo(2L);
+
+        assertThat(metrics.meter(MetricRegistry.name("snmp", "walks", "succeeded")).getCount()).isEqualTo(2L);
+        assertThat(metrics.timer(MetricRegistry.name("snmp", "walkDuration")).getCount()).isEqualTo(2L);
     }
 
     @Test


### PR DESCRIPTION
Closes #441.

## What does this change?

The `MetricRegistry` was populated throughout the pipeline and **nothing read it**. Parse timers, queue-depth gauges, drop counters and DNS lookup timers were all computed and then unobservable from outside the process: no reporter existed anywhere in `src/main/java`, the management server served only `/livez` and `/readyz`, and the MCP tools query flow data rather than JVM state.

`GET /metrics` on the management port now renders the registry in Prometheus text exposition format 0.0.4.

```
# TYPE snmp_walks counter
snmp_walks 3.0
# TYPE snmp_walkDuration_seconds summary
snmp_walkDuration_seconds{quantile="0.5"} 0.25
snmp_walkDuration_seconds_count 1.0
```

## Why hand-written instead of a bridge library?

The registry uses five metric types and the exposition format is a dozen rules. The available Dropwizard-to-Prometheus bridges track the Prometheus Java client's own major versions, and adding one would put three artifacts into a dependency tree this project keeps deliberately small — particularly after the Scorecard remediation in #317.

Choices worth a second opinion, all reversible:

- **Names are emitted as they appear in the registry**, with characters Prometheus disallows replaced by `_`. `enrichment.optionInterfaces.consumed` becomes `enrichment_optionInterfaces_consumed`.
- **Counters get no `_total` suffix.** The convention says they should; the tradeoff is that a name found in the source is then not the name to search for in Grafana. Prometheus accepts the shorter form. Say the word if you'd rather follow convention.
- **Timer durations are converted to seconds** from Dropwizard's nanoseconds, since that is the unit Prometheus tooling assumes.
- **Non-numeric gauges are skipped.** Emitting an unparseable value breaks the entire scrape, not just that series.

The endpoint shares the probes' concurrency cap rather than carrying its own. Rendering walks the whole registry, so it is the more expensive handler and has more reason to be bounded, not less. `metrics-enabled` is a separate setting from `enabled` because the two differ in exposure: probes answer up/down, while metric names and values describe the deployment's exporters and throughput.

## SNMP walk instrumentation

Also instruments the SNMP walk path, which had **no metrics at all** — `ExporterInterfaceTable` had meters for option records, but `CachingSnmpService` and `DefaultSnmpService` had none.

The meters sit on `DefaultSnmpService`, deliberately *below* the cache, so they count table walks actually issued against an agent rather than enrichment lookups served from cache. That distinction is the entire point: this is the baseline instrument for #443, where one walk per ifIndex is meant to become one walk per interval, and a meter above the cache would show no change at all.

This surfaced while starting #443: the first task there is "capture a baseline", and it turned out to be unexecutable because nothing counted walks. Hence this PR carries both.

## How was it verified?

`make jar` green: **965 tests** (up from 956), SpotBugs clean, coverage met. Note the gate is `make jar` — there is no `make verify` target; `jar` runs `mvn verify`.

New tests cover the parts most likely to be wrong: name sanitisation including a name starting with a digit, nanosecond-to-second conversion (a 250 ms sample must render `0.25`, not `2.5E8`), non-numeric gauges being skipped, an empty registry rendering empty rather than throwing, the endpoint's content type and 404-when-disabled, and — for the SNMP meters — that a repeat lookup of the same ifIndex does **not** increment the walk count while a different ifIndex on the same agent does.

Verified against the packaged jar, not only tests, since both changed constructors are Spring-injected and the unit tests construct them directly:

- Management server logs `listening on 0.0.0.0:18080 (/livez, /readyz, /metrics)`
- Zero `UnsatisfiedDependency` / `BeanCreationException` / `NoSuchBeanDefinition`
- `SnmpEnricher` initialises, which requires the new `DefaultSnmpService(SecretResolvers, MetricRegistry)` constructor to resolve
- The only failure is `Connect to http://localhost:8123 failed` — no ClickHouse on this machine, unrelated to the change

## Anything reviewers should look at closely?

**The exposition format itself.** It is hand-rolled, so a format bug would be mine rather than a library's. `PrometheusExpositionTest` pins the cases I thought were risky, but a sceptical read of `PrometheusExposition` against the spec is worth more than the tests.

**Docs contained a claim that is now false.** `operations.md` carried a warning block stating "Riptide does not export metrics yet: there is no reporter and no scrape endpoint". Replaced, with the type mapping and the sanitisation rules documented so nobody has to read the renderer to know what a metric will be called.
