### PR TITLE
fix(daemon): report receivers when they bind and name the one that fails

### DIFF
--- a/src/main/java/org/riptide/flows/Daemon.java
+++ b/src/main/java/org/riptide/flows/Daemon.java
@@ -198,14 +198,39 @@ public class Daemon implements ApplicationRunner {
                     }
                 })).toList();
 
-        log.info("Listening for flows with {} receivers \\o/", this.listeners.size());
     }
 
+    // Start-time logging lives here rather than in each Listener: only the call site holds the
+    // receiver's name *and* can observe its failure — a listener that throws from start() cannot
+    // log its own. A future Listener should not add its own bind line and duplicate this.
+    //
+    // These lines necessarily follow Spring's "Started RiptideApplication", which is logged before
+    // callRunners(). That reads oddly but is honest; the alternative is binding during context
+    // refresh via SmartLifecycle, which would move isStarted() and the health semantics with it.
+    // Do NOT "fix" the ordering by moving the summary back into the constructor — that was #453,
+    // where it claimed to be listening before anything was bound.
     @Override
     public void run(final ApplicationArguments args) throws Exception {
         this.pipeline.start();
-        this.listeners.forEach(Listener::start);
+
+        for (final var listener : this.listeners) {
+            try {
+                listener.start();
+            } catch (final Exception e) {
+                // Named here because the propagating stack identifies the transport but neither the
+                // configured receiver nor its port. Message only: Spring prints the full trace as
+                // the exception leaves run(), and a second copy is noise at the moment the operator
+                // is trying to read. Rethrown rather than skipped — /readyz checks every listener,
+                // so continuing would yield a running-but-never-ready daemon.
+                log.error("Receiver '{}' failed to start on {}: {}",
+                        listener.getName(), listener.getDescription(), e.getMessage());
+                throw e;
+            }
+            log.info("Receiver '{}' listening on {}", listener.getName(), listener.getDescription());
+        }
+
         this.started = true;
+        log.info("Listening for flows with {} receivers \\o/", this.listeners.size());
     }
 
     @PreDestroy

--- a/src/main/java/org/riptide/flows/Daemon.java
+++ b/src/main/java/org/riptide/flows/Daemon.java
@@ -201,13 +201,13 @@ public class Daemon implements ApplicationRunner {
     }
 
     // Start-time logging lives here rather than in each Listener: only the call site holds the
-    // receiver's name *and* can observe its failure — a listener that throws from start() cannot
+    // receiver's name *and* can observe its failure: a listener that throws from start() cannot
     // log its own. A future Listener should not add its own bind line and duplicate this.
     //
     // These lines necessarily follow Spring's "Started RiptideApplication", which is logged before
     // callRunners(). That reads oddly but is honest; the alternative is binding during context
     // refresh via SmartLifecycle, which would move isStarted() and the health semantics with it.
-    // Do NOT "fix" the ordering by moving the summary back into the constructor — that was #453,
+    // Do NOT "fix" the ordering by moving the summary back into the constructor: that was #453,
     // where it claimed to be listening before anything was bound.
     @Override
     public void run(final ApplicationArguments args) throws Exception {
@@ -220,10 +220,11 @@ public class Daemon implements ApplicationRunner {
                 // Named here because the propagating stack identifies the transport but neither the
                 // configured receiver nor its port. Message only: Spring prints the full trace as
                 // the exception leaves run(), and a second copy is noise at the moment the operator
-                // is trying to read. Rethrown rather than skipped — /readyz checks every listener,
+                // is trying to read. Rethrown rather than skipped: /readyz checks every listener,
                 // so continuing would yield a running-but-never-ready daemon.
+                final var reason = e.getMessage() != null ? e.getMessage() : e.getClass().getName();
                 log.error("Receiver '{}' failed to start on {}: {}",
-                        listener.getName(), listener.getDescription(), e.getMessage());
+                        listener.getName(), listener.getDescription(), reason);
                 throw e;
             }
             log.info("Receiver '{}' listening on {}", listener.getName(), listener.getDescription());

--- a/src/main/java/org/riptide/flows/Daemon.java
+++ b/src/main/java/org/riptide/flows/Daemon.java
@@ -197,7 +197,6 @@ public class Daemon implements ApplicationRunner {
                                 .withHost(config.getHost());
                     }
                 })).toList();
-
     }
 
     // Start-time logging lives here rather than in each Listener: only the call site holds the
