### PR TITLE
chore(benchmarks): measure the UDP read thread's per-packet cost

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ help:
 	@echo "  coverage:     Run the unit test suite and render the JaCoCo coverage report"
 	@echo "  e2e:          Run integration and e2e tests (*IT, requires Docker) in addition to the unit suite"
 	@echo "  fuzz:         Coverage-guided fuzzing of the flow parsers (Jazzer); FUZZ_TIME=<seconds> per target"
+	@echo "  bench:        Run the JMH microbenchmarks; BENCH_TARGET=<regex> to narrow, BENCH_OPTS=<jmh flags>"
 	@echo "  lint-actions: Lint the GitHub Actions workflows (actionlint + zizmor)"
 	@echo "  docs:         Build the Docusaurus documentation site into docs/build"
 	@echo "  docs-serve:   Run the documentation site locally with live reload"
@@ -103,6 +104,28 @@ fuzz: deps-jar
 	JAZZER_FUZZ=1 mvn $(BUILD_OPTS) --batch-mode test-compile surefire:test \
 		-Dtest='org.riptide.flows.fuzz.$(FUZZ_TARGET)' \
 		-Djazzer.max_duration=$(FUZZ_TIME)s
+
+# JMH microbenchmarks (src/test/java/org/riptide/benchmarks). Not part of `make jar`: a benchmark
+# run takes minutes and its numbers are meaningless on a loaded machine, so it is opt-in and never
+# a build gate. BENCH_TARGET is a JMH regex over benchmark class names.
+#
+# BENCH_OPTS overrides the per-class @Fork/@Warmup/@Measurement annotations, which are all set to
+# JMH-light values (1 fork, 2 warmup, 5 measurement) for a quick single run. Two forks and ten
+# iterations is the setting worth quoting a number from: these decode benchmarks sit around 20us/op,
+# and a single noisy fork has been observed moving the mean by 2x on a loaded machine. This is still
+# lighter on forks than JMH's own default of 5. Check `uptime` before trusting any result.
+#
+# dependency:build-classpath is what lets JMH run from the test classpath without a shade/uber jar.
+BENCH_TARGET ?= .*Benchmark
+BENCH_OPTS   ?= -wi 3 -i 10 -f 2
+.PHONY: bench
+bench: deps-jar
+	mvn $(BUILD_OPTS) --batch-mode test-compile \
+		dependency:build-classpath -Dmdep.outputFile=target/test-cp.txt -Dmdep.includeScope=test
+	java -cp "target/classes:target/test-classes:$$(cat target/test-cp.txt)" \
+		org.riptide.benchmarks.Benchmarks '$(BENCH_TARGET)' $(BENCH_OPTS) \
+		-rf json -rff target/jmh-result.json
+	@echo "JMH result: target/jmh-result.json"
 
 .PHONY: deps-lint-actions
 deps-lint-actions:

