### PR TITLE
fix(listeners): release every resource when a listener is stopped

### DIFF
--- a/src/main/java/org/riptide/flows/listeners/Listener.java
+++ b/src/main/java/org/riptide/flows/listeners/Listener.java
@@ -18,6 +18,20 @@ public interface Listener {
     String getName();
     String getDescription();
     void start();
+
+    /**
+     * Releases everything {@link #start()} acquired.
+     *
+     * <p>Must be safe to call when {@code start()} never ran or did not finish: a listener is
+     * constructed in one lifecycle phase and started in another, so a failure between them leaves a
+     * constructed listener owning nothing. Implementations must not assume fields assigned during
+     * {@code start()} are populated.
+     *
+     * <p>Release is best-effort across resources — a step that fails must not prevent the remaining
+     * steps from being attempted, or a failed channel close would strand the event loop threads
+     * behind it. Failures are reported once every step has been attempted, the first thrown with any
+     * others attached via {@link Throwable#addSuppressed}; they are never silently swallowed.
+     */
     void stop();
 
     /**

--- a/src/main/java/org/riptide/flows/listeners/TcpListener.java
+++ b/src/main/java/org/riptide/flows/listeners/TcpListener.java
@@ -170,10 +170,11 @@ public class TcpListener implements Listener {
                 .syncUninterruptibly();
     }
 
-    // Every field below is assigned in start(), which runs in a later lifecycle phase than the
-    // constructor — a context refresh that fails in between leaves this listener owning nothing.
-    // Steps are attempted independently so a failure does not strand the resources after it; see
-    // Teardown.
+    // socketFuture, workerGroup and bossGroup are assigned in start(), which runs in a later
+    // lifecycle phase than the constructor — a context refresh that fails in between leaves this
+    // listener owning none of them, so those steps are guarded. channels and parser are set at
+    // construction and are never null. Steps are attempted independently so a failure does not
+    // strand the resources after it; see Teardown.
     @Override
     public void stop() {
         final var teardown = new Teardown();
@@ -185,16 +186,16 @@ public class TcpListener implements Listener {
 
         teardown.attemptIfPresent(this.socketFuture, () -> {
             final var ch = this.socketFuture.channel();
-            if (ch != null) {
-                LOG.info("Closing channel...");
-                teardown.attempt(ch.close()::syncUninterruptibly);
-                if (ch.parent() != null) {
-                    teardown.attempt(ch.parent().close()::syncUninterruptibly);
-                }
+            LOG.info("Closing channel...");
+            // Channel and parent are attempted separately: a parent that fails to close must not
+            // be skipped because the child did, and vice versa.
+            teardown.attempt(() -> ch.close().syncUninterruptibly());
+            if (ch.parent() != null) {
+                teardown.attempt(() -> ch.parent().close().syncUninterruptibly());
             }
         });
 
-        teardown.attemptIfPresent(this.parser, () -> {
+        teardown.attempt(() -> {
             LOG.info("Stopping parser...");
             this.parser.stop();
         });

--- a/src/main/java/org/riptide/flows/listeners/TcpListener.java
+++ b/src/main/java/org/riptide/flows/listeners/TcpListener.java
@@ -178,28 +178,37 @@ public class TcpListener implements Listener {
     public void stop() {
         final var teardown = new Teardown();
 
-        LOG.info("Disconnecting clients...");
-        teardown.attempt(() -> this.channels.close().awaitUninterruptibly());
+        teardown.attempt(() -> {
+            LOG.info("Disconnecting clients...");
+            this.channels.close().awaitUninterruptibly();
+        });
 
         teardown.attemptIfPresent(this.socketFuture, () -> {
-            LOG.info("Closing channel...");
-            this.socketFuture.channel().close().syncUninterruptibly();
-            if (this.socketFuture.channel().parent() != null) {
-                this.socketFuture.channel().parent().close().syncUninterruptibly();
+            final var ch = this.socketFuture.channel();
+            if (ch != null) {
+                LOG.info("Closing channel...");
+                teardown.attempt(ch.close()::syncUninterruptibly);
+                if (ch.parent() != null) {
+                    teardown.attempt(ch.parent().close()::syncUninterruptibly);
+                }
             }
         });
 
-        LOG.info("Stopping parser...");
-        teardown.attempt(this.parser::stop);
+        teardown.attemptIfPresent(this.parser, () -> {
+            LOG.info("Stopping parser...");
+            this.parser.stop();
+        });
 
-        LOG.info("Closing worker group...");
         // switch to use even listener rather than sync to prevent shutdown deadlock hang
-        teardown.attemptIfPresent(this.workerGroup,
-                () -> this.workerGroup.shutdownGracefully().syncUninterruptibly());
+        teardown.attemptIfPresent(this.workerGroup, () -> {
+            LOG.info("Closing worker group...");
+            this.workerGroup.shutdownGracefully().syncUninterruptibly();
+        });
 
-        LOG.info("Closing boss group...");
-        teardown.attemptIfPresent(this.bossGroup,
-                () -> this.bossGroup.shutdownGracefully().syncUninterruptibly());
+        teardown.attemptIfPresent(this.bossGroup, () -> {
+            LOG.info("Closing boss group...");
+            this.bossGroup.shutdownGracefully().syncUninterruptibly();
+        });
 
         teardown.done();
     }

--- a/src/main/java/org/riptide/flows/listeners/TcpListener.java
+++ b/src/main/java/org/riptide/flows/listeners/TcpListener.java
@@ -170,30 +170,38 @@ public class TcpListener implements Listener {
                 .syncUninterruptibly();
     }
 
+    // Every field below is assigned in start(), which runs in a later lifecycle phase than the
+    // constructor — a context refresh that fails in between leaves this listener owning nothing.
+    // Steps are attempted independently so a failure does not strand the resources after it; see
+    // Teardown.
     @Override
     public void stop() {
-        LOG.info("Disconnecting clients...");
-        this.channels.close().awaitUninterruptibly();
+        final var teardown = new Teardown();
 
-        if (this.socketFuture != null) {
+        LOG.info("Disconnecting clients...");
+        teardown.attempt(() -> this.channels.close().awaitUninterruptibly());
+
+        teardown.attemptIfPresent(this.socketFuture, () -> {
             LOG.info("Closing channel...");
             this.socketFuture.channel().close().syncUninterruptibly();
             if (this.socketFuture.channel().parent() != null) {
                 this.socketFuture.channel().parent().close().syncUninterruptibly();
             }
-        }
+        });
 
         LOG.info("Stopping parser...");
-        if (this.parser != null) {
-            this.parser.stop();
-        }
+        teardown.attempt(this.parser::stop);
 
         LOG.info("Closing worker group...");
         // switch to use even listener rather than sync to prevent shutdown deadlock hang
-        this.workerGroup.shutdownGracefully().syncUninterruptibly();
+        teardown.attemptIfPresent(this.workerGroup,
+                () -> this.workerGroup.shutdownGracefully().syncUninterruptibly());
 
         LOG.info("Closing boss group...");
-        this.bossGroup.shutdownGracefully().syncUninterruptibly();
+        teardown.attemptIfPresent(this.bossGroup,
+                () -> this.bossGroup.shutdownGracefully().syncUninterruptibly());
+
+        teardown.done();
     }
 
     @Override

--- a/src/main/java/org/riptide/flows/listeners/Teardown.java
+++ b/src/main/java/org/riptide/flows/listeners/Teardown.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.listeners;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Runs the steps of a {@link Listener#stop()} so that one failing step does not strand the
+ * resources released by the steps after it.
+ *
+ * <p>Netty's {@code syncUninterruptibly()} sneaky-throws the future's cause, checked exceptions
+ * included, so any step can throw. Straight-line teardown therefore skips everything below the
+ * first failure — which is how a channel that fails to close takes the event loop groups with it.
+ *
+ * <p>Steps run in the order given; several teardown orderings are load-bearing (a UDP listener must
+ * deregister its {@code socketDrops} gauge before releasing the port it describes). Failures are
+ * collected and rethrown by {@link #done()}: the first as-is, the rest suppressed onto it. Keeping
+ * the first exception rather than wrapping matters because {@code Daemon.stop()} catches
+ * {@code Exception} specifically to receive Netty's sneaky-thrown cause intact.
+ */
+final class Teardown {
+
+    private final List<Throwable> failures = new ArrayList<>();
+
+    /** Runs {@code step}, recording rather than propagating any failure. */
+    void attempt(final Runnable step) {
+        try {
+            step.run();
+        } catch (final Throwable t) {
+            this.failures.add(t);
+        }
+    }
+
+    /** As {@link #attempt}, skipping the step when {@code resource} was never acquired. */
+    void attemptIfPresent(final Object resource, final Runnable step) {
+        if (resource != null) {
+            attempt(step);
+        }
+    }
+
+    /**
+     * Rethrows the first recorded failure with the remainder suppressed, or returns if every step
+     * succeeded.
+     */
+    void done() {
+        if (this.failures.isEmpty()) {
+            return;
+        }
+        final Throwable first = this.failures.getFirst();
+        this.failures.stream().skip(1).forEach(first::addSuppressed);
+        throw sneakyThrow(first);
+    }
+
+    // Preserves the original throwable's type instead of wrapping it: Daemon.stop() catches
+    // Exception (not RuntimeException) precisely so Netty's sneaky-thrown checked causes reach it
+    // unaltered, and wrapping here would defeat that.
+    @SuppressWarnings("unchecked")
+    private static <T extends Throwable> RuntimeException sneakyThrow(final Throwable t) throws T {
+        throw (T) t;
+    }
+}

--- a/src/main/java/org/riptide/flows/listeners/Teardown.java
+++ b/src/main/java/org/riptide/flows/listeners/Teardown.java
@@ -51,7 +51,7 @@ final class Teardown {
             return;
         }
         final Throwable first = this.failures.getFirst();
-        this.failures.stream().skip(1).forEach(first::addSuppressed);
+        this.failures.stream().skip(1).filter(t -> t != first).forEach(first::addSuppressed);
         throw sneakyThrow(first);
     }
 