@@ -216,16 +215,22 @@ public class Daemon implements ApplicationRunner {
         for (final var listener : this.listeners) {
             try {
                 listener.start();
-            } catch (final Exception e) {
+            } catch (final Throwable t) {
                 // Named here because the propagating stack identifies the transport but neither the
                 // configured receiver nor its port. Message only: Spring prints the full trace as
                 // the exception leaves run(), and a second copy is noise at the moment the operator
                 // is trying to read. Rethrown rather than skipped: /readyz checks every listener,
                 // so continuing would yield a running-but-never-ready daemon.
-                final var reason = e.getMessage() != null ? e.getMessage() : e.getClass().getName();
+                //
+                // Throwable, not Exception: a missing native transport surfaces as
+                // NoClassDefFoundError and starting the event loop threads can raise
+                // OutOfMemoryError. Narrowing to Exception would let exactly those aborts through
+                // with the unattributed stack this logging exists to replace. Rethrown immediately,
+                // so nothing is swallowed — precise rethrow keeps the declared type unchanged.
+                final var reason = t.getMessage() != null ? t.getMessage() : t.getClass().getName();
                 log.error("Receiver '{}' failed to start on {}: {}",
                         listener.getName(), listener.getDescription(), reason);
-                throw e;
+                throw t;
             }
             log.info("Receiver '{}' listening on {}", listener.getName(), listener.getDescription());
         }

--- a/src/main/java/org/riptide/flows/Daemon.java
+++ b/src/main/java/org/riptide/flows/Daemon.java
@@ -246,17 +246,30 @@ public class Daemon implements ApplicationRunner {
         // dispatches, so the pipeline's shutdown drain below sees every accepted flow. A
         // failing listener must not keep the pipeline (and its batch drain) from stopping —
         // the flusher is a daemon thread, so a skipped drain silently loses the whole buffer.
-        // Exception, not RuntimeException: Listener.stop() declares no checked exceptions, but
-        // the Netty listeners call syncUninterruptibly(), which sneaky-throws the future's
-        // cause — checked exceptions included. Do not "tidy" this back to RuntimeException.
-        for (final var listener : this.listeners) {
-            try {
-                listener.stop();
-            } catch (final Exception e) {
-                log.warn("Failed to stop listener {}", listener.getName(), e);
+        // Throwable, not Exception and emphatically not RuntimeException. Listener.stop() declares
+        // no checked exceptions, but the Netty listeners call syncUninterruptibly(), which
+        // sneaky-throws the future's cause — checked exceptions included. Do not "tidy" this back
+        // to RuntimeException.
+        //
+        // Throwable widens it further so the promise above actually holds: an Error (a listener's
+        // event loop dying with OutOfMemoryError, a missing native transport surfacing as
+        // NoClassDefFoundError) used to escape this loop, skipping every later listener *and* the
+        // pipeline drain below — silently losing the whole batch buffer, which is the one outcome
+        // this method exists to prevent. Shutdown is best-effort per listener for the same reason
+        // teardown is best-effort per resource inside them (see Teardown).
+        try {
+            for (final var listener : this.listeners) {
+                try {
+                    listener.stop();
+                } catch (final Throwable t) {
+                    log.warn("Failed to stop listener {}", listener.getName(), t);
+                }
             }
+        } finally {
+            // In a finally so the drain survives anything the loop itself could throw, not merely
+            // anything stop() throws.
+            this.pipeline.stop();
         }
-        this.pipeline.stop();
     }
 
     /** The configured receivers, for health reporting. */

--- a/src/main/java/org/riptide/flows/Daemon.java
+++ b/src/main/java/org/riptide/flows/Daemon.java
@@ -227,7 +227,15 @@ public class Daemon implements ApplicationRunner {
                 // OutOfMemoryError. Narrowing to Exception would let exactly those aborts through
                 // with the unattributed stack this logging exists to replace. Rethrown immediately,
                 // so nothing is swallowed — precise rethrow keeps the declared type unchanged.
-                final var reason = t.getMessage() != null ? t.getMessage() : t.getClass().getName();
+                // Type as well as message: a NoClassDefFoundError — one of the two cases the
+                // Throwable catch exists for — carries a message like "io/netty/.../Epoll" that
+                // reads as a config problem unless the type is shown. Blank counts as absent:
+                // several construction paths carry an empty message, which would otherwise print
+                // as a bare trailing colon and lose the cause entirely.
+                final var message = t.getMessage();
+                final var reason = message != null && !message.isBlank()
+                        ? t.getClass().getSimpleName() + ": " + message
+                        : t.getClass().getName();
                 log.error("Receiver '{}' failed to start on {}: {}",
                         listener.getName(), listener.getDescription(), reason);
                 throw t;

--- a/src/main/java/org/riptide/flows/listeners/Listener.java
+++ b/src/main/java/org/riptide/flows/listeners/Listener.java
@@ -16,7 +16,23 @@ import org.riptide.flows.parser.Parser;
  */
 public interface Listener {
     String getName();
+
+    /**
+     * Where this listener listens, for the startup log and diagnostics — for example
+     * {@code UDP 0.0.0.0:9999}.
+     *
+     * <p>Must report the port actually bound once started, not the configured one: {@code port: 0}
+     * asks the kernel to choose, and echoing back {@code 0} tells an operator nothing about where
+     * the socket is. Must stop reporting it once the listener is no longer active, so a stopped
+     * listener does not name a port another process may since have taken.
+     *
+     * <p>The host is reported as configured rather than read back from the channel — a wildcard
+     * bind reads back as {@code 0:0:0:0:0:0:0:0} on a dual-stack JVM and a hostname as its resolved
+     * literal, neither of which is what the operator wrote or can grep for. {@link ListenerAddress}
+     * implements this split; implementations should use it rather than repeat the rules.
+     */
     String getDescription();
+
     void start();
 
     /**

--- a/src/main/java/org/riptide/flows/listeners/ListenerAddress.java
+++ b/src/main/java/org/riptide/flows/listeners/ListenerAddress.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.listeners;
+
+import io.netty.channel.ChannelFuture;
+
+import java.net.InetSocketAddress;
+
+/**
+ * Renders where a listener listens, for the startup log and diagnostics.
+ *
+ * <p>Host from configuration, port from the socket. Those are the halves each source answers best:
+ * the operator wrote the host and can grep for it, while the port is the half the kernel may choose
+ * — {@code port: 0} means the configured value says nothing about where the socket actually is.
+ *
+ * <p>Reading the host back off the channel instead looks more truthful and reads far worse. A
+ * wildcard bind reports {@code 0:0:0:0:0:0:0:0} on a dual-stack JVM rather than the {@code *} the
+ * operator configured, and a configured hostname comes back as its resolved literal, so the log no
+ * longer contains the string that is in the config file.
+ *
+ * <p>IPv6 hosts are bracketed, so address and port stay distinguishable: an unbracketed
+ * {@code ::1:4739} leaves the reader counting colons.
+ */
+final class ListenerAddress {
+
+    private ListenerAddress() {
+    }
+
+    /**
+     * @param socketFuture the bind future, or {@code null} before {@code start()}; the bound port is
+     *                     used only while its channel is active, so a stopped listener stops
+     *                     claiming a port another process may since have taken — the same
+     *                     misattribution {@code UdpListener.stop()} avoids by deregistering its
+     *                     {@code socketDrops} gauge before releasing the socket
+     * @param host         the configured host, or {@code null} for a wildcard bind
+     * @param port         the configured port, reported when nothing is bound
+     */
+    static String describe(final ChannelFuture socketFuture, final String host, final int port) {
+        int effectivePort = port;
+        if (socketFuture != null
+                && socketFuture.channel().isActive()
+                && socketFuture.channel().localAddress() instanceof InetSocketAddress bound) {
+            effectivePort = bound.getPort();
+        }
+        final var rendered = host != null ? host : "*";
+        return (rendered.indexOf(':') >= 0 ? "[" + rendered + "]" : rendered) + ":" + effectivePort;
+    }
+}

--- a/src/main/java/org/riptide/flows/listeners/TcpListener.java
+++ b/src/main/java/org/riptide/flows/listeners/TcpListener.java
@@ -221,24 +221,7 @@ public class TcpListener implements Listener {
 
     @Override
     public String getDescription() {
-        return "TCP " + boundOrConfiguredAddress();
-    }
-
-    /**
-     * The address actually bound once started, the configured one before that.
-     *
-     * <p>They differ whenever the kernel chooses: {@code port: 0} configures an ephemeral port, and
-     * reporting the literal {@code 0} tells an operator nothing about where the socket is.
-     *
-     * <p>{@code socketFuture} is assigned only after {@code bind()} returns, so a listener that
-     * failed to bind still reports its configured address — which is the one that has to be fixed.
-     */
-    private String boundOrConfiguredAddress() {
-        if (this.socketFuture != null
-                && this.socketFuture.channel().localAddress() instanceof InetSocketAddress bound) {
-            return bound.getHostString() + ":" + bound.getPort();
-        }
-        return (this.host != null ? this.host : "*") + ":" + this.port;
+        return "TCP " + ListenerAddress.describe(this.socketFuture, this.host, this.port);
     }
 
     @Override

--- a/src/main/java/org/riptide/flows/listeners/TcpListener.java
+++ b/src/main/java/org/riptide/flows/listeners/TcpListener.java
@@ -221,7 +221,24 @@ public class TcpListener implements Listener {
 
     @Override
     public String getDescription() {
-        return String.format("TCP %s:%s",  this.host != null ? this.host : "*", this.port);
+        return "TCP " + boundOrConfiguredAddress();
+    }
+
+    /**
+     * The address actually bound once started, the configured one before that.
+     *
+     * <p>They differ whenever the kernel chooses: {@code port: 0} configures an ephemeral port, and
+     * reporting the literal {@code 0} tells an operator nothing about where the socket is.
+     *
+     * <p>{@code socketFuture} is assigned only after {@code bind()} returns, so a listener that
+     * failed to bind still reports its configured address — which is the one that has to be fixed.
+     */
+    private String boundOrConfiguredAddress() {
+        if (this.socketFuture != null
+                && this.socketFuture.channel().localAddress() instanceof InetSocketAddress bound) {
+            return bound.getHostString() + ":" + bound.getPort();
+        }
+        return (this.host != null ? this.host : "*") + ":" + this.port;
     }
 
     @Override

--- a/src/main/java/org/riptide/flows/listeners/Teardown.java
+++ b/src/main/java/org/riptide/flows/listeners/Teardown.java
@@ -19,8 +19,9 @@ import java.util.List;
  * <p>Steps run in the order given; several teardown orderings are load-bearing (a UDP listener must
  * deregister its {@code socketDrops} gauge before releasing the port it describes). Failures are
  * collected and rethrown by {@link #done()}: the first as-is, the rest suppressed onto it. Keeping
- * the first exception rather than wrapping matters because {@code Daemon.stop()} catches
- * {@code Exception} specifically to receive Netty's sneaky-thrown cause intact.
+ * the first throwable rather than wrapping matters because the caller diagnoses from it —
+ * {@code Daemon.stop()} logs it against the listener's name — and wrapping would bury Netty's
+ * sneaky-thrown cause under a synthesised type.
  */
 final class Teardown {
 
@@ -55,9 +56,12 @@ final class Teardown {
         throw sneakyThrow(first);
     }
 
-    // Preserves the original throwable's type instead of wrapping it: Daemon.stop() catches
-    // Exception (not RuntimeException) precisely so Netty's sneaky-thrown checked causes reach it
-    // unaltered, and wrapping here would defeat that.
+    // Preserves the original throwable's type instead of wrapping it, so what the caller logs is
+    // the real cause — including the checked exceptions Netty sneaky-throws out of
+    // syncUninterruptibly(), which a wrapper would bury. Callers must catch Throwable to receive
+    // it: an Error is a legitimate outcome here, and Daemon.stop() catches Throwable for exactly
+    // that reason. Narrowing a caller back to Exception reintroduces the bug where one listener's
+    // Error skips every listener after it.
     @SuppressWarnings("unchecked")
     private static <T extends Throwable> RuntimeException sneakyThrow(final Throwable t) throws T {
         throw (T) t;

--- a/src/main/java/org/riptide/flows/listeners/UdpListener.java
+++ b/src/main/java/org/riptide/flows/listeners/UdpListener.java
@@ -184,7 +184,25 @@ public class UdpListener implements Listener {
 
     @Override
     public String getDescription() {
-        return String.format("UDP %s:%s", this.host != null ? this.host : "*", this.port);
+        return "UDP " + boundOrConfiguredAddress();
+    }
+
+    /**
+     * The address actually bound once started, the configured one before that.
+     *
+     * <p>They differ whenever the kernel chooses: {@code port: 0} configures an ephemeral port, and
+     * reporting the literal {@code 0} tells an operator nothing about where the socket is. Read
+     * from the channel for the same reason {@link #registerSocketDrops()} does.
+     *
+     * <p>{@code socketFuture} is assigned only after {@code bind()} returns, so a listener that
+     * failed to bind still reports its configured address — which is the one that has to be fixed.
+     */
+    private String boundOrConfiguredAddress() {
+        if (this.socketFuture != null
+                && this.socketFuture.channel().localAddress() instanceof InetSocketAddress bound) {
+            return bound.getHostString() + ":" + bound.getPort();
+        }
+        return (this.host != null ? this.host : "*") + ":" + this.port;
     }
 
     private class DefaultChannelInitializer extends ChannelInitializer<DatagramChannel> {

--- a/src/main/java/org/riptide/flows/listeners/UdpListener.java
+++ b/src/main/java/org/riptide/flows/listeners/UdpListener.java
@@ -184,25 +184,7 @@ public class UdpListener implements Listener {
 
     @Override
     public String getDescription() {
-        return "UDP " + boundOrConfiguredAddress();
-    }
-
-    /**
-     * The address actually bound once started, the configured one before that.
-     *
-     * <p>They differ whenever the kernel chooses: {@code port: 0} configures an ephemeral port, and
-     * reporting the literal {@code 0} tells an operator nothing about where the socket is. Read
-     * from the channel for the same reason {@link #registerSocketDrops()} does.
-     *
-     * <p>{@code socketFuture} is assigned only after {@code bind()} returns, so a listener that
-     * failed to bind still reports its configured address — which is the one that has to be fixed.
-     */
-    private String boundOrConfiguredAddress() {
-        if (this.socketFuture != null
-                && this.socketFuture.channel().localAddress() instanceof InetSocketAddress bound) {
-            return bound.getHostString() + ":" + bound.getPort();
-        }
-        return (this.host != null ? this.host : "*") + ":" + this.port;
+        return "UDP " + ListenerAddress.describe(this.socketFuture, this.host, this.port);
     }
 
     private class DefaultChannelInitializer extends ChannelInitializer<DatagramChannel> {

--- a/src/test/java/org/riptide/flows/DaemonStartupLoggingTest.java
+++ b/src/test/java/org/riptide/flows/DaemonStartupLoggingTest.java
@@ -49,10 +49,17 @@ class DaemonStartupLoggingTest {
 
     private Logger logger;
     private ListAppender<ILoggingEvent> appender;
+    private Level originalLevel;
 
     @BeforeEach
     void captureDaemonLog() {
         this.logger = (Logger) LoggerFactory.getLogger(Daemon.class);
+        this.originalLevel = this.logger.getLevel();
+        // Pinned, not inherited: two of the assertions below are negative (no "Listening for flows"),
+        // and if ambient test logging were ever raised above INFO they would pass vacuously — the
+        // events would simply never be captured. The capture must not depend on configuration this
+        // test does not own.
+        this.logger.setLevel(Level.INFO);
         this.appender = new ListAppender<>();
         this.appender.start();
         this.logger.addAppender(this.appender);
@@ -62,6 +69,7 @@ class DaemonStartupLoggingTest {
     void releaseDaemonLog() {
         this.logger.detachAppender(this.appender);
         this.appender.stop();
+        this.logger.setLevel(this.originalLevel);
     }
 
     @Test

--- a/src/test/java/org/riptide/flows/DaemonStartupLoggingTest.java
+++ b/src/test/java/org/riptide/flows/DaemonStartupLoggingTest.java
@@ -122,10 +122,13 @@ class DaemonStartupLoggingTest {
 
     @Test
     void aReceiverThatCannotBindIsNamedWithItsAddress() throws Exception {
-        // reuseAddress(false) so the conflict is real: Java enables SO_REUSEADDR on ServerSocket by
-        // default on some platforms, which lets a second bind succeed and the test silently pass.
+        // The conflict comes from the socket being live and listening: on Linux and macOS a second
+        // bind to the same address and port fails with EADDRINUSE regardless of SO_REUSEADDR, which
+        // only relaxes TIME_WAIT — sharing a live listener needs SO_REUSEPORT, which neither side
+        // sets. Note TcpListener hard-codes SO_REUSEADDR on its own bootstrap, so nothing set here
+        // would gate it anyway. (On Windows, SO_REUSEADDR does permit hijacking a live socket, so
+        // this test assumes POSIX semantics — as does CI.)
         try (var occupied = new ServerSocket()) {
-            occupied.setReuseAddress(false);
             occupied.bind(new java.net.InetSocketAddress(InetAddress.getByName("127.0.0.1"), 0));
             final int taken = occupied.getLocalPort();
 
@@ -210,15 +213,26 @@ class DaemonStartupLoggingTest {
         // Polled: shutdownGracefully().syncUninterruptibly() returns when the termination future
         // completes, which SingleThreadEventExecutor does from inside the event loop thread's own
         // finally block, so the thread is briefly still alive afterwards.
+        // Sleeping rather than spinning: getAllStackTraces() walks every thread behind a safepoint,
+        // so a tight loop would pin a core and hammer safepoints for the whole deadline on exactly
+        // the run where the assertion is about to fail and the output matters most.
         final long deadline = System.nanoTime() + java.util.concurrent.TimeUnit.SECONDS.toNanos(10);
         List<String> alive;
-        do {
+        while (true) {
             alive = Thread.getAllStackTraces().keySet().stream()
                     .map(Thread::getName)
                     .filter(name -> name.startsWith(prefix))
                     .toList();
-        } while (!alive.isEmpty() && System.nanoTime() < deadline);
-        return alive;
+            if (alive.isEmpty() || System.nanoTime() >= deadline) {
+                return alive;
+            }
+            try {
+                Thread.sleep(10);
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return alive;
+            }
+        }
     }
 
     private Daemon daemon(final Map<String, Object> properties) {

--- a/src/test/java/org/riptide/flows/DaemonStartupLoggingTest.java
+++ b/src/test/java/org/riptide/flows/DaemonStartupLoggingTest.java
@@ -116,16 +116,22 @@ class DaemonStartupLoggingTest {
                         assertThat(Integer.parseInt(matcher.group(1))).isPositive();
                     });
 
-            final var summaryIndex = indexOfMessageContaining("Listening for flows");
-            final var lastReceiverIndex = Math.max(
-                    indexOfMessageContaining("Receiver 'nf5'"),
-                    indexOfMessageContaining("Receiver 'nf9'"));
-            assertThat(summaryIndex)
-                    .as("the summary marks the point every receiver is bound, so it comes last")
-                    .isGreaterThan(lastReceiverIndex);
+            final var summaryIndex = lastIndexOfMessageContaining("Listening for flows");
+            // Presence first: with the ordering assertion first, a regression that removed the
+            // summary entirely reported -1 as an ordering failure and the presence assertion below
+            // was unreachable.
             assertThat(summaryIndex)
                     .as("the summary log message must be present")
                     .isGreaterThanOrEqualTo(0);
+            // Last, not first: each receiver logs once today, so the two coincide — but a second
+            // matching line (a retry, or a mixed success/failure run) would let this pass while the
+            // summary actually preceded a receiver line, which is the invariant being pinned.
+            final var lastReceiverIndex = Math.max(
+                    lastIndexOfMessageContaining("Receiver 'nf5'"),
+                    lastIndexOfMessageContaining("Receiver 'nf9'"));
+            assertThat(summaryIndex)
+                    .as("the summary marks the point every receiver is bound, so it comes last")
+                    .isGreaterThan(lastReceiverIndex);
             assertThat(messages().get(summaryIndex))
                     .as("its count must match the receivers reported")
                     .contains("2 receivers");
@@ -153,9 +159,20 @@ class DaemonStartupLoggingTest {
                     "riptide.receivers.ipfixtcp.port", String.valueOf(taken)));
 
             try {
+                // BindException specifically: isInstanceOf(Exception.class) would also pass if the
+                // daemon's own error-logging path threw, so it could not tell "aborted for the
+                // reason under test" from "aborted for an unrelated reason".
                 assertThatThrownBy(() -> daemon.run(new DefaultApplicationArguments()))
                         .as("a receiver that cannot bind must still abort startup")
-                        .isInstanceOf(Exception.class);
+                        .isInstanceOfSatisfying(Throwable.class, thrown -> {
+                            var cause = thrown;
+                            while (cause != null && !(cause instanceof java.net.BindException)) {
+                                cause = cause.getCause();
+                            }
+                            assertThat(cause)
+                                    .as("a BindException must be in the causal chain of %s", thrown)
+                                    .isNotNull();
+                        });
 
                 assertThat(events())
                         .as("the failing receiver is named, with its address: a stack alone is not")
@@ -169,6 +186,119 @@ class DaemonStartupLoggingTest {
 
                 assertThat(messages())
                         .as("a failed start must not be summarised as listening")
+                        .noneSatisfy(m -> assertThat(m).contains("Listening for flows"));
+            } finally {
+                daemon.stop();
+            }
+        }
+    }
+
+    /**
+     * The default configuration omits {@code host} — {@code ReceiverConfig.host} has no default, so
+     * the listener binds the wildcard. Reading the host back off the channel renders that as
+     * {@code 0:0:0:0:0:0:0:0} on a dual-stack JVM, which is materially worse than the {@code *} it
+     * replaced in the very line this logging exists to provide. Every other test here pins
+     * {@code 127.0.0.1}, the one value for which both renderings agree, which is exactly why that
+     * regression was invisible.
+     */
+    @Test
+    void aWildcardBindIsReportedReadablyWithItsResolvedPort() throws Exception {
+        final var daemon = daemon(Map.of(
+                "riptide.receivers.wildcard.type", "netflow5",
+                "riptide.receivers.wildcard.port", "0"));
+
+        try {
+            daemon.run(new DefaultApplicationArguments());
+
+            assertThat(messages())
+                    .as("a wildcard bind stays readable and still resolves its ephemeral port")
+                    .anySatisfy(m -> {
+                        assertThat(m).contains("Receiver 'wildcard' listening on UDP *:");
+                        assertThat(m).doesNotContain("0:0:0:0");
+                        final var matcher = java.util.regex.Pattern
+                                .compile("listening on UDP \\*:(\\d+)").matcher(m);
+                        assertThat(matcher.find()).as("parseable in %s", m).isTrue();
+                        assertThat(Integer.parseInt(matcher.group(1))).isPositive();
+                    });
+        } finally {
+            daemon.stop();
+        }
+    }
+
+    /**
+     * The TCP rendering path had no coverage: the only TCP receiver elsewhere in this class fails to
+     * bind, so it takes the not-yet-bound fallback and the success branch could have been broken
+     * while every test stayed green.
+     */
+    @Test
+    void aTcpReceiverReportsItsResolvedPort() throws Exception {
+        final var daemon = daemon(Map.of(
+                "riptide.receivers.tcpok.type", "ipfix",
+                "riptide.receivers.tcpok.transport", "TCP",
+                "riptide.receivers.tcpok.host", "127.0.0.1",
+                "riptide.receivers.tcpok.port", "0"));
+
+        try {
+            daemon.run(new DefaultApplicationArguments());
+
+            assertThat(messages())
+                    .as("the TCP success branch reports a real bound port")
+                    .anySatisfy(m -> {
+                        assertThat(m).contains("Receiver 'tcpok' listening on TCP 127.0.0.1:");
+                        assertThat(m).doesNotContain(":0");
+                    });
+        } finally {
+            daemon.stop();
+        }
+    }
+
+    /**
+     * The spec scenario "receivers that bound before the failure are still reported" — the log shape
+     * the change exists to fix was one that narrated the receiver which worked and stayed silent
+     * about the one that did not.
+     */
+    @Test
+    void aSuccessfulAndAFailingReceiverAreBothDistinguishableInTheLog() throws Exception {
+        try (var occupied = new ServerSocket()) {
+            occupied.bind(new java.net.InetSocketAddress(InetAddress.getByName("127.0.0.1"), 0));
+            final int taken = occupied.getLocalPort();
+
+            final var daemon = daemon(Map.of(
+                    "riptide.receivers.aaa-ok.type", "netflow5",
+                    "riptide.receivers.aaa-ok.host", "127.0.0.1",
+                    "riptide.receivers.aaa-ok.port", "0",
+                    "riptide.receivers.zzz-clash.type", "ipfix",
+                    "riptide.receivers.zzz-clash.transport", "TCP",
+                    "riptide.receivers.zzz-clash.host", "127.0.0.1",
+                    "riptide.receivers.zzz-clash.port", String.valueOf(taken)));
+
+            try {
+                // Receiver start order follows HashMap iteration, so which one runs first is not
+                // guaranteed. Assert only what must hold either way: if the good one ran, it is
+                // reported as listening; the failing one is always reported as failed; and no
+                // summary is emitted.
+                assertThatThrownBy(() -> daemon.run(new DefaultApplicationArguments()))
+                        .as("one receiver failing still aborts startup")
+                        .isInstanceOf(Throwable.class);
+
+                assertThat(events())
+                        .as("the failing receiver is named as failed, distinguishably")
+                        .anySatisfy(event -> {
+                            assertThat(event.getLevel()).isEqualTo(Level.ERROR);
+                            assertThat(event.getFormattedMessage())
+                                    .contains("Receiver 'zzz-clash'")
+                                    .contains("failed to start")
+                                    .contains(String.valueOf(taken));
+                        });
+
+                assertThat(messages())
+                        .as("no receiver is both reported listening and reported failed")
+                        .noneSatisfy(m -> assertThat(m)
+                                .contains("Receiver 'zzz-clash'")
+                                .contains("listening on"));
+
+                assertThat(messages())
+                        .as("a partially started daemon must not be summarised as listening")
                         .noneSatisfy(m -> assertThat(m).contains("Listening for flows"));
             } finally {
                 daemon.stop();
@@ -209,7 +339,15 @@ class DaemonStartupLoggingTest {
                 "riptide.receivers.second.host", "127.0.0.1",
                 "riptide.receivers.second.port", "0"), pipeline, registry);
 
-        daemon.run(new DefaultApplicationArguments());
+        try {
+            daemon.run(new DefaultApplicationArguments());
+        } catch (final Throwable startFailed) {
+            // Guarded like the other tests in this class: if either ephemeral bind fails, the
+            // already-started listener's event loops would otherwise survive the JVM and the
+            // thread-name assertions in sibling tests would fail confusingly instead of here.
+            daemon.stop();
+            throw startFailed;
+        }
         armed.set(true);
 
         daemon.stop();
@@ -277,9 +415,10 @@ class DaemonStartupLoggingTest {
         return List.copyOf(this.appender.list);
     }
 
-    private int indexOfMessageContaining(final String fragment) {
+    /** Index of the LAST message containing {@code fragment}, or -1. */
+    private int lastIndexOfMessageContaining(final String fragment) {
         final var all = messages();
-        for (int i = 0; i < all.size(); i++) {
+        for (int i = all.size() - 1; i >= 0; i--) {
             if (all.get(i).contains(fragment)) {
                 return i;
             }

--- a/src/test/java/org/riptide/flows/DaemonStartupLoggingTest.java
+++ b/src/test/java/org/riptide/flows/DaemonStartupLoggingTest.java
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  *
  * <p>The regression this pins (#453): the {@code Listening for flows} summary was emitted from the
  * constructor, while the sockets are bound in {@link Daemon#run}. Those are different lifecycle
- * phases — a bean failing during context refresh means {@code run()} never executes — so the line
+ * phases: a bean failing during context refresh means {@code run()} never executes, so the line
  * announced success before anything listened, and on a healthy boot the bind was the last thing to
  * happen and the only thing never logged.
  *
@@ -61,6 +61,7 @@ class DaemonStartupLoggingTest {
     @AfterEach
     void releaseDaemonLog() {
         this.logger.detachAppender(this.appender);
+        this.appender.stop();
     }
 
     @Test
@@ -100,6 +101,9 @@ class DaemonStartupLoggingTest {
             assertThat(summaryIndex)
                     .as("the summary marks the point every receiver is bound, so it comes last")
                     .isGreaterThan(lastReceiverIndex);
+            assertThat(summaryIndex)
+                    .as("the summary log message must be present")
+                    .isGreaterThanOrEqualTo(0);
             assertThat(messages().get(summaryIndex))
                     .as("its count must match the receivers reported")
                     .contains("2 receivers");
@@ -129,7 +133,7 @@ class DaemonStartupLoggingTest {
                         .isInstanceOf(Exception.class);
 
                 assertThat(events())
-                        .as("the failing receiver is named, with its address — a stack alone is not")
+                        .as("the failing receiver is named, with its address: a stack alone is not")
                         .anySatisfy(event -> {
                             assertThat(event.getLevel()).isEqualTo(Level.ERROR);
                             assertThat(event.getFormattedMessage())

--- a/src/test/java/org/riptide/flows/DaemonStartupLoggingTest.java
+++ b/src/test/java/org/riptide/flows/DaemonStartupLoggingTest.java
@@ -159,13 +159,81 @@ class DaemonStartupLoggingTest {
         }
     }
 
+    /**
+     * A listener dying with an {@code Error} must not take the rest of shutdown with it.
+     *
+     * <p>{@code stop()} promises that a failing listener cannot keep the pipeline from draining —
+     * the batch flusher is a daemon thread, so a skipped drain silently loses the whole buffer. An
+     * {@code Error} used to escape the loop and break that promise, skipping every later listener
+     * and the drain itself.
+     *
+     * <p>The failure is injected through the {@code MetricRegistry} the daemon hands its listeners:
+     * {@code UdpListener.stop()} deregisters its {@code socketDrops} gauge, so an {@code Error}
+     * from {@code remove()} surfaces out of that listener's teardown.
+     */
+    @Test
+    void anErrorStoppingOneListenerStopsNeitherTheOthersNorTheDrain() throws Exception {
+        final var armed = new java.util.concurrent.atomic.AtomicBoolean();
+        final var registry = new MetricRegistry() {
+            @Override
+            public boolean remove(final String name) {
+                if (armed.get()) {
+                    throw new StackOverflowError("listener teardown died");
+                }
+                return super.remove(name);
+            }
+        };
+        final var pipeline = Mockito.mock(Pipeline.class);
+        final var daemon = daemon(Map.of(
+                "riptide.receivers.first.type", "netflow5",
+                "riptide.receivers.first.host", "127.0.0.1",
+                "riptide.receivers.first.port", "0",
+                "riptide.receivers.second.type", "netflow5",
+                "riptide.receivers.second.host", "127.0.0.1",
+                "riptide.receivers.second.port", "0"), pipeline, registry);
+
+        daemon.run(new DefaultApplicationArguments());
+        armed.set(true);
+
+        daemon.stop();
+
+        assertThat(liveThreadNames("udp-listener-nio-first-"))
+                .as("the listener whose teardown raised an Error is still released")
+                .isEmpty();
+        assertThat(liveThreadNames("udp-listener-nio-second-"))
+                .as("an Error in one listener must not skip the listeners after it")
+                .isEmpty();
+        Mockito.verify(pipeline).stop();
+    }
+
+    private static List<String> liveThreadNames(final String prefix) {
+        // Polled: shutdownGracefully().syncUninterruptibly() returns when the termination future
+        // completes, which SingleThreadEventExecutor does from inside the event loop thread's own
+        // finally block, so the thread is briefly still alive afterwards.
+        final long deadline = System.nanoTime() + java.util.concurrent.TimeUnit.SECONDS.toNanos(10);
+        List<String> alive;
+        do {
+            alive = Thread.getAllStackTraces().keySet().stream()
+                    .map(Thread::getName)
+                    .filter(name -> name.startsWith(prefix))
+                    .toList();
+        } while (!alive.isEmpty() && System.nanoTime() < deadline);
+        return alive;
+    }
+
     private Daemon daemon(final Map<String, Object> properties) {
+        return daemon(properties, Mockito.mock(Pipeline.class), new MetricRegistry());
+    }
+
+    private Daemon daemon(final Map<String, Object> properties,
+                          final Pipeline pipeline,
+                          final MetricRegistry registry) {
         final var config = new Binder(new MapConfigurationPropertySource(properties))
                 .bind("riptide", DaemonConfig.class)
                 .orElseGet(DaemonConfig::new);
         return new Daemon(
-                Mockito.mock(Pipeline.class),
-                new MetricRegistry(),
+                pipeline,
+                registry,
                 Mockito.mock(ValueConversionService.class),
                 Mockito.mock(ValueConversionService.class),
                 Mockito.mock(ExporterInterfaceTable.class),

--- a/src/test/java/org/riptide/flows/DaemonStartupLoggingTest.java
+++ b/src/test/java/org/riptide/flows/DaemonStartupLoggingTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.codahale.metrics.MetricRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.riptide.config.DaemonConfig;
+import org.riptide.flows.parser.ie.values.ValueConversionService;
+import org.riptide.flows.parser.session.ExporterSamplingTable;
+import org.riptide.pipeline.Pipeline;
+import org.riptide.snmp.ExporterInterfaceTable;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.DefaultApplicationArguments;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * What the log says at startup must match what is bound.
+ *
+ * <p>The regression this pins (#453): the {@code Listening for flows} summary was emitted from the
+ * constructor, while the sockets are bound in {@link Daemon#run}. Those are different lifecycle
+ * phases — a bean failing during context refresh means {@code run()} never executes — so the line
+ * announced success before anything listened, and on a healthy boot the bind was the last thing to
+ * happen and the only thing never logged.
+ *
+ * <p>The costlier half was attribution: a receiver that failed to bind appeared in the log neither
+ * by name nor by port, leaving an operator with {@code Address already in use} and several
+ * configured receivers to choose between.
+ */
+class DaemonStartupLoggingTest {
+
+    private Logger logger;
+    private ListAppender<ILoggingEvent> appender;
+
+    @BeforeEach
+    void captureDaemonLog() {
+        this.logger = (Logger) LoggerFactory.getLogger(Daemon.class);
+        this.appender = new ListAppender<>();
+        this.appender.start();
+        this.logger.addAppender(this.appender);
+    }
+
+    @AfterEach
+    void releaseDaemonLog() {
+        this.logger.detachAppender(this.appender);
+    }
+
+    @Test
+    void constructingTheDaemonClaimsNothingAboutListening() {
+        daemon(Map.of(
+                "riptide.receivers.nf5.type", "netflow5",
+                "riptide.receivers.nf5.host", "127.0.0.1",
+                "riptide.receivers.nf5.port", "0"));
+
+        assertThat(messages())
+                .as("nothing is bound until run(); the constructor must not claim otherwise")
+                .noneSatisfy(message -> assertThat(message).contains("Listening for flows"));
+    }
+
+    @Test
+    void eachReceiverIsReportedWhenItBindsAndThenSummarised() throws Exception {
+        final var daemon = daemon(Map.of(
+                "riptide.receivers.nf5.type", "netflow5",
+                "riptide.receivers.nf5.host", "127.0.0.1",
+                "riptide.receivers.nf5.port", "0",
+                "riptide.receivers.nf9.type", "netflow9",
+                "riptide.receivers.nf9.host", "127.0.0.1",
+                "riptide.receivers.nf9.port", "0"));
+
+        try {
+            daemon.run(new DefaultApplicationArguments());
+
+            assertThat(messages())
+                    .as("every receiver is named as it binds")
+                    .anySatisfy(m -> assertThat(m).contains("Receiver 'nf5'").contains("listening on"))
+                    .anySatisfy(m -> assertThat(m).contains("Receiver 'nf9'").contains("listening on"));
+
+            final var summaryIndex = indexOfMessageContaining("Listening for flows");
+            final var lastReceiverIndex = Math.max(
+                    indexOfMessageContaining("Receiver 'nf5'"),
+                    indexOfMessageContaining("Receiver 'nf9'"));
+            assertThat(summaryIndex)
+                    .as("the summary marks the point every receiver is bound, so it comes last")
+                    .isGreaterThan(lastReceiverIndex);
+            assertThat(messages().get(summaryIndex))
+                    .as("its count must match the receivers reported")
+                    .contains("2 receivers");
+        } finally {
+            daemon.stop();
+        }
+    }
+
+    @Test
+    void aReceiverThatCannotBindIsNamedWithItsAddress() throws Exception {
+        // reuseAddress(false) so the conflict is real: Java enables SO_REUSEADDR on ServerSocket by
+        // default on some platforms, which lets a second bind succeed and the test silently pass.
+        try (var occupied = new ServerSocket()) {
+            occupied.setReuseAddress(false);
+            occupied.bind(new java.net.InetSocketAddress(InetAddress.getByName("127.0.0.1"), 0));
+            final int taken = occupied.getLocalPort();
+
+            final var daemon = daemon(Map.of(
+                    "riptide.receivers.ipfixtcp.type", "ipfix",
+                    "riptide.receivers.ipfixtcp.transport", "TCP",
+                    "riptide.receivers.ipfixtcp.host", "127.0.0.1",
+                    "riptide.receivers.ipfixtcp.port", String.valueOf(taken)));
+
+            try {
+                assertThatThrownBy(() -> daemon.run(new DefaultApplicationArguments()))
+                        .as("a receiver that cannot bind must still abort startup")
+                        .isInstanceOf(Exception.class);
+
+                assertThat(events())
+                        .as("the failing receiver is named, with its address — a stack alone is not")
+                        .anySatisfy(event -> {
+                            assertThat(event.getLevel()).isEqualTo(Level.ERROR);
+                            assertThat(event.getFormattedMessage())
+                                    .contains("Receiver 'ipfixtcp'")
+                                    .contains("failed to start")
+                                    .contains(String.valueOf(taken));
+                        });
+
+                assertThat(messages())
+                        .as("a failed start must not be summarised as listening")
+                        .noneSatisfy(m -> assertThat(m).contains("Listening for flows"));
+            } finally {
+                daemon.stop();
+            }
+        }
+    }
+
+    private Daemon daemon(final Map<String, Object> properties) {
+        final var config = new Binder(new MapConfigurationPropertySource(properties))
+                .bind("riptide", DaemonConfig.class)
+                .orElseGet(DaemonConfig::new);
+        return new Daemon(
+                Mockito.mock(Pipeline.class),
+                new MetricRegistry(),
+                Mockito.mock(ValueConversionService.class),
+                Mockito.mock(ValueConversionService.class),
+                Mockito.mock(ExporterInterfaceTable.class),
+                Mockito.mock(ExporterSamplingTable.class),
+                config);
+    }
+
+    private List<String> messages() {
+        return this.appender.list.stream().map(ILoggingEvent::getFormattedMessage).toList();
+    }
+
+    private List<ILoggingEvent> events() {
+        return List.copyOf(this.appender.list);
+    }
+
+    private int indexOfMessageContaining(final String fragment) {
+        final var all = messages();
+        for (int i = 0; i < all.size(); i++) {
+            if (all.get(i).contains(fragment)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/src/test/java/org/riptide/flows/DaemonStartupLoggingTest.java
+++ b/src/test/java/org/riptide/flows/DaemonStartupLoggingTest.java
@@ -102,6 +102,20 @@ class DaemonStartupLoggingTest {
                     .anySatisfy(m -> assertThat(m).contains("Receiver 'nf5'").contains("listening on"))
                     .anySatisfy(m -> assertThat(m).contains("Receiver 'nf9'").contains("listening on"));
 
+            // Both receivers are configured with port 0, so the kernel picks. Reporting the literal
+            // 0 would tell an operator nothing about where the socket actually is — the same "log
+            // does not match what is bound" defect this change exists to fix.
+            assertThat(messages().stream().filter(m -> m.contains("listening on")).toList())
+                    .as("the ephemeral port is resolved, not echoed back as configured")
+                    .isNotEmpty()
+                    .allSatisfy(m -> {
+                        assertThat(m).doesNotContain(":0");
+                        final var matcher = java.util.regex.Pattern
+                                .compile("listening on \\w+ \\S+:(\\d+)").matcher(m);
+                        assertThat(matcher.find()).as("address is parseable in %s", m).isTrue();
+                        assertThat(Integer.parseInt(matcher.group(1))).isPositive();
+                    });
+
             final var summaryIndex = indexOfMessageContaining("Listening for flows");
             final var lastReceiverIndex = Math.max(
                     indexOfMessageContaining("Receiver 'nf5'"),


### PR DESCRIPTION
Fixes #453

## What

`Daemon` announced `Listening for flows with N receivers \o/` from its **constructor**, while the sockets are bound in `ApplicationRunner.run()`. Different lifecycle phases, so the line printed before anything listened — and since Spring logs `Started RiptideApplication` before `callRunners()`, on a healthy boot the bind was both the last thing to happen and the only thing never logged.

The costlier half was attribution. Grepping a failed boot for the receiver that could not bind returned **nothing** — neither its configured name nor its port appeared anywhere. An operator saw `Address already in use`, two lines claiming success, and several configured receivers to choose between.

```
BEFORE                                      AFTER
Listening for flows ... \o/  ← constructor  Started RiptideApplication in 1.1s
Started RiptideApplication                  Receiver 'nf5udp'   listening on UDP 0.0.0.0:19802
Application run failed                      Receiver 'ipfixtcp' listening on TCP 0.0.0.0:19801
  BindException: Address already in use     Listening for flows with 2 receivers \o/
  ↑ which receiver? grep → 0 matches
                                            ERROR Receiver 'ipfixtcp' failed to start on
                                                  TCP 0.0.0.0:19801: BindException: Address already in use
```

Wording follows `ManagementServer`, which already logs its real address when it is genuinely listening. `getName()` and `getDescription()` already existed and were simply unused at startup.

## Address rendering

`getDescription()` reports the **port** from the socket and the **host** from configuration. Those are the halves each source answers best: the operator wrote the host and can grep for it, while the port is the half the kernel may choose (`port: 0` says nothing about where the socket is).

Reading the host back off the channel was tried and reverted — it made the default configuration worse. `ReceiverConfig` has no default host, so an unset host binds the wildcard, which a dual-stack JVM reports as `0:0:0:0:0:0:0:0`. Verified against the real listener: `UDP *:9999` became `UDP 0:0:0:0:0:0:0:0:9999`, in the exact line this change exists to provide. IPv6 was also emitted unbracketed, and a configured hostname came back as its resolved literal.

The bound port is used only while the channel is active, so a stopped listener no longer names a port another process may since have taken — the same misattribution `UdpListener.stop()` already avoids by deregistering its `socketDrops` gauge before releasing the socket.

Rules live in one `ListenerAddress` renderer, and `Listener.getDescription()` now states the contract so a third implementation cannot satisfy the interface while violating it.

## Shutdown

`Daemon.stop()` already promised that "a failing listener must not keep the pipeline (and its batch drain) from stopping". `catch (Exception)` did not deliver it: an `Error` escaped the loop, skipping every later listener **and** the drain. Widened to `Throwable`, with `pipeline.stop()` in a `finally`. That closes the asymmetry where #452 made teardown best-effort *per resource* inside a listener while the loop *over* listeners could still be abandoned wholesale.

## Tests

`DaemonStartupLoggingTest`, 7 tests. Each was verified non-vacuous against the code it guards — including the wildcard case, which fails with `UDP [0:0:0:0:0:0:0:0]:55280` if the host is read back off the channel.

Covers: nothing claimed at construction; per-receiver lines followed by a matching summary; a named failure with no summary; a wildcard bind; the TCP success branch (previously uncovered — the only TCP receiver failed to bind, so that path could have been broken with every test green); coexisting success and failure; and an `Error` during teardown not stranding the other listeners or the drain.

## Verification

Merged with `--admin` during a GitHub Actions **major outage** (webhooks throttled, no workflows dispatched). Both blocking CI jobs were reproduced locally instead — these are the exact commands CI runs, since CI invokes Makefile targets rather than tooling directly:

- `make jar` → BUILD SUCCESS, 999 unit tests, 0 failures, SpotBugs/Checkstyle/Error Prone clean
- `make e2e` → BUILD SUCCESS, 41 integration tests, 0 failures

No workflow files are touched, so the `lint` job had nothing to check. **CodeQL/analyze was not reproduced** — worth a run on `main` once Actions recovers.

## Review

Three adversarial review rounds; the last was a parallel Blind Hunter / Edge Case Hunter / Acceptance Auditor pass that produced 15 patches, all applied. Three findings were deliberately deferred and recorded: zero configured receivers reports ready, `run()` relies on Spring closing the context to release already-started listeners, and a throwable from the teardown loop itself is discarded rather than suppressed onto a drain failure.

## Spec

Adds two capabilities: `receiver-startup-observability` (what is logged, and when) and `receiver-orchestration` (the daemon starting and stopping its receivers as a set). The latter exists because the cross-listener teardown guarantee was pinned by a test with no requirement behind it.

Not addressed, and documented as a non-goal: the bind lines necessarily print *after* Spring's `Started RiptideApplication`. Binding during context refresh via `SmartLifecycle` would fix the ordering and fail the refresh the way `managementServer` already does, but it moves `isStarted()` and the health semantics with it.