--- a/src/test/java/org/riptide/benchmarks/parser/netflow9/Netflow9ReadThreadBenchmark.java
+++ b/src/test/java/org/riptide/benchmarks/parser/netflow9/Netflow9ReadThreadBenchmark.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.benchmarks.parser.netflow9;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.riptide.flows.parser.data.Flow;
+import org.riptide.flows.parser.ie.values.ValueConversionService;
+import org.riptide.flows.parser.ie.values.visitor.BooleanVisitor;
+import org.riptide.flows.parser.ie.values.visitor.DoubleVisitor;
+import org.riptide.flows.parser.ie.values.visitor.DurationVisitor;
+import org.riptide.flows.parser.ie.values.visitor.InetAddressVisitor;
+import org.riptide.flows.parser.ie.values.visitor.InstantVisitor;
+import org.riptide.flows.parser.ie.values.visitor.IntegerVisitor;
+import org.riptide.flows.parser.ie.values.visitor.LongVisitor;
+import org.riptide.flows.parser.ie.values.visitor.StringVisitor;
+import org.riptide.flows.parser.ie.values.visitor.UnsignedLongVisitor;
+import org.riptide.flows.parser.netflow9.Netflow9FlowBuilder;
+import org.riptide.flows.parser.netflow9.Netflow9RawFlow;
+import org.riptide.flows.parser.netflow9.Netflow9UdpParser;
+import org.riptide.flows.parser.netflow9.proto.Header;
+import org.riptide.flows.parser.netflow9.proto.Packet;
+import org.riptide.flows.parser.session.SequenceNumberTracker;
+import org.riptide.flows.parser.session.Session;
+import org.riptide.flows.parser.session.TransactionalSession;
+import org.riptide.flows.parser.session.UdpSessionManager;
+import org.riptide.pipeline.ExporterIdentity;
+
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.riptide.flows.utils.BufferUtils.slice;
+
+/**
+ * What one UDP event-loop thread pays per NetFlow v9 datagram, for issue #450.
+ *
+ * <p>#450 asks whether UDP ingest is capped by reading on a single event loop. The premise there is
+ * that the thread "drains a socket into a handoff queue", which the code does not support: the
+ * handoff to the parser pool happens <em>after</em> the full decode. Everything this benchmark
+ * measures runs on {@code udp-listener-nio-<name>-0} before {@code ParserBase.transmit} enqueues
+ * anything, so {@code 1s / decodeAndBuildFlows} is the theoretical single-thread packet ceiling for
+ * this exporter's packet shape, with no kernel, no socket and no downstream in the way.
+ *
+ * <p><strong>Read it as an upper bound, not a prediction.</strong> The real loop additionally pays a
+ * {@code recvfrom} syscall, two {@code Meter} marks, the {@code CompletableFuture} plumbing and the
+ * enqueue, and it competes for cache with whatever else the JVM is doing. It also runs against many
+ * exporters rather than one warm session. If the measured ceiling is already close to the offered
+ * load, the single reader is a real constraint; if it is far above, #450's remedies (SO_REUSEPORT
+ * fan-out, moving decode off the read thread) are solving a problem that is not there.
+ *
+ * <h2>Why the work is reconstructed rather than called through the parser</h2>
+ *
+ * <p>{@code UdpParserBase.parse} cannot be measured directly: it ends in
+ * {@code ParserBase.transmit}, which hands off to the dispatch pool and returns a future, so timing
+ * it would measure the enqueue and not the decode. The sequence below mirrors
+ * {@code UdpParserBase.parse} (session lookup, transactional wrapper, decode) followed by the
+ * pre-handoff half of {@code ParserBase.transmit} (sequence verification, {@code buildFlows}), and
+ * stops where {@code enqueue} begins. <strong>If that path changes, this benchmark drifts</strong>,
+ * and the drift is silent.
+ *
+ * <h2>Steady state, not cold start</h2>
+ *
+ * <p>The template is installed once in {@link #setup()} and the benchmark decodes a data-only packet
+ * against a warm session. That is the steady state worth measuring: an exporter re-announces
+ * templates on the order of minutes and sends data continuously, so template handling is a rounding
+ * error in the mix. It also means the {@link TransactionalSession} undo stack stays empty here,
+ * which is representative but does understate the cost of a template-carrying packet.
+ *
+ * <h2>The buffer must be pooled and direct</h2>
+ *
+ * <p>{@code UdpListener} never sets {@link io.netty.channel.ChannelOption#ALLOCATOR}, so datagram
+ * content comes from {@link ByteBufAllocator#DEFAULT}: pooled, and direct on every platform we ship
+ * on. The handler retains exactly that buffer, so every {@code BufferUtils.slice}/{@code uint16}/
+ * {@code uint32} in the decode below reads through a direct {@code ByteBuf}. An earlier revision of
+ * this benchmark used {@code Unpooled.wrappedBuffer(byte[])} and measured the heap implementation
+ * instead, which understated {@code decodeOnly} by about 31% (12.0us against 15.8us) and so
+ * overstated the packets/s ceiling by about a quarter. Since the whole point of the number is to
+ * decide whether the single reader is a constraint, a bias in the direction that makes it look safer
+ * is the one bias that must not be there. Do not switch this back to a heap buffer.
+ *
+ * <p>Fixture is a Cisco ASR9k data packet: a representative carrier-router packet shape. Note it
+ * carries a single observation domain, so nothing here exercises the multi-domain template index or
+ * the per-domain resolver costs. Per-packet record count is printed by {@link #setup()} so the ns/op
+ * figure can be converted to records/s.
+ */
+@Fork(value = 1)
+@Warmup(iterations = 2)
+@Measurement(iterations = 5)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+// Scope.Thread, not Scope.Benchmark: the state below is mutable (the buffer's reader index, the
+// sequence counter) and sharing it across threads corrupts both. Since `make bench` advertises
+// arbitrary BENCH_OPTS, -t is a flag someone investigating a threading question will reach for, and
+// at Scope.Benchmark it produces interleaved garbage rather than a refusal.
+@State(Scope.Thread)
+public class Netflow9ReadThreadBenchmark {
+
+    private static final String FOLDER = "/flows/";
+
+    /** Matches {@code UdpParserBase}'s default, so housekeeping never expires the warm template. */
+    private static final Duration TEMPLATE_TIMEOUT = Duration.ofMinutes(30);
+
+    /** Matches {@code ParserBase}'s default patience. */
+    private static final int SEQUENCE_PATIENCE = 32;
+
+    private final ValueConversionService converter = new ValueConversionService(Netflow9RawFlow.class, List.of(
+            new StringVisitor(),
+            new BooleanVisitor(),
+            new DoubleVisitor(),
+            new DurationVisitor(),
+            new InetAddressVisitor(),
+            new InstantVisitor(),
+            new IntegerVisitor(),
+            new LongVisitor(),
+            new UnsignedLongVisitor()
+    ));
+
+    private final Netflow9FlowBuilder flowBuilder = new Netflow9FlowBuilder(converter);
+
+    private UdpSessionManager sessionManager;
+    private UdpSessionManager.SessionKey sessionKey;
+    private ByteBuf data;
+    private long sequenceNumber = 1;
+
+    @Setup
+    public void setup() throws Exception {
+        // The session key the listener would build from the datagram envelope: for NetFlow v9 the
+        // remote port is deliberately excluded (exporters hop source ports), so this is exactly
+        // what Netflow9UdpParser.buildSessionKey produces.
+        final InetAddress remote = InetAddress.getLoopbackAddress();
+        final InetSocketAddress local = new InetSocketAddress(InetAddress.getLoopbackAddress(), 9995);
+        this.sessionKey = new Netflow9UdpParser.HostSessionKey(remote, local);
+
+        this.sessionManager = new UdpSessionManager(TEMPLATE_TIMEOUT,
+                () -> new SequenceNumberTracker(SEQUENCE_PATIENCE));
+
+        // Install the template once, exactly as a template datagram would, so the measured packet
+        // decodes against a warm session.
+        final ByteBuf template = buffer("netflow9_test_cisco_asr9k_tpl260.dat");
+        try {
+            decode(template);
+        } finally {
+            template.release();
+        }
+
+        this.data = buffer("netflow9_test_cisco_asr9k_data260.dat");
+
+        // Read the size before decoding, which consumes the buffer.
+        final int bytes = this.data.readableBytes();
+        final int records = decode(this.data).size();
+
+        // Asserted, not just printed. If the template ever fails to install (a fixture swap, a
+        // changed template ID), Packet takes the MissingTemplateException branch, counts an
+        // undecodable set and skips it — and both benchmarks then measure the much cheaper
+        // skip-the-set path while still reporting a perfectly plausible ns/op. With -f 2 and JSON
+        // output the one line that would betray it scrolls past in stdout.
+        if (records == 0) {
+            throw new IllegalStateException(
+                    "Fixture decoded to zero records: template 260 is not installed, so this would "
+                            + "benchmark the undecodable-set path instead of the decode path");
+        }
+
+        System.out.printf("%n[setup] records/packet = %d, datagram bytes = %d%n", records, bytes);
+    }
+
+    @TearDown
+    public void tearDown() {
+        if (this.data != null) {
+            this.data.release();
+            this.data = null;
+        }
+    }
+
+    /**
+     * The decode half only: header framing, set walking, template resolution, record extraction.
+     * Isolated from {@link #decodeAndBuildFlows} so the per-packet cost can be attributed. If the
+     * cost is concentrated here, cheaper reads (recvmmsg) or more readers (SO_REUSEPORT) are the
+     * lever; if it is concentrated in the difference, moving flow construction off the read thread
+     * is.
+     */
+    @Benchmark
+    public void decodeOnly(final Blackhole blackhole) throws Exception {
+        // Rewound in the method rather than via @Setup(Level.Invocation): JMH documents that level
+        // as unreliable below ~1ms/op, and this op is ~20us. Both benchmarks pay it equally.
+        this.data.resetReaderIndex();
+
+        final TransactionalSession session = new TransactionalSession(this.sessionManager.getSession(this.sessionKey));
+
+        final Header header = new Header(slice(this.data, Header.SIZE));
+        final Packet packet = new Packet(session, header, this.data);
+
+        blackhole.consume(packet);
+    }
+
+    /**
+     * Everything the event loop does per datagram before the handoff. Mirrors
+     * {@code UdpParserBase.parse} plus the pre-{@code enqueue} half of {@code ParserBase.transmit}.
+     */
+    @Benchmark
+    public void decodeAndBuildFlows(final Blackhole blackhole) throws Exception {
+        this.data.resetReaderIndex();
+
+        final TransactionalSession session = new TransactionalSession(this.sessionManager.getSession(this.sessionKey));
+
+        final Header header = new Header(slice(this.data, Header.SIZE));
+        final Packet packet = new Packet(session, header, this.data);
+
+        final ExporterIdentity exporter =
+                new ExporterIdentity.NetflowIpfix(session.getRemoteAddress(), header.sourceId);
+
+        // NetFlow v9 counts export packets, so the increment is 1 (see FlowPacket.getSequenceIncrement).
+        blackhole.consume(session.verifySequenceNumber(exporter, this.sequenceNumber++, 1));
+
+        // .toList() is not incidental: ParserBase.transmit materialises the stream on this thread,
+        // so the flow objects are constructed here and not in the pool.
+        final List<Flow> flows = this.flowBuilder.buildFlows(Instant.EPOCH, packet, exporter).toList();
+
+        blackhole.consume(flows);
+    }
+
+    /** Decode a whole datagram against the shared session, returning the flows it carried. */
+    private List<Flow> decode(final ByteBuf buffer) throws Exception {
+        buffer.resetReaderIndex();
+
+        final Session session = new TransactionalSession(this.sessionManager.getSession(this.sessionKey));
+        final Header header = new Header(slice(buffer, Header.SIZE));
+        final Packet packet = new Packet(session, header, buffer);
+
+        return this.flowBuilder.buildFlows(Instant.EPOCH, packet,
+                new ExporterIdentity.NetflowIpfix(session.getRemoteAddress(), header.sourceId)).toList();
+    }
+
+    /**
+     * The fixture in a pooled direct buffer, matching what the event loop hands the parser.
+     *
+     * <p>Loaded from the classpath rather than a cwd-relative path so the JMH main can be run from
+     * anywhere, as the sibling IPFIX benchmarks already do.
+     */
+    private static ByteBuf buffer(final String fixture) throws Exception {
+        try (InputStream in = Netflow9ReadThreadBenchmark.class.getResourceAsStream(FOLDER + fixture)) {
+            if (in == null) {
+                throw new IllegalStateException("Fixture not on the classpath: " + FOLDER + fixture);
+            }
+            final byte[] bytes = in.readAllBytes();
+            final ByteBuf buffer = ByteBufAllocator.DEFAULT.directBuffer(bytes.length);
+            buffer.writeBytes(bytes);
+            return buffer;
+        }
+    }
+}


