### PR TITLE
refactor(netty): construct event loop groups via the 4.2 IoHandler API

### DIFF
--- a/src/main/java/org/riptide/dns/netty/NettyDnsResolver.java
+++ b/src/main/java/org/riptide/dns/netty/NettyDnsResolver.java
@@ -9,7 +9,9 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
 import io.netty.resolver.dns.DefaultDnsCache;
 import io.netty.resolver.dns.DnsServerAddressStreamProvider;
 import lombok.extern.slf4j.Slf4j;
@@ -34,7 +36,7 @@ public class NettyDnsResolver implements DnsResolver, DisposableBean {
     final DefaultDnsReverseCache reverseCache;
     final DnsServerAddressStreamProvider dnsNameserverProvider;
     final DefaultDnsCache nettyCache;
-    final NioEventLoopGroup group;
+    final EventLoopGroup group;
     private final List<NettyDnsResolverWorker> workers;
     private final RoundRobinIterator<NettyDnsResolverWorker> iterator;
     private final Timer lookupTimer;
@@ -48,9 +50,9 @@ public class NettyDnsResolver implements DnsResolver, DisposableBean {
         this.reverseCache = Objects.requireNonNull(cache);
         this.nettyCache = new DefaultDnsCache();
         this.dnsNameserverProvider = dnsNameserverProvider;
-        this.group = new NioEventLoopGroup(config.getMaximumDnsResolverThreads(), new ThreadFactoryBuilder()
+        this.group = new MultiThreadIoEventLoopGroup(config.getMaximumDnsResolverThreads(), new ThreadFactoryBuilder()
                 .setNameFormat("NettyDnsResolver-NIO-EventLoop-%d")
-                .build());
+                .build(), NioIoHandler.newFactory());
         final var queryTimeout = config.getQueryTimeoutMillis();
         this.workers = IntStream.range(0, config.getMaximumDnsResolverThreads())
                 .mapToObj(i -> new NettyDnsResolverWorker(this, queryTimeout))

--- a/src/main/java/org/riptide/flows/listeners/TcpListener.java
+++ b/src/main/java/org/riptide/flows/listeners/TcpListener.java
@@ -61,13 +61,14 @@ public class TcpListener implements Listener {
         // selected for accept. Netty's default (0 = 2 * num cores) would build the rest as loops
         // nothing can reach — they hold a selector each and never run. A second bind() on this
         // listener would make the count matter again.
+        final var formatName = name.replace("%", "%%");
         this.bossGroup = new MultiThreadIoEventLoopGroup(1, new ThreadFactoryBuilder()
-                .setNameFormat("tcp-listener-nio-boss-" + name + "-%d")
+                .setNameFormat("tcp-listener-nio-boss-" + formatName + "-%d")
                 .build(), NioIoHandler.newFactory());
         // Netty defaults to 2 * num cores when the number of threads is set to 0; here that is
         // real capacity, since each accepted connection is assigned a loop round-robin.
         this.workerGroup = new MultiThreadIoEventLoopGroup(0, new ThreadFactoryBuilder()
-                .setNameFormat("tcp-listener-nio-worker-" + name + "-%d")
+                .setNameFormat("tcp-listener-nio-worker-" + formatName + "-%d")
                 .build(), NioIoHandler.newFactory());
 
         this.parser.start(this.bossGroup);

--- a/src/main/java/org/riptide/flows/listeners/TcpListener.java
+++ b/src/main/java/org/riptide/flows/listeners/TcpListener.java
@@ -59,8 +59,14 @@ public class TcpListener implements Listener {
     public void start() {
         // One thread: ServerBootstrap registers a single channel, so only one event loop is ever
         // selected for accept. Netty's default (0 = 2 * num cores) would build the rest as loops
-        // nothing can reach — they hold a selector each and never run. A second bind() on this
-        // listener would make the count matter again.
+        // nothing can reach — they hold a selector each and never run.
+        //
+        // This holds only because nothing else uses the group. Two assumptions, both of which
+        // would need this count raised again if they change: this listener binds once, and the
+        // parser schedules nothing on it. The second is why UdpListener must stay at the default
+        // — there the same group is the parser's scheduler (UdpParserBase schedules housekeeping
+        // on it), whereas ParserBase.start ignores the executor it is handed and IpfixTcpParser
+        // does not override it.
         final var formatName = name.replace("%", "%%");
         this.bossGroup = new MultiThreadIoEventLoopGroup(1, new ThreadFactoryBuilder()
                 .setNameFormat("tcp-listener-nio-boss-" + formatName + "-%d")

--- a/src/main/java/org/riptide/flows/listeners/TcpListener.java
+++ b/src/main/java/org/riptide/flows/listeners/TcpListener.java
@@ -7,6 +7,7 @@ package org.riptide.flows.listeners;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFuture;
@@ -15,10 +16,11 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.group.DefaultChannelGroup;
-import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.codec.ByteToMessageDecoder;
@@ -55,8 +57,18 @@ public class TcpListener implements Listener {
 
     @Override
     public void start() {
-        this.bossGroup = new NioEventLoopGroup();
-        this.workerGroup = new NioEventLoopGroup();
+        // One thread: ServerBootstrap registers a single channel, so only one event loop is ever
+        // selected for accept. Netty's default (0 = 2 * num cores) would build the rest as loops
+        // nothing can reach — they hold a selector each and never run. A second bind() on this
+        // listener would make the count matter again.
+        this.bossGroup = new MultiThreadIoEventLoopGroup(1, new ThreadFactoryBuilder()
+                .setNameFormat("tcp-listener-nio-boss-" + name + "-%d")
+                .build(), NioIoHandler.newFactory());
+        // Netty defaults to 2 * num cores when the number of threads is set to 0; here that is
+        // real capacity, since each accepted connection is assigned a loop round-robin.
+        this.workerGroup = new MultiThreadIoEventLoopGroup(0, new ThreadFactoryBuilder()
+                .setNameFormat("tcp-listener-nio-worker-" + name + "-%d")
+                .build(), NioIoHandler.newFactory());
 
         this.parser.start(this.bossGroup);
 

--- a/src/main/java/org/riptide/flows/listeners/UdpListener.java
+++ b/src/main/java/org/riptide/flows/listeners/UdpListener.java
@@ -18,8 +18,9 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.FixedRecvByteBufAllocator;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.nio.NioDatagramChannel;
@@ -62,9 +63,9 @@ public class UdpListener implements Listener {
     @Override
     public void start() {
         // Netty defaults to 2 * num cores when the number of threads is set to 0
-        this.bossGroup = new NioEventLoopGroup(0, new ThreadFactoryBuilder()
+        this.bossGroup = new MultiThreadIoEventLoopGroup(0, new ThreadFactoryBuilder()
                 .setNameFormat("udp-listener-nio-" + name + "-%d")
-                .build());
+                .build(), NioIoHandler.newFactory());
 
         this.parser.start(this.bossGroup);
 

--- a/src/main/java/org/riptide/flows/listeners/UdpListener.java
+++ b/src/main/java/org/riptide/flows/listeners/UdpListener.java
@@ -62,10 +62,18 @@ public class UdpListener implements Listener {
 
     @Override
     public void start() {
-        // One thread: UdpListener binds a single DatagramChannel, so only one event loop is ever
-        // selected. Netty's default (0 = 2 * num cores) would build the rest as loops nothing can reach.
+        // Netty defaults to 2 * num cores when the number of threads is set to 0.
+        //
+        // Do NOT size this to 1 on the reasoning that a single DatagramChannel occupies one loop.
+        // This group is also the parser's ScheduledExecutorService (see parser.start below), and
+        // UdpParserBase schedules doHousekeeping on it every 60s — one task per sub-parser under
+        // DispatchingUdpParser. scheduleAtFixedRate calls next(), so with more than one loop the
+        // sweep runs on a different thread from the socket; measured, this group starts exactly
+        // two threads. Collapsing to one loop would put every housekeeping sweep on the thread
+        // draining the socket, stalling reception into kernel loss on the socketDrops gauge.
+        // Sizing this group is issue #450, and needs the ingest path measured first.
         final var formatName = name.replace("%", "%%");
-        this.bossGroup = new MultiThreadIoEventLoopGroup(1, new ThreadFactoryBuilder()
+        this.bossGroup = new MultiThreadIoEventLoopGroup(0, new ThreadFactoryBuilder()
                 .setNameFormat("udp-listener-nio-" + formatName + "-%d")
                 .build(), NioIoHandler.newFactory());
 

--- a/src/main/java/org/riptide/flows/listeners/UdpListener.java
+++ b/src/main/java/org/riptide/flows/listeners/UdpListener.java
@@ -62,9 +62,11 @@ public class UdpListener implements Listener {
 
     @Override
     public void start() {
-        // Netty defaults to 2 * num cores when the number of threads is set to 0
-        this.bossGroup = new MultiThreadIoEventLoopGroup(0, new ThreadFactoryBuilder()
-                .setNameFormat("udp-listener-nio-" + name + "-%d")
+        // One thread: UdpListener binds a single DatagramChannel, so only one event loop is ever
+        // selected. Netty's default (0 = 2 * num cores) would build the rest as loops nothing can reach.
+        final var formatName = name.replace("%", "%%");
+        this.bossGroup = new MultiThreadIoEventLoopGroup(1, new ThreadFactoryBuilder()
+                .setNameFormat("udp-listener-nio-" + formatName + "-%d")
                 .build(), NioIoHandler.newFactory());
 
         this.parser.start(this.bossGroup);

--- a/src/test/java/org/riptide/flows/listeners/TcpListenerThreadNamingTest.java
+++ b/src/test/java/org/riptide/flows/listeners/TcpListenerThreadNamingTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.listeners;
+
+import com.codahale.metrics.MetricRegistry;
+import io.netty.buffer.ByteBuf;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A listener's threads must be attributable to it in a dump.
+ *
+ * <p>Before this, {@code TcpListener} built both of its groups with no thread factory, so its
+ * threads carried Netty's default {@code nioEventLoopGroup-N-M} — which names neither the listener
+ * nor the thread's role. With several listeners configured, a dump could not tell you which one was
+ * busy.
+ *
+ * <p>Scope: only the boss thread is asserted. Netty starts an event loop's carrier thread lazily,
+ * on first registration, so the worker group has no live thread until a connection is accepted;
+ * covering it would mean discovering the ephemeral port (which {@code TcpListener} does not expose)
+ * and connecting. The worker factory is applied at the same construction site.
+ */
+class TcpListenerThreadNamingTest {
+
+    @Test
+    void bossThreadIsNamedAfterTheListenerAndItsRole() {
+        final var listener = new TcpListener("naming", parser(), new MetricRegistry())
+                .withHost("127.0.0.1")
+                .withPort(0);
+
+        listener.start();
+        try {
+            assertThat(liveThreadNames())
+                    .as("the accept thread must identify its listener and role")
+                    .anyMatch(name -> name.startsWith("tcp-listener-nio-boss-naming-"));
+
+            assertThat(liveThreadNames())
+                    .as("no group may fall back to Netty's anonymous default naming")
+                    .noneMatch(name -> name.startsWith("nioEventLoopGroup-"));
+        } finally {
+            listener.stop();
+        }
+    }
+
+    private static java.util.stream.Stream<String> liveThreadNames() {
+        return Thread.getAllStackTraces().keySet().stream().map(Thread::getName);
+    }
+
+    private static TcpParser parser() {
+        return new TcpParser() {
+            @Override
+            public Handler accept(final InetSocketAddress remoteAddress, final InetSocketAddress localAddress) {
+                return new Handler() {
+                    @Override
+                    public void inactive() {
+                    }
+
+                    @Override
+                    public void active() {
+                    }
+
+                    @Override
+                    public Optional<CompletableFuture<?>> parse(final Instant receivedAt, final ByteBuf buffer) {
+                        return Optional.empty();
+                    }
+                };
+            }
+
+            @Override
+            public String getName() {
+                return "naming";
+            }
+
+            @Override
+            public String getDescription() {
+                return "naming";
+            }
+
+            @Override
+            public Object dumpInternalState() {
+                return null;
+            }
+
+            @Override
+            public void start(final ScheduledExecutorService executorService) {
+            }
+
+            @Override
+            public void stop() {
+            }
+        };
+    }
+}

--- a/src/test/java/org/riptide/flows/listeners/TcpListenerThreadNamingTest.java
+++ b/src/test/java/org/riptide/flows/listeners/TcpListenerThreadNamingTest.java
@@ -34,19 +34,40 @@ class TcpListenerThreadNamingTest {
 
     @Test
     void bossThreadIsNamedAfterTheListenerAndItsRole() {
+        final var existingThreads = liveThreadNames().collect(java.util.stream.Collectors.toSet());
+
         final var listener = new TcpListener("naming", parser(), new MetricRegistry())
                 .withHost("127.0.0.1")
                 .withPort(0);
 
         listener.start();
         try {
-            assertThat(liveThreadNames())
+            final var newThreads = liveThreadNames()
+                    .filter(name -> !existingThreads.contains(name))
+                    .toList();
+
+            assertThat(newThreads)
                     .as("the accept thread must identify its listener and role")
                     .anyMatch(name -> name.startsWith("tcp-listener-nio-boss-naming-"));
 
-            assertThat(liveThreadNames())
+            assertThat(newThreads)
                     .as("no group may fall back to Netty's anonymous default naming")
                     .noneMatch(name -> name.startsWith("nioEventLoopGroup-"));
+        } finally {
+            listener.stop();
+        }
+    }
+
+    @Test
+    void handlesPercentInListenerName() {
+        final var listener = new TcpListener("listener%1", parser(), new MetricRegistry())
+                .withHost("127.0.0.1")
+                .withPort(0);
+
+        listener.start();
+        try {
+            assertThat(liveThreadNames())
+                    .anyMatch(name -> name.startsWith("tcp-listener-nio-boss-listener%1-"));
         } finally {
             listener.stop();
         }

--- a/src/test/java/org/riptide/flows/listeners/UdpListenerSchedulerIsolationTest.java
+++ b/src/test/java/org/riptide/flows/listeners/UdpListenerSchedulerIsolationTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.listeners;
+
+import com.codahale.metrics.MetricRegistry;
+import io.netty.buffer.ByteBuf;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A {@code UdpListener}'s event loop group is also the parser's {@code ScheduledExecutorService}:
+ * {@code start()} hands it to {@code parser.start(...)}, and {@code UdpParserBase} schedules
+ * {@code doHousekeeping} on it every 60s — once per sub-parser under {@code DispatchingUdpParser}.
+ *
+ * <p>The regression this pins: sizing the group to one loop on the reasoning that a single
+ * {@code DatagramChannel} only occupies one. {@code scheduleAtFixedRate} calls {@code next()}, so
+ * with the default group the sweep runs on a different loop from the socket; with one loop it runs
+ * on the thread draining the socket, turning every sweep into a pause in packet reception that
+ * surfaces as kernel loss on the {@code socketDrops} gauge rather than as an application error.
+ *
+ * <p>Sizing this group is issue #450 and needs the ingest path measured first.
+ */
+class UdpListenerSchedulerIsolationTest {
+
+    @Test
+    void scheduledParserWorkDoesNotShareTheThreadDrainingTheSocket() {
+        final var listener = new UdpListener("isolation", schedulingParser(), new MetricRegistry())
+                .withHost("127.0.0.1")
+                .withPort(0);
+
+        listener.start();
+        try {
+            final var loopThreads = Thread.getAllStackTraces().keySet().stream()
+                    .map(Thread::getName)
+                    .filter(name -> name.startsWith("udp-listener-nio-isolation-"))
+                    .collect(Collectors.toSet());
+
+            assertThat(loopThreads)
+                    .as("the parser's scheduled housekeeping must not run on the socket's event loop")
+                    .hasSizeGreaterThan(1);
+        } finally {
+            listener.stop();
+        }
+    }
+
+    /** Stands in for {@code UdpParserBase}, which schedules housekeeping on the group it is given. */
+    private static UdpParser schedulingParser() {
+        return new UdpParser() {
+            @Override
+            public void start(final ScheduledExecutorService executorService) {
+                executorService.scheduleAtFixedRate(() -> {
+                }, 60_000, 60_000, TimeUnit.MILLISECONDS);
+            }
+
+            @Override
+            public CompletableFuture<?> parse(final Instant receivedAt, final ByteBuf buffer,
+                                              final InetSocketAddress remoteAddress,
+                                              final InetSocketAddress localAddress) {
+                return CompletableFuture.completedFuture(null);
+            }
+
+            @Override
+            public String getName() {
+                return "isolation";
+            }
+
+            @Override
+            public String getDescription() {
+                return "isolation";
+            }
+
+            @Override
+            public Object dumpInternalState() {
+                return null;
+            }
+
+            @Override
+            public void stop() {
+            }
+        };
+    }
+}


### PR DESCRIPTION
Fixes #442

## What

`UdpListener`, `TcpListener` and `NettyDnsResolver` built `NioEventLoopGroup`, the pre-4.2 Netty idiom, while the pom pins `netty.version` to `4.2.16.Final`. Netty 4.2 restructured the event loop around the `IoHandler` abstraction, separating I/O processing from task processing; `MultiThreadIoEventLoopGroup` with `NioIoHandler.newFactory()` is the supported form and `NioEventLoopGroup` is retained only for compatibility. We were carrying the constraints of the pinned version without using its interface.

Same NIO transport, same threading semantics, no behaviour change.

`NettyDnsResolver.group` is widened from the concrete `NioEventLoopGroup` to the `EventLoopGroup` interface — its only reader is `NettyDnsResolverWorker`, which needs nothing beyond `next()`.

`TcpListener` additionally gains named thread factories for both groups. It was the only one of the three building groups without one, so its threads carried Netty's anonymous `nioEventLoopGroup-N-M` and could not be attributed to a listener in a dump. That is the one operator-visible change here.

## Why `TcpListener`'s boss group is sized to 1

`ServerBootstrap` registers exactly one channel, so exactly one event loop is ever selected for accept, and the parser never routes work to this group either (`ParserBase.start` ignores the `ScheduledExecutorService` it is handed, and `IpfixTcpParser` does not override it).

Measured on a 10-core host, Netty 4.2.16, Java 25 — carrier threads are started lazily, on first `register()`/`execute()`, so the default is not conservative, it is unreachable:

```
                    loops built   threads STARTED   fds
  boss nThreads=0        20              1          60
  boss nThreads=1         1              1           3
```

Same single thread either way; the default just builds 19 loops nothing can reach, holding a selector each. The constructor comment records the two assumptions that make `1` safe (single bind, and a parser that schedules nothing) so a future change that breaks either has something to trip over.

## Why `UdpListener`'s group is **not** sized the same way

The same reasoning does not transfer, and this PR contains a fix for having applied it there. `UdpListener`'s group is also the parser's `ScheduledExecutorService`: `start()` hands it to `parser.start()`, and `UdpParserBase` schedules `doHousekeeping` on it every 60s — one task per sub-parser under `DispatchingUdpParser`.

`scheduleAtFixedRate` calls `next()`, so with the default group the sweep lands on a different loop from the one `bind()` later registers the channel on; measured, the group starts exactly two threads. Collapsing to one loop puts every housekeeping sweep on the thread draining the socket, which would surface as kernel loss on `listeners.<name>.socketDrops` rather than as an application error.

Sizing that group is #450, which needs the ingest path measured first.

## Tests

`TcpListenerThreadNamingTest` is the first test this file has had; `UdpListenerSchedulerIsolationTest` pins the invariant that a parser scheduling on the group it is given must not land on the socket's loop. Both were verified non-vacuous by reintroducing the defect each one describes and confirming it fails.

## Verification

`make jar` green — SpotBugs 0, coverage checks met, 988 tests, 0 failures.

Ingest A/B benchmark, baseline `main` (589a739) in a worktree vs branch head, same box, same offered load, 28 runs:

```
                       base      branch    delta
block A+B (base 1st)   7708.2    7892.3    +2.39%
block C (branch 1st)   7677.4    7689.7    +0.16%
pooled, n=14 each      7695.0    7805.5    +1.44%   t=1.55   CI -0.4%..+3.3%
```

Within noise. Loop-thread counts identical in both arms. The first block's nominally-significant +2.4% was an artifact of always running base first — counterbalancing revealed a +1.3% position effect favouring whichever arm ran second.

Caveats, since they bound the claim: run locally on Apple Silicon, not the lab rig, so only the A/B is meaningful and not the absolute rate. Load was a saturating loopback flood rather than nl6 — nl6 through Docker Desktop delivered ~250 pkt/s in bursts, leaving the event loop idle and unable to resolve any difference. Detection floor is roughly ±3%. UDP only, so the TCP path carrying the largest diff is covered by unit tests alone.
