### PR TITLE
refactor(parser): drop the unused executor parameter from Parser.start

### DIFF
--- a/src/main/java/org/riptide/flows/listeners/TcpListener.java
+++ b/src/main/java/org/riptide/flows/listeners/TcpListener.java
@@ -77,7 +77,7 @@ public class TcpListener implements Listener {
                 .setNameFormat("tcp-listener-nio-worker-" + formatName + "-%d")
                 .build(), NioIoHandler.newFactory());
 
-        this.parser.start(this.bossGroup);
+        this.parser.start();
 
         final InetSocketAddress address = this.host != null
                 ? SocketUtils.socketAddress(this.host, this.port)

--- a/src/main/java/org/riptide/flows/listeners/UdpListener.java
+++ b/src/main/java/org/riptide/flows/listeners/UdpListener.java
@@ -70,14 +70,15 @@ public class UdpListener implements Listener {
         // double as the parser's ScheduledExecutorService, which is why it could not be sized —
         // UdpParserBase scheduled a 60s sweep on it, and scheduleAtFixedRate dispatches by
         // round-robin, so with one loop every sweep would have landed on the thread draining the
-        // socket (#457). The parser owns its own scheduler now and ignores what it is handed here.
-        // Do not give this group other work to make it earn its keep; give the work its own thread.
+        // socket (#457). The parser owns its scheduler now, and since #459 there is no longer a
+        // parameter to hand this group to. Do not give this group other work to make it earn its
+        // keep; give the work its own thread.
         final var formatName = name.replace("%", "%%");
         this.bossGroup = new MultiThreadIoEventLoopGroup(1, new ThreadFactoryBuilder()
                 .setNameFormat("udp-listener-nio-" + formatName + "-%d")
                 .build(), NioIoHandler.newFactory());
 
-        this.parser.start(this.bossGroup);
+        this.parser.start();
 
         final InetSocketAddress address = this.host != null
                 ? SocketUtils.socketAddress(this.host, this.port)

--- a/src/main/java/org/riptide/flows/listeners/multi/DispatchingUdpParser.java
+++ b/src/main/java/org/riptide/flows/listeners/multi/DispatchingUdpParser.java
@@ -17,7 +17,6 @@ import java.time.Instant;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
 public class DispatchingUdpParser implements UdpParser {
@@ -73,9 +72,9 @@ public class DispatchingUdpParser implements UdpParser {
     }
 
     @Override
-    public void start(ScheduledExecutorService executorService) {
+    public void start() {
         for (final var parser: this.parsers) {
-            parser.start(executorService);
+            parser.start();
         }
     }
 

--- a/src/main/java/org/riptide/flows/parser/Parser.java
+++ b/src/main/java/org/riptide/flows/parser/Parser.java
@@ -5,7 +5,6 @@
 
 package org.riptide.flows.parser;
 
-import java.util.concurrent.ScheduledExecutorService;
 
 public interface Parser {
     String getName();
@@ -13,6 +12,6 @@ public interface Parser {
 
     Object dumpInternalState();
 
-    void start(ScheduledExecutorService executorService);
+    void start();
     void stop();
 }

--- a/src/main/java/org/riptide/flows/parser/ParserBase.java
+++ b/src/main/java/org/riptide/flows/parser/ParserBase.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.function.BiConsumer;
@@ -130,7 +129,7 @@ public abstract class ParserBase implements Parser {
     }
 
     @Override
-    public void start(ScheduledExecutorService executorService) {
+    public void start() {
         // A bounded queue with core == max, so the pool never grows or shrinks and the keep-alive
         // is inert. Replaces a zero-capacity SynchronousQueue whose rejection handler did an
         // unbounded blocking put(): with no capacity, "queue full" was the steady state under load,
@@ -228,7 +227,7 @@ public abstract class ParserBase implements Parser {
     }
 
     /**
-     * Both sizing knobs are read once, in {@link #start(ScheduledExecutorService)}. Silently
+     * Both sizing knobs are read once, in {@link #start()}. Silently
      * accepting a later change would leave the getter and the drop warning reporting a capacity the
      * queue does not have.
      */

--- a/src/main/java/org/riptide/flows/parser/UdpParserBase.java
+++ b/src/main/java/org/riptide/flows/parser/UdpParserBase.java
@@ -128,22 +128,23 @@ public abstract class UdpParserBase extends ParserBase implements UdpParser {
     }
 
     /**
-     * The passed executor is deliberately ignored.
+     * Owns the scheduler that sweeps its sessions.
      *
-     * <p>It is a listener's event loop group, whose job is draining a socket. Scheduling on it
-     * dispatches by round-robin, so the sweep can land on the reading thread itself and turn every
-     * execution into a pause in packet reception — kernel loss on the {@code socketDrops} gauge
-     * rather than an application error. It only missed that thread because the group was built
-     * larger than its one channel needs.
-     *
-     * <p>Ownership follows the data instead: this class creates {@code sessionManager} and discards
-     * it in {@link #stop}, so it owns the schedule that sweeps it. Same shape as
+     * <p>Ownership follows the data: this class creates {@code sessionManager} and discards it in
+     * {@link #stop}, so it owns the schedule that reaps it. Same shape as
      * {@code InterfaceSnapshotPoller} and {@code GeoIpEnricher} — a named daemon single-thread
      * scheduler, shut down with its owner.
+     *
+     * <p>Until #459 this method took a {@code ScheduledExecutorService} from its listener and, until
+     * #457, scheduled on it. That executor was the listener's event loop group, whose job is
+     * draining a socket: {@code scheduleAtFixedRate} dispatches by round-robin, so the sweep could
+     * land on the reading thread and turn every execution into a pause in packet reception — kernel
+     * loss on {@code socketDrops} rather than an application error. The parameter is gone, so that
+     * is no longer a mistake anyone can make.
      */
     @Override
-    public void start(final ScheduledExecutorService executorService) {
-        super.start(executorService);
+    public void start() {
+        super.start();
         this.sessionManager = new UdpSessionManager(this.templateTimeout, this::sequenceNumberTracker, this.optionListener);
         // Daemon: ParserBase.stop() already documents that abandoned non-daemon workers wedge JVM
         // exit, and a reaper killed mid-sweep costs nothing — it reads and prunes, it never writes

--- a/src/test/java/org/riptide/flows/listeners/ListenerTeardownTest.java
+++ b/src/test/java/org/riptide/flows/listeners/ListenerTeardownTest.java
@@ -13,7 +13,6 @@ import java.net.InetSocketAddress;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ScheduledExecutorService;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -173,7 +172,7 @@ class ListenerTeardownTest {
             }
 
             @Override
-            public void start(final ScheduledExecutorService executorService) {
+            public void start() {
             }
 
             @Override
@@ -211,7 +210,7 @@ class ListenerTeardownTest {
             }
 
             @Override
-            public void start(final ScheduledExecutorService executorService) {
+            public void start() {
             }
 
             @Override

--- a/src/test/java/org/riptide/flows/listeners/TcpListenerThreadNamingTest.java
+++ b/src/test/java/org/riptide/flows/listeners/TcpListenerThreadNamingTest.java
@@ -13,7 +13,6 @@ import java.net.InetSocketAddress;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ScheduledExecutorService;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -113,7 +112,7 @@ class TcpListenerThreadNamingTest {
             }
 
             @Override
-            public void start(final ScheduledExecutorService executorService) {
+            public void start() {
             }
 
             @Override

--- a/src/test/java/org/riptide/flows/listeners/UdpListenerGaugeLifecycleTest.java
+++ b/src/test/java/org/riptide/flows/listeners/UdpListenerGaugeLifecycleTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 import java.net.InetSocketAddress;
 import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ScheduledExecutorService;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -71,7 +70,7 @@ class UdpListenerGaugeLifecycleTest {
             }
 
             @Override
-            public void start(final ScheduledExecutorService executorService) {
+            public void start() {
             }
 
             @Override

--- a/src/test/java/org/riptide/flows/listeners/UdpListenerReleaseTest.java
+++ b/src/test/java/org/riptide/flows/listeners/UdpListenerReleaseTest.java
@@ -15,7 +15,6 @@ import java.net.InetSocketAddress;
 import java.time.Instant;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ScheduledExecutorService;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -102,7 +101,7 @@ class UdpListenerReleaseTest {
             }
 
             @Override
-            public void start(final ScheduledExecutorService executorService) {
+            public void start() {
             }
 
             @Override

--- a/src/test/java/org/riptide/flows/listeners/UdpListenerSchedulerIsolationTest.java
+++ b/src/test/java/org/riptide/flows/listeners/UdpListenerSchedulerIsolationTest.java
@@ -12,8 +12,6 @@ import org.junit.jupiter.api.Test;
 import java.net.InetSocketAddress;
 import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -62,13 +60,15 @@ class UdpListenerSchedulerIsolationTest {
         }
     }
 
-    /** Stands in for {@code UdpParserBase}, which schedules housekeeping on the group it is given. */
+    /**
+     * Stands in for {@code UdpParserBase}. It used to schedule on the executor the listener handed
+     * over — that is what made the old assertion meaningful. Since #459 there is no such executor,
+     * so the stub does nothing and the assertion above rests purely on the listener's own sizing.
+     */
     private static UdpParser schedulingParser() {
         return new UdpParser() {
             @Override
-            public void start(final ScheduledExecutorService executorService) {
-                executorService.scheduleAtFixedRate(() -> {
-                }, 60_000, 60_000, TimeUnit.MILLISECONDS);
+            public void start() {
             }
 
             @Override

--- a/src/test/java/org/riptide/flows/parser/ParserDispatchTest.java
+++ b/src/test/java/org/riptide/flows/parser/ParserDispatchTest.java
@@ -323,7 +323,7 @@ class ParserDispatchTest {
         if (this.scheduler == null) {
             this.scheduler = Executors.newSingleThreadScheduledExecutor();
         }
-        parser.start(this.scheduler);
+        parser.start();
         this.started.add(parser);
         return parser;
     }

--- a/src/test/java/org/riptide/flows/parser/UdpParserBaseTest.java
+++ b/src/test/java/org/riptide/flows/parser/UdpParserBaseTest.java
@@ -69,7 +69,7 @@ class UdpParserBaseTest {
     void setUp() {
         this.executor = Executors.newSingleThreadScheduledExecutor();
         this.parser = new StubParser();
-        this.parser.start(this.executor);
+        this.parser.start();
     }
 
     @AfterEach
@@ -124,7 +124,7 @@ class UdpParserBaseTest {
     void gaugesReportExportersAndTemplatesSeparately() throws Exception {
         final var registry = new MetricRegistry();
         final var parser = new StubParser(registry);
-        parser.start(this.executor);
+        parser.start();
         try {
             parse(parser, ADD_TEMPLATE, REMOTE);
             parse(parser, ADD_TEMPLATE, SECOND_REMOTE);
@@ -162,7 +162,7 @@ class UdpParserBaseTest {
     void sessionCountSeparatesObservationDomainsOfOneExporter() throws Exception {
         final var registry = new MetricRegistry();
         final var parser = new StubParser(registry);
-        parser.start(this.executor);
+        parser.start();
         try {
             parse(parser, ADD_TEMPLATE, REMOTE);         // domain 0, template 256
             parse(parser, ADD_SECOND_TEMPLATE, REMOTE);  // domain 0, template 257

--- a/src/test/java/org/riptide/flows/parser/UdpParserHousekeepingTest.java
+++ b/src/test/java/org/riptide/flows/parser/UdpParserHousekeepingTest.java
@@ -11,52 +11,35 @@ import org.riptide.flows.parser.netflow5.Netflow5UdpParser;
 import org.riptide.pipeline.Identity;
 
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
- * A parser schedules its session housekeeping on a scheduler it owns, never on the executor its
- * listener hands over.
+ * A parser owns the scheduler that sweeps its sessions, and releases it with itself.
  *
- * <p>That executor is the listener's event loop group, whose job is draining a socket.
- * {@code scheduleAtFixedRate} dispatches by round-robin, so work placed there can land on the
- * reading thread and turn every sweep into a pause in packet reception — kernel loss on
- * {@code socketDrops} rather than an application error (#457).
+ * <p>This class used to carry a third test: hand {@code start()} a poisoned
+ * {@code ScheduledExecutorService} and assert nothing was scheduled on it. That guard is gone
+ * because #459 removed the parameter — there is no executor to pass any more, so the mistake it
+ * caught cannot be made. Deleting a test is normally a loss of coverage; here the hazard became
+ * structurally impossible rather than merely watched, which is the only good reason to remove one.
  *
- * <p>Two assertions, because either alone can pass on a parser that does nothing: the handed-over
- * executor must go unused, AND the sweep must actually be scheduled somewhere.
+ * <p>What it protected, for the record: the executor was the listener's event loop group, whose job
+ * is draining a socket. {@code scheduleAtFixedRate} dispatches by round-robin, so a sweep placed
+ * there could land on the reading thread and turn every execution into a pause in packet reception
+ * — kernel loss on {@code socketDrops} rather than an application error (#457).
  */
 class UdpParserHousekeepingTest {
-
-    @Test
-    void nothingIsScheduledOnTheExecutorTheListenerPasses() {
-        final var poisoned = new PoisonedScheduler();
-        final var parser = parser("poison-check");
-
-        parser.start(poisoned);
-        try {
-            assertThat(poisoned.used)
-                    .as("the listener's event loop group must not be used as a timer")
-                    .isFalse();
-        } finally {
-            parser.stop();
-        }
-    }
 
     @Test
     void housekeepingRunsOnASchedulerTheParserOwns() {
         final var parser = parser("owned-check");
 
-        parser.start(new PoisonedScheduler());
+        parser.start();
         try {
             assertThat(awaitThreads("udp-parser-housekeeping-owned-check"))
-                    .as("the sweep must be scheduled somewhere — without this the guard above "
-                        + "passes on a parser that schedules nothing at all")
+                    .as("the sweep must be scheduled on a thread belonging to this parser")
                     .isNotEmpty();
         } finally {
             parser.stop();
@@ -70,7 +53,7 @@ class UdpParserHousekeepingTest {
     @Test
     void stoppingTwiceIsWellDefined() {
         final var parser = parser("double-stop");
-        parser.start(new PoisonedScheduler());
+        parser.start();
         parser.stop();
 
         assertThatCode(parser::stop).doesNotThrowAnyException();
@@ -110,34 +93,5 @@ class UdpParserHousekeepingTest {
 
     private static UdpParserBase parser(final String name) {
         return new Netflow5UdpParser(name, (source, flows) -> { }, new Identity("t", "o", "z", "s"), new MetricRegistry());
-    }
-
-    /** Fails the test rather than the process: records any use instead of scheduling anything. */
-    private static final class PoisonedScheduler implements ScheduledExecutorService {
-        private volatile boolean used;
-
-        private <T> T poison() {
-            this.used = true;
-            throw new UnsupportedOperationException(
-                    "a parser must own its scheduler, not borrow the listener's event loop group");
-        }
-
-        @Override public ScheduledFuture<?> schedule(Runnable c, long d, TimeUnit u) { return poison(); }
-        @Override public <V> ScheduledFuture<V> schedule(Callable<V> c, long d, TimeUnit u) { return poison(); }
-        @Override public ScheduledFuture<?> scheduleAtFixedRate(Runnable c, long i, long p, TimeUnit u) { return poison(); }
-        @Override public ScheduledFuture<?> scheduleWithFixedDelay(Runnable c, long i, long d, TimeUnit u) { return poison(); }
-        @Override public void execute(Runnable command) { poison(); }
-        @Override public <T> java.util.concurrent.Future<T> submit(Callable<T> task) { return poison(); }
-        @Override public <T> java.util.concurrent.Future<T> submit(Runnable task, T result) { return poison(); }
-        @Override public java.util.concurrent.Future<?> submit(Runnable task) { return poison(); }
-        @Override public <T> List<java.util.concurrent.Future<T>> invokeAll(java.util.Collection<? extends Callable<T>> t) { return poison(); }
-        @Override public <T> List<java.util.concurrent.Future<T>> invokeAll(java.util.Collection<? extends Callable<T>> t, long o, TimeUnit u) { return poison(); }
-        @Override public <T> T invokeAny(java.util.Collection<? extends Callable<T>> t) { return poison(); }
-        @Override public <T> T invokeAny(java.util.Collection<? extends Callable<T>> t, long o, TimeUnit u) { return poison(); }
-        @Override public void shutdown() { poison(); }
-        @Override public List<Runnable> shutdownNow() { return poison(); }
-        @Override public boolean isShutdown() { return false; }
-        @Override public boolean isTerminated() { return false; }
-        @Override public boolean awaitTermination(long timeout, TimeUnit unit) { return poison(); }
     }
 }


### PR DESCRIPTION
Fixes #459

`Parser.start` took a `ScheduledExecutorService` that no implementation used. `ParserBase` ignored it outright and built its own `ThreadPoolExecutor`, `IpfixTcpParser` never overrode `start`, `DispatchingUdpParser` only forwarded it, and #457 gave `UdpParserBase` its own scheduler so it stopped using it too.

It was not merely unused, it was an attractive nuisance. Both listeners passed their event loop group — whose job is draining a socket — so a future implementation that used the argument would have scheduled work there. With `UdpListener`'s group now sized to a single loop that would put the work *directly* on the reading thread, worse than the original bug which only risked it by round-robin. Removing the parameter closes that structurally rather than by comment.

Mechanical and wide: the interface, four implementations, both listener call sites, six test stubs, and eight imports orphaned by the change.

## A deleted test, deliberately

`UdpParserHousekeepingTest` loses its poisoned-executor test, which handed `start()` an executor and asserted nothing was scheduled on it. There is no executor to pass now, so the guard cannot be written and the mistake cannot be made.

Deleting a test is normally lost coverage. Here the hazard became structurally impossible rather than merely watched, which is the only good reason to remove one. The class javadoc records what it protected and why it went, so the deletion does not read as an accident later.

`UdpListenerSchedulerIsolationTest`'s stub no longer schedules, having nothing to schedule on. That test now rests purely on the listener's sizing — its javadoc already said so after #457. Its name has outlived its subject; worth a rename in passing if you'd rather not carry the mismatch.

## Verification

`make jar` — 1001 tests, 0 failures, SpotBugs/Checkstyle/Error Prone clean.

Assisted-by: ClaudeCode:claude-opus-5