### PR DESCRIPTION
Refs #450. Adds the measurement that issue asked for, plus a `make bench` target so the number can be re-derived rather than taken on trust.

Does not close #450: the benchmark answers the capacity question, but the loop sizing and the housekeeping/scheduler entanglement are still open there. See the [design note](https://github.com/Riptide-Labs/riptide/issues/450#issuecomment-5209095059) and the [results](https://github.com/Riptide-Labs/riptide/issues/450#issuecomment-5209271496) with its [correction](https://github.com/Riptide-Labs/riptide/issues/450#issuecomment-5209560005).

## Why

#450 asks whether UDP ingest is capped by reading on a single event loop, on the premise that the thread "drains a socket into a handoff queue". The code does not support that premise: `ParserBase.transmit` hands off only after the full decode, so the read thread also owns the session lookup, the protocol decode, and the construction of every `Flow` in the packet. That makes the question worth measuring rather than reasoning about.

## What it measures

`Netflow9ReadThreadBenchmark` mirrors `UdpParserBase.parse` plus the pre-`enqueue` half of `ParserBase.transmit`, and stops where the handoff begins. `UdpParserBase.parse` cannot be timed directly because it ends in an enqueue and returns a future, so the sequence is reconstructed. That means the benchmark drifts silently if the parse path changes, which the class javadoc says explicitly.