--- a/src/main/java/org/riptide/flows/listeners/UdpListener.java
+++ b/src/main/java/org/riptide/flows/listeners/UdpListener.java
@@ -126,22 +126,30 @@ public class UdpListener implements Listener {
         // longer own, and the next process to bind it would have its kernel drops published as
         // this receiver's ingest loss. Same reason BatchingFlowRepository removes its queue-depth
         // gauge in stop().
-        teardown.attempt(() -> this.metrics.remove(MetricRegistry.name("listeners", this.name, "socketDrops")));
+        teardown.attemptIfPresent(this.metrics,
+                () -> this.metrics.remove(MetricRegistry.name("listeners", this.name, "socketDrops")));
 
         teardown.attemptIfPresent(this.socketFuture, () -> {
-            LOG.info("Closing channel...");
-            this.socketFuture.channel().close().syncUninterruptibly();
-            if (this.socketFuture.channel().parent() != null) {
-                this.socketFuture.channel().parent().close().syncUninterruptibly();
+            final var ch = this.socketFuture.channel();
+            if (ch != null) {
+                LOG.info("Closing channel...");
+                teardown.attempt(ch.close()::syncUninterruptibly);
+                if (ch.parent() != null) {
+                    teardown.attempt(ch.parent().close()::syncUninterruptibly);
+                }
             }
         });
 
-        teardown.attempt(this.parser::stop);
+        teardown.attemptIfPresent(this.parser, () -> {
+            LOG.info("Stopping parser...");
+            this.parser.stop();
+        });
 
-        LOG.info("Closing boss group...");
         // switch to use even listener rather than sync to prevent shutdown deadlock hang
-        teardown.attemptIfPresent(this.bossGroup,
-                () -> this.bossGroup.shutdownGracefully().syncUninterruptibly());
+        teardown.attemptIfPresent(this.bossGroup, () -> {
+            LOG.info("Closing boss group...");
+            this.bossGroup.shutdownGracefully().syncUninterruptibly();
+        });
 
         teardown.done();
     }

--- a/src/main/java/org/riptide/flows/listeners/UdpListener.java
+++ b/src/main/java/org/riptide/flows/listeners/UdpListener.java
@@ -116,8 +116,11 @@ public class UdpListener implements Listener {
         this.metrics.register(gauge, (Gauge<Long>) () -> UdpSocketDrops.forSocket(bound));
     }
 
-    // Steps are attempted independently so a failure does not strand the resources after it; see
-    // Teardown. The order below is load-bearing and must not change.
+    // socketFuture and bossGroup are assigned in start(), which runs in a later lifecycle phase
+    // than the constructor — a context refresh that fails in between leaves this listener owning
+    // neither, so those steps are guarded. metrics and parser are set at construction and are never
+    // null. Steps are attempted independently so a failure does not strand the resources after it;
+    // see Teardown. The order below is load-bearing and must not change.
     @Override
     public void stop() {
         final var teardown = new Teardown();
@@ -126,21 +129,21 @@ public class UdpListener implements Listener {
         // longer own, and the next process to bind it would have its kernel drops published as
         // this receiver's ingest loss. Same reason BatchingFlowRepository removes its queue-depth
         // gauge in stop().
-        teardown.attemptIfPresent(this.metrics,
+        teardown.attempt(
                 () -> this.metrics.remove(MetricRegistry.name("listeners", this.name, "socketDrops")));
 
         teardown.attemptIfPresent(this.socketFuture, () -> {
             final var ch = this.socketFuture.channel();
-            if (ch != null) {
-                LOG.info("Closing channel...");
-                teardown.attempt(ch.close()::syncUninterruptibly);
-                if (ch.parent() != null) {
-                    teardown.attempt(ch.parent().close()::syncUninterruptibly);
-                }
+            LOG.info("Closing channel...");
+            // Channel and parent are attempted separately: a parent that fails to close must not
+            // be skipped because the child did, and vice versa.
+            teardown.attempt(() -> ch.close().syncUninterruptibly());
+            if (ch.parent() != null) {
+                teardown.attempt(() -> ch.parent().close().syncUninterruptibly());
             }
         });
 
-        teardown.attemptIfPresent(this.parser, () -> {
+        teardown.attempt(() -> {
             LOG.info("Stopping parser...");
             this.parser.stop();
         });

--- a/src/main/java/org/riptide/flows/listeners/UdpListener.java
+++ b/src/main/java/org/riptide/flows/listeners/UdpListener.java
@@ -116,29 +116,34 @@ public class UdpListener implements Listener {
         this.metrics.register(gauge, (Gauge<Long>) () -> UdpSocketDrops.forSocket(bound));
     }
 
+    // Steps are attempted independently so a failure does not strand the resources after it; see
+    // Teardown. The order below is load-bearing and must not change.
     @Override
     public void stop() {
+        final var teardown = new Teardown();
+
         // Deregister before closing: once the socket is gone the closure describes a port we no
         // longer own, and the next process to bind it would have its kernel drops published as
         // this receiver's ingest loss. Same reason BatchingFlowRepository removes its queue-depth
         // gauge in stop().
-        this.metrics.remove(MetricRegistry.name("listeners", this.name, "socketDrops"));
+        teardown.attempt(() -> this.metrics.remove(MetricRegistry.name("listeners", this.name, "socketDrops")));
 
-        if (this.socketFuture != null) {
+        teardown.attemptIfPresent(this.socketFuture, () -> {
             LOG.info("Closing channel...");
             this.socketFuture.channel().close().syncUninterruptibly();
             if (this.socketFuture.channel().parent() != null) {
                 this.socketFuture.channel().parent().close().syncUninterruptibly();
             }
-        }
+        });
 
-        this.parser.stop();
+        teardown.attempt(this.parser::stop);
 
         LOG.info("Closing boss group...");
-        if (this.bossGroup != null) {
-            // switch to use even listener rather than sync to prevent shutdown deadlock hang
-            this.bossGroup.shutdownGracefully().syncUninterruptibly();
-        }
+        // switch to use even listener rather than sync to prevent shutdown deadlock hang
+        teardown.attemptIfPresent(this.bossGroup,
+                () -> this.bossGroup.shutdownGracefully().syncUninterruptibly());
+
+        teardown.done();
     }
 
     @Override

--- a/src/test/java/org/riptide/flows/listeners/ListenerTeardownTest.java
+++ b/src/test/java/org/riptide/flows/listeners/ListenerTeardownTest.java
@@ -71,9 +71,10 @@ class ListenerTeardownTest {
                 .as("the failure must still reach the caller, not be swallowed")
                 .isSameAs(failure);
 
-        assertThat(liveThreadNames("tcp-listener-nio-"))
-                .as("the parser's failure must not prevent the event loop groups from shutting down")
-                .isEmpty();
+        awaitNoThreads("tcp-listener-nio-boss-stranded-",
+                "the parser's failure must not prevent the event loop groups from shutting down");
+        awaitNoThreads("tcp-listener-nio-worker-stranded-",
+                "the parser's failure must not prevent the event loop groups from shutting down");
     }
 
     @Test
@@ -109,9 +110,8 @@ class ListenerTeardownTest {
                         .as("later failures are attached rather than discarded")
                         .contains(parserFailure));
 
-        assertThat(liveThreadNames("udp-listener-nio-multi-"))
-                .as("both failures notwithstanding, the event loops are still released")
-                .isEmpty();
+        awaitNoThreads("udp-listener-nio-multi-",
+                "both failures notwithstanding, the event loops are still released");
     }
 
     private static java.util.List<String> liveThreadNames(final String prefix) {
@@ -119,6 +119,21 @@ class ListenerTeardownTest {
                 .map(Thread::getName)
                 .filter(name -> name.startsWith(prefix))
                 .toList();
+    }
+
+    /**
+     * Polls rather than asserting once. {@code shutdownGracefully().syncUninterruptibly()} returns
+     * when the termination future completes, and {@code SingleThreadEventExecutor} completes it
+     * from inside the event loop thread's own {@code finally} block — so the thread is briefly
+     * still alive, and visible to {@link Thread#getAllStackTraces()}, after the waiter wakes.
+     * A single assertion here would flake.
+     */
+    private static void awaitNoThreads(final String prefix, final String because) {
+        final long deadline = System.nanoTime() + java.util.concurrent.TimeUnit.SECONDS.toNanos(10);
+        while (!liveThreadNames(prefix).isEmpty() && System.nanoTime() < deadline) {
+            Thread.onSpinWait();
+        }
+        assertThat(liveThreadNames(prefix)).as(because).isEmpty();
     }
 
     /** @param stopFailure thrown from {@code stop()} when non-null. */

--- a/src/test/java/org/riptide/flows/listeners/ListenerTeardownTest.java
+++ b/src/test/java/org/riptide/flows/listeners/ListenerTeardownTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.listeners;
+
+import com.codahale.metrics.MetricRegistry;
+import io.netty.buffer.ByteBuf;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * A listener must release everything it acquired, whether or not it finished starting and whether
+ * or not an individual release fails.
+ *
+ * <p>Two regressions are pinned here. The first: {@code Daemon} constructs listeners in one
+ * lifecycle phase and starts them in another ({@code ApplicationRunner.run()}), so a bean failing
+ * during context refresh leaves constructed-but-unstarted listeners that are then torn down —
+ * {@code TcpListener.stop()} used to NPE on its unassigned event loop groups (#452), burying the
+ * real startup error under an unrelated stack.
+ *
+ * <p>The second: every teardown step calls {@code syncUninterruptibly()}, which sneaky-throws the
+ * future's cause, so straight-line teardown skipped every step below the first failure and stranded
+ * the event loop threads behind it.
+ */
+class ListenerTeardownTest {
+
+    @Test
+    void tcpListenerStopsCleanlyWhenStartNeverRan() {
+        final var listener = new TcpListener("unstarted", tcpParser(null), new MetricRegistry())
+                .withHost("127.0.0.1")
+                .withPort(0);
+
+        assertThatCode(listener::stop)
+                .as("a constructed-but-unstarted listener owns nothing; tearing it down is a normal path")
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void udpListenerStopsCleanlyWhenStartNeverRan() {
+        final var listener = new UdpListener("unstarted", udpParser(null), new MetricRegistry())
+                .withHost("127.0.0.1")
+                .withPort(0);
+
+        assertThatCode(listener::stop).doesNotThrowAnyException();
+    }
+
+    @Test
+    void aFailingStepDoesNotStrandTheEventLoops() {
+        final var failure = new IllegalStateException("parser teardown blew up");
+        final var listener = new TcpListener("stranded", tcpParser(failure), new MetricRegistry())
+                .withHost("127.0.0.1")
+                .withPort(0);
+
+        listener.start();
+        assertThat(liveThreadNames("tcp-listener-nio-boss-stranded-"))
+                .as("precondition: the listener owns an event loop before we stop it")
+                .isNotEmpty();
+
+        assertThatThrownBy(listener::stop)
+                .as("the failure must still reach the caller, not be swallowed")
+                .isSameAs(failure);
+
+        assertThat(liveThreadNames("tcp-listener-nio-"))
+                .as("the parser's failure must not prevent the event loop groups from shutting down")
+                .isEmpty();
+    }
+
+    @Test
+    void multipleFailuresAreReportedTogether() {
+        final var parserFailure = new IllegalStateException("parser teardown blew up");
+        final var metricsFailure = new IllegalStateException("gauge removal blew up");
+
+        // Fails on the gauge removal (first step) as well as on the parser, so two steps fail in
+        // one teardown — unreachable before this change, because the first failure ended it.
+        // Armed only after start(), since registerSocketDrops() also calls remove() to rebind the
+        // gauge to the live socket.
+        final var armed = new java.util.concurrent.atomic.AtomicBoolean();
+        final var metrics = new MetricRegistry() {
+            @Override
+            public boolean remove(final String name) {
+                if (armed.get()) {
+                    throw metricsFailure;
+                }
+                return super.remove(name);
+            }
+        };
+        final var listener = new UdpListener("multi", udpParser(parserFailure), metrics)
+                .withHost("127.0.0.1")
+                .withPort(0);
+
+        listener.start();
+        armed.set(true);
+
+        assertThatThrownBy(listener::stop)
+                .as("the first failure is reported as-is, so Netty's sneaky-thrown causes survive")
+                .isSameAs(metricsFailure)
+                .satisfies(t -> assertThat(t.getSuppressed())
+                        .as("later failures are attached rather than discarded")
+                        .contains(parserFailure));
+
+        assertThat(liveThreadNames("udp-listener-nio-multi-"))
+                .as("both failures notwithstanding, the event loops are still released")
+                .isEmpty();
+    }
+
+    private static java.util.List<String> liveThreadNames(final String prefix) {
+        return Thread.getAllStackTraces().keySet().stream()
+                .map(Thread::getName)
+                .filter(name -> name.startsWith(prefix))
+                .toList();
+    }
+
+    /** @param stopFailure thrown from {@code stop()} when non-null. */
+    private static TcpParser tcpParser(final RuntimeException stopFailure) {
+        return new TcpParser() {
+            @Override
+            public Handler accept(final InetSocketAddress remoteAddress, final InetSocketAddress localAddress) {
+                return new Handler() {
+                    @Override
+                    public void inactive() {
+                    }
+
+                    @Override
+                    public void active() {
+                    }
+
+                    @Override
+                    public Optional<CompletableFuture<?>> parse(final Instant receivedAt, final ByteBuf buffer) {
+                        return Optional.empty();
+                    }
+                };
+            }
+
+            @Override
+            public String getName() {
+                return "teardown";
+            }
+
+            @Override
+            public String getDescription() {
+                return "teardown";
+            }
+
+            @Override
+            public Object dumpInternalState() {
+                return null;
+            }
+
+            @Override
+            public void start(final ScheduledExecutorService executorService) {
+            }
+
+            @Override
+            public void stop() {
+                if (stopFailure != null) {
+                    throw stopFailure;
+                }
+            }
+        };
+    }
+
+    /** @param stopFailure thrown from {@code stop()} when non-null. */
+    private static UdpParser udpParser(final RuntimeException stopFailure) {
+        return new UdpParser() {
+            @Override
+            public CompletableFuture<?> parse(final Instant receivedAt, final ByteBuf buffer,
+                                              final InetSocketAddress remoteAddress,
+                                              final InetSocketAddress localAddress) {
+                return CompletableFuture.completedFuture(null);
+            }
+
+            @Override
+            public String getName() {
+                return "teardown";
+            }
+
+            @Override
+            public String getDescription() {
+                return "teardown";
+            }
+
+            @Override
+            public Object dumpInternalState() {
+                return null;
+            }
+
+            @Override
+            public void start(final ScheduledExecutorService executorService) {
+            }
+
+            @Override
+            public void stop() {
+                if (stopFailure != null) {
+                    throw stopFailure;
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
Fixes #452

## What

`TcpListener.stop()` dereferenced its event loop groups without a null check, so stopping a listener whose `start()` never completed raised a `NullPointerException` on `workerGroup`.

The trigger is ordinary. `Daemon` builds its listeners in the constructor but starts them in `ApplicationRunner.run()`, which only executes once the context is fully refreshed. Any bean failing during refresh — a `BindException` on `riptide.management.port` is enough — means `run()` never fires while `@PreDestroy stop()` still does, so the groups were never assigned. The NPE then competed with the actual startup error in the log, and the actual error is the one the operator needs.

```
        CONSTRUCTOR                          ApplicationRunner.run()        @PreDestroy
  build listeners  ──────────────────────▶   pipeline.start()          ┌──▶ stop()
        │                                    listeners.forEach(start)  │      listener.stop()
        └──▶ context refresh continues       started = true            │
             managementServer: BindException ─── refresh aborts ───────┘
                                                  run() NEVER CALLED
```

## The wider weakness the NPE was one instance of

Teardown in both listeners aborted on the first failure. Every step calls `syncUninterruptibly()`, which sneaky-throws the future's cause, so a channel that failed to close took the event loop groups with it and their threads were never shut down. `Daemon` already documents that sneaky-throw as the reason it catches `Exception` rather than `RuntimeException` — the hazard was known at the caller and unhandled at the callee.

Both listeners now attempt every step regardless of what the earlier ones did, via a small `Teardown` helper. Failures are collected and reported once the sequence finishes: the first is rethrown as-is with the rest attached via `addSuppressed`, so `Daemon`'s `Failed to stop listener` warning keeps firing and Netty's sneaky-thrown causes still reach its `catch` intact. Swallowing them would have traded a noisy failure for a silent one on a path where the pipeline's batch drain can lose buffered flows.

Teardown order is unchanged; `UdpListener` still deregisters its `socketDrops` gauge before releasing the port that gauge describes.

The contract now lives on `Listener.stop()` rather than being rediscovered per implementation — `UdpListener` guarded defensively and `TcpListener` did not, with nothing stating which was right.

## Why not fixed at the caller

`Daemon.stop()` could skip the loop when `!started` — one line, covering every listener present and future. It is unsound: `listeners.forEach(Listener::start)` has no try/catch, so a listener failing to start leaves earlier listeners bound while `started` is still `false`, and skipping them would turn a noisy log line into a real leak. Only the listener knows what it acquired.

## Tests

`ListenerTeardownTest` covers both halves of the invariant. Verified non-vacuous: **3 of its 4 tests fail against the previous code**. The fourth covers `UdpListener` stopping without start, which already worked; it pins that against regression.

Thread-absence assertions poll rather than asserting once — `shutdownGracefully().syncUninterruptibly()` returns when the termination future completes, and `SingleThreadEventExecutor` completes it from inside the event loop thread's own `finally` block, so the thread is briefly still alive afterwards. They are also scoped to the listener under test rather than to every `TcpListener` in the JVM.

## Verification

`make jar` green — SpotBugs 0, coverage checks met, 992 tests, 0 failures.

Confirmed end to end by starting the daemon with an ipfix/TCP receiver and `riptide.management.port` occupied:

```
Disconnecting clients... → Stopping parser... → Closing worker group... → Closing boss group...
Caused by: java.net.BindException: Address already in use
```

Teardown now runs through both event loop groups and the `BindException` stands alone. Previously it stopped at `Closing worker group...` with the NPE beside the real error.

## Related

Found while verifying #442 on a running instance. The same investigation turned up #453 (`Daemon` announces `Listening for flows` from the constructor, before any socket is bound), deliberately excluded here as startup observability rather than shutdown robustness.
