### PR TITLE
refactor(parser): own the housekeeping scheduler instead of borrowing the listener's

### DIFF
--- a/src/main/java/org/riptide/flows/listeners/UdpListener.java
+++ b/src/main/java/org/riptide/flows/listeners/UdpListener.java
@@ -62,18 +62,18 @@ public class UdpListener implements Listener {
 
     @Override
     public void start() {
-        // Netty defaults to 2 * num cores when the number of threads is set to 0.
+        // One thread, because this group drives this listener's one DatagramChannel and nothing
+        // else. Netty's default (0 = 2 * num cores) built 20 loops on a 10-core host of which 19
+        // could never be selected, each holding a selector.
         //
-        // Do NOT size this to 1 on the reasoning that a single DatagramChannel occupies one loop.
-        // This group is also the parser's ScheduledExecutorService (see parser.start below), and
-        // UdpParserBase schedules doHousekeeping on it every 60s — one task per sub-parser under
-        // DispatchingUdpParser. scheduleAtFixedRate calls next(), so with more than one loop the
-        // sweep runs on a different thread from the socket; measured, this group starts exactly
-        // two threads. Collapsing to one loop would put every housekeeping sweep on the thread
-        // draining the socket, stalling reception into kernel loss on the socketDrops gauge.
-        // Sizing this group is issue #450, and needs the ingest path measured first.
+        // The rule that matters is the second half: this group serves the channel only. It used to
+        // double as the parser's ScheduledExecutorService, which is why it could not be sized —
+        // UdpParserBase scheduled a 60s sweep on it, and scheduleAtFixedRate dispatches by
+        // round-robin, so with one loop every sweep would have landed on the thread draining the
+        // socket (#457). The parser owns its own scheduler now and ignores what it is handed here.
+        // Do not give this group other work to make it earn its keep; give the work its own thread.
         final var formatName = name.replace("%", "%%");
-        this.bossGroup = new MultiThreadIoEventLoopGroup(0, new ThreadFactoryBuilder()
+        this.bossGroup = new MultiThreadIoEventLoopGroup(1, new ThreadFactoryBuilder()
                 .setNameFormat("udp-listener-nio-" + formatName + "-%d")
                 .build(), NioIoHandler.newFactory());
 

--- a/src/main/java/org/riptide/flows/parser/UdpParserBase.java
+++ b/src/main/java/org/riptide/flows/parser/UdpParserBase.java
@@ -27,6 +27,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -53,6 +54,8 @@ public abstract class UdpParserBase extends ParserBase implements UdpParser {
     private UdpSessionManager sessionManager;
 
     private ScheduledFuture<?> housekeepingFuture;
+    /** Owned, not borrowed — see {@link #start}. */
+    private ScheduledExecutorService housekeeper;
     private Duration templateTimeout = Duration.ofMinutes(30);
     private OptionListener optionListener = OptionListener.NONE;
 
@@ -124,11 +127,36 @@ public abstract class UdpParserBase extends ParserBase implements UdpParser {
         this.optionListener = Objects.requireNonNull(optionListener);
     }
 
+    /**
+     * The passed executor is deliberately ignored.
+     *
+     * <p>It is a listener's event loop group, whose job is draining a socket. Scheduling on it
+     * dispatches by round-robin, so the sweep can land on the reading thread itself and turn every
+     * execution into a pause in packet reception — kernel loss on the {@code socketDrops} gauge
+     * rather than an application error. It only missed that thread because the group was built
+     * larger than its one channel needs.
+     *
+     * <p>Ownership follows the data instead: this class creates {@code sessionManager} and discards
+     * it in {@link #stop}, so it owns the schedule that sweeps it. Same shape as
+     * {@code InterfaceSnapshotPoller} and {@code GeoIpEnricher} — a named daemon single-thread
+     * scheduler, shut down with its owner.
+     */
     @Override
     public void start(final ScheduledExecutorService executorService) {
         super.start(executorService);
         this.sessionManager = new UdpSessionManager(this.templateTimeout, this::sequenceNumberTracker, this.optionListener);
-        this.housekeepingFuture = executorService.scheduleAtFixedRate(this.sessionManager::doHousekeeping,
+        // Daemon: ParserBase.stop() already documents that abandoned non-daemon workers wedge JVM
+        // exit, and a reaper killed mid-sweep costs nothing — it reads and prunes, it never writes
+        // anything a later sweep cannot redo.
+        this.housekeeper = Executors.newSingleThreadScheduledExecutor(runnable -> {
+            final Thread thread = new Thread(runnable, "udp-parser-housekeeping-" + getName());
+            thread.setDaemon(true);
+            return thread;
+        });
+        // The handle is kept and cancelled explicitly rather than discarded: doHousekeeping throwing
+        // would otherwise cancel the schedule silently and leave reaping dead for the process
+        // lifetime.
+        this.housekeepingFuture = this.housekeeper.scheduleAtFixedRate(this.sessionManager::doHousekeeping,
                 HOUSEKEEPING_INTERVAL,
                 HOUSEKEEPING_INTERVAL,
                 TimeUnit.MILLISECONDS);
@@ -139,6 +167,12 @@ public abstract class UdpParserBase extends ParserBase implements UdpParser {
         if (this.housekeepingFuture != null) {
             this.housekeepingFuture.cancel(false);
             this.housekeepingFuture = null;
+        }
+        // Nulled like the future above, so a second stop() is well defined rather than shutting down
+        // an already-dead executor.
+        if (this.housekeeper != null) {
+            this.housekeeper.shutdownNow();
+            this.housekeeper = null;
         }
 
         super.stop();

--- a/src/test/java/org/riptide/benchmarks/parser/netflow9/Netflow9ReadThreadBenchmark.java
+++ b/src/test/java/org/riptide/benchmarks/parser/netflow9/Netflow9ReadThreadBenchmark.java
@@ -52,7 +52,7 @@ import java.util.concurrent.TimeUnit;
 import static org.riptide.flows.utils.BufferUtils.slice;
 
 /**
- * What one UDP event-loop thread pays per NetFlow v9 datagram, for issue #450.
+ * What one UDP event-loop thread pays per NetFlow v9 datagram, measured for issue #450.
  *
  * <p>#450 asks whether UDP ingest is capped by reading on a single event loop. The premise there is
  * that the thread "drains a socket into a handoff queue", which the code does not support: the

--- a/src/test/java/org/riptide/flows/listeners/UdpListenerSchedulerIsolationTest.java
+++ b/src/test/java/org/riptide/flows/listeners/UdpListenerSchedulerIsolationTest.java
@@ -19,22 +19,30 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * A {@code UdpListener}'s event loop group is also the parser's {@code ScheduledExecutorService}:
- * {@code start()} hands it to {@code parser.start(...)}, and {@code UdpParserBase} schedules
- * {@code doHousekeeping} on it every 60s — once per sub-parser under {@code DispatchingUdpParser}.
+ * A {@code UdpListener}'s event loop group must drive its channel and nothing else.
  *
- * <p>The regression this pins: sizing the group to one loop on the reasoning that a single
- * {@code DatagramChannel} only occupies one. {@code scheduleAtFixedRate} calls {@code next()}, so
- * with the default group the sweep runs on a different loop from the socket; with one loop it runs
- * on the thread draining the socket, turning every sweep into a pause in packet reception that
- * surfaces as kernel loss on the {@code socketDrops} gauge rather than as an application error.
+ * <p>History, because this assertion inverted and that reads like a weakening. It used to require
+ * the group to start MORE than one thread: {@code start()} handed the group to
+ * {@code parser.start(...)}, {@code UdpParserBase} scheduled a 60s sweep on it, and
+ * {@code scheduleAtFixedRate} dispatches by round-robin — so a one-loop group would have put every
+ * sweep on the thread draining the socket, turning it into a pause in packet reception that
+ * surfaces as kernel loss on {@code socketDrops} rather than as an application error. That
+ * regression was caught in review once already.
  *
- * <p>Sizing this group is issue #450 and needs the ingest path measured first.
+ * <p>The parser owns its scheduler now (#457), so the group is sized to its one channel.
+ *
+ * <p>Note what this test does and does not prove after that inversion. It proves the SIZING: a
+ * second thread here means something other than the channel took work on this group. It does NOT
+ * prove the decoupling, because with one loop {@code next()} returns that same loop — a re-coupled
+ * sweep would share the socket's thread and the count would still be 1. Verified: reverting the
+ * parser to schedule on the passed executor leaves this test green. The decoupling guard is
+ * {@code UdpParserHousekeepingTest}, which fails loudly on that revert. Both are needed; neither
+ * covers the other.
  */
 class UdpListenerSchedulerIsolationTest {
 
     @Test
-    void scheduledParserWorkDoesNotShareTheThreadDrainingTheSocket() {
+    void theListenerGroupDrivesItsChannelAndNothingElse() {
         final var listener = new UdpListener("isolation", schedulingParser(), new MetricRegistry())
                 .withHost("127.0.0.1")
                 .withPort(0);
@@ -47,8 +55,8 @@ class UdpListenerSchedulerIsolationTest {
                     .collect(Collectors.toSet());
 
             assertThat(loopThreads)
-                    .as("the parser's scheduled housekeeping must not run on the socket's event loop")
-                    .hasSizeGreaterThan(1);
+                    .as("one channel needs one loop; a second means something else took work here")
+                    .hasSize(1);
         } finally {
             listener.stop();
         }

--- a/src/test/java/org/riptide/flows/parser/UdpParserHousekeepingTest.java
+++ b/src/test/java/org/riptide/flows/parser/UdpParserHousekeepingTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.parser;
+
+import com.codahale.metrics.MetricRegistry;
+import org.junit.jupiter.api.Test;
+import org.riptide.flows.parser.netflow5.Netflow5UdpParser;
+import org.riptide.pipeline.Identity;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * A parser schedules its session housekeeping on a scheduler it owns, never on the executor its
+ * listener hands over.
+ *
+ * <p>That executor is the listener's event loop group, whose job is draining a socket.
+ * {@code scheduleAtFixedRate} dispatches by round-robin, so work placed there can land on the
+ * reading thread and turn every sweep into a pause in packet reception — kernel loss on
+ * {@code socketDrops} rather than an application error (#457).
+ *
+ * <p>Two assertions, because either alone can pass on a parser that does nothing: the handed-over
+ * executor must go unused, AND the sweep must actually be scheduled somewhere.
+ */
+class UdpParserHousekeepingTest {
+
+    @Test
+    void nothingIsScheduledOnTheExecutorTheListenerPasses() {
+        final var poisoned = new PoisonedScheduler();
+        final var parser = parser("poison-check");
+
+        parser.start(poisoned);
+        try {
+            assertThat(poisoned.used)
+                    .as("the listener's event loop group must not be used as a timer")
+                    .isFalse();
+        } finally {
+            parser.stop();
+        }
+    }
+
+    @Test
+    void housekeepingRunsOnASchedulerTheParserOwns() {
+        final var parser = parser("owned-check");
+
+        parser.start(new PoisonedScheduler());
+        try {
+            assertThat(awaitThreads("udp-parser-housekeeping-owned-check"))
+                    .as("the sweep must be scheduled somewhere — without this the guard above "
+                        + "passes on a parser that schedules nothing at all")
+                    .isNotEmpty();
+        } finally {
+            parser.stop();
+        }
+
+        assertThat(awaitNoThreads("udp-parser-housekeeping-owned-check"))
+                .as("the scheduler is released with its owner")
+                .isEmpty();
+    }
+
+    @Test
+    void stoppingTwiceIsWellDefined() {
+        final var parser = parser("double-stop");
+        parser.start(new PoisonedScheduler());
+        parser.stop();
+
+        assertThatCode(parser::stop).doesNotThrowAnyException();
+    }
+
+    /** Polls until the named threads appear, or the deadline passes. */
+    private static List<String> awaitThreads(final String prefix) {
+        return await(prefix, false);
+    }
+
+    /** Polls until the named threads are gone, or the deadline passes. */
+    private static List<String> awaitNoThreads(final String prefix) {
+        return await(prefix, true);
+    }
+
+    // One loop, two exit conditions: waiting for a scheduler to appear and waiting for it to be
+    // released need opposite predicates, and using the appear-helper for both made every
+    // disappearance assertion sit out the full deadline before passing.
+    private static List<String> await(final String prefix, final boolean wantGone) {
+        final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        while (true) {
+            final var alive = Thread.getAllStackTraces().keySet().stream()
+                    .map(Thread::getName)
+                    .filter(name -> name.startsWith(prefix))
+                    .toList();
+            if (alive.isEmpty() == wantGone || System.nanoTime() >= deadline) {
+                return alive;
+            }
+            try {
+                Thread.sleep(10);
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return alive;
+            }
+        }
+    }
+
+    private static UdpParserBase parser(final String name) {
+        return new Netflow5UdpParser(name, (source, flows) -> { }, new Identity("t", "o", "z", "s"), new MetricRegistry());
+    }
+
+    /** Fails the test rather than the process: records any use instead of scheduling anything. */
+    private static final class PoisonedScheduler implements ScheduledExecutorService {
+        private volatile boolean used;
+
+        private <T> T poison() {
+            this.used = true;
+            throw new UnsupportedOperationException(
+                    "a parser must own its scheduler, not borrow the listener's event loop group");
+        }
+
+        @Override public ScheduledFuture<?> schedule(Runnable c, long d, TimeUnit u) { return poison(); }
+        @Override public <V> ScheduledFuture<V> schedule(Callable<V> c, long d, TimeUnit u) { return poison(); }
+        @Override public ScheduledFuture<?> scheduleAtFixedRate(Runnable c, long i, long p, TimeUnit u) { return poison(); }
+        @Override public ScheduledFuture<?> scheduleWithFixedDelay(Runnable c, long i, long d, TimeUnit u) { return poison(); }
+        @Override public void execute(Runnable command) { poison(); }
+        @Override public <T> java.util.concurrent.Future<T> submit(Callable<T> task) { return poison(); }
+        @Override public <T> java.util.concurrent.Future<T> submit(Runnable task, T result) { return poison(); }
+        @Override public java.util.concurrent.Future<?> submit(Runnable task) { return poison(); }
+        @Override public <T> List<java.util.concurrent.Future<T>> invokeAll(java.util.Collection<? extends Callable<T>> t) { return poison(); }
+        @Override public <T> List<java.util.concurrent.Future<T>> invokeAll(java.util.Collection<? extends Callable<T>> t, long o, TimeUnit u) { return poison(); }
+        @Override public <T> T invokeAny(java.util.Collection<? extends Callable<T>> t) { return poison(); }
+        @Override public <T> T invokeAny(java.util.Collection<? extends Callable<T>> t, long o, TimeUnit u) { return poison(); }
+        @Override public void shutdown() { poison(); }
+        @Override public List<Runnable> shutdownNow() { return poison(); }
+        @Override public boolean isShutdown() { return false; }
+        @Override public boolean isTerminated() { return false; }
+        @Override public boolean awaitTermination(long timeout, TimeUnit unit) { return poison(); }
+    }
+}


### PR DESCRIPTION
Fixes #457

## What

`UdpListener` handed its event loop group to the parser as a `ScheduledExecutorService`, and `UdpParserBase` scheduled a 60s session sweep on it — once per sub-parser, and a `multi` receiver has four. `scheduleAtFixedRate` dispatches by round-robin, so the sweep could land on the thread draining the socket. It only missed because the group was built with `nThreads = 0`: 20 loops on a 10-core host, 2 threads ever started, 18 idle forever holding a selector each.

The coupling and the over-allocation were the same fact — the group could not be sized while it was also somebody else's timer.

`UdpParserBase` now owns a named daemon single-thread scheduler and shuts it down in `stop()`, matching `InterfaceSnapshotPoller` and `GeoIpEnricher`. Ownership follows the data: it creates `sessionManager` and discards it, so it owns the schedule that sweeps it. `UdpListener`'s group is sized to 1 — verified that `bootstrap.group()` is its only remaining user.

Verified on a running instance with a `multi` receiver:

```
1 × udp-listener-nio-flows-0                              (was 2 threads across 20 loops)
4 × udp-parser-housekeeping-flows:{netflow5,netflow9,ipfix,sflow}
```

## Not a throughput change

#450 measured the read thread at ~36,091 packets/s, 12–64× above measured load. This is a latent correctness fix: the coupling had already produced one regression, caught in review during #456 when the group was sized to 1 on the reasonable-looking argument that one channel needs one loop.

## Tests, and a correction

`UdpListenerSchedulerIsolationTest` is rewritten in place, keeping its history. Its assertion inverts from "more than one thread" to "exactly one" — and the javadoc records what that inversion cost.

I had claimed the inverted test would still catch re-coupling because `next()` would spin a second loop. That is false with a one-loop group: `next()` returns that same loop, so a re-coupled sweep shares the socket's thread and the count stays 1. Confirmed by reverting the parser — the listener test stayed green. It now proves the **sizing** only.

The decoupling is proved by the new `UdpParserHousekeepingTest`, which hands the parser a poisoned executor and asserts nothing is scheduled on it. All three of its tests fail against the reverted code, which makes it load-bearing rather than supplementary.

## Verification

`make jar` — 1002 tests, 0 failures, SpotBugs/Checkstyle/Error Prone clean.
`make e2e` — 41 integration tests, 0 failures.

## Follow-up

`Parser.start(ScheduledExecutorService)` is left intact and now dead on **every** path — `ParserBase` already ignored it. Removing it touches the interface and every implementor, so it is filed separately.