Two benchmarks so the cost can be attributed: `decodeOnly` (header framing, set walking, template resolution, record extraction) and `decodeAndBuildFlows` (everything the event loop does per datagram).

## Result

10-core host, Cisco ASR9k fixture, 21 records in a 1392-byte datagram, 2 forks x 10 iterations:

```
Benchmark                                        Mode  Cnt      Score     Error  Units
Netflow9ReadThreadBenchmark.decodeAndBuildFlows  avgt   20  27707,471 ± 248,574  ns/op
Netflow9ReadThreadBenchmark.decodeOnly           avgt   20  14160,890 ± 285,670  ns/op
```

36,091 packets/s and ~758,000 records/s on one thread: roughly 64x the 11,840 rows/s the batching work measured end to end, and 12x the older ~61k rows/s ceiling quoted in `ParserBase`. Read it as an upper bound (no syscall, one warm exporter, no cache competition), but the headroom says the single reader is not the constraint at any load this collector has demonstrated.

The split also shows `buildFlows` is ~49% of the cost and touches no `Session` at all, so that half could move to the existing pool without the per-exporter affinity a full decode offload would require.

## The one thing worth reviewing carefully

The fixture is decoded from a **pooled direct** buffer, deliberately. `UdpListener` never sets `ChannelOption.ALLOCATOR`, so datagram content comes from `ByteBufAllocator.DEFAULT` and the handler retains exactly that buffer. An earlier revision used `Unpooled.wrappedBuffer(byte[])` and measured the heap implementation, which understated `decodeOnly` by ~31% and overstated the packets/s ceiling by ~23%. The bias pointed towards making the single reader look safer than it is, which is the one direction that could have produced a wrong call on #450. The javadoc carries a do-not-revert note.

Caught in review, along with a constant sequence number that re-marked one `SequenceNumberTracker` ring slot on every op (measuring the duplicate path instead of the steady-state advance).

## Robustness

- `setup()` fails hard on a zero record count. An uninstalled template sends `Packet` down the `MissingTemplateException` branch, which skips the whole set, and both benchmarks would then measure the cheap skip path at a perfectly plausible ns/op.
- `@State(Scope.Thread)`, since the reader index and sequence counter are mutable and `make bench` advertises arbitrary JMH flags. At `Scope.Benchmark`, `-t 4` produced interleaved garbage rather than a refusal.
- Fixtures load from the classpath, like the sibling IPFIX benchmarks, so the run does not depend on the working directory.

## The make target

`bench` is opt-in and never a build gate: a run takes minutes and the numbers are meaningless on a loaded machine. `BENCH_TARGET` narrows by regex, `BENCH_OPTS` overrides the per-class JMH annotations.

## Verification

- `mvn verify` green: 992 tests, SpotBugs 0 bugs, coverage checks met.
- `make bench BENCH_TARGET=Netflow9ReadThreadBenchmark` produces the numbers above.
- `-t 4` verified clean after the `Scope.Thread` change (previously `Invalid version number: 0x0104`, `Invalid template ID: 0`).
- Classpath loading verified by running the JMH main from `/tmp`.

Environment caveat for anyone re-running: the host was loaded during this work. One intermediate run returned `44760 ± 45386 ns/op` (error exceeding the score) at load average 12.9 and was discarded. Check `uptime` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
