### PR TITLE
fix(netflow5): apply the configured sampling fallback to v5 receivers

### DIFF
--- a/docs/docs/configuration/receivers.md
+++ b/docs/docs/configuration/receivers.md
@@ -84,16 +84,37 @@ Until the first table arrives, flows from that exporter are recorded as unsample
 
 IPFIX does not yet get this correlation: its rate is read only from the flow record itself, so an IPFIX exporter that advertises out of band needs the fallback below.
 
+**NetFlow v5 has no options-table mechanism**, so there is nothing for riptide to correlate.
+A v5 exporter states its rate in the packet header instead, in a single 16-bit field holding a 2-bit sampling mode and a 14-bit interval.
+riptide reads the mode from that field and reports it as the sampling algorithm, but **does not yet read the interval** — so a sampling v5 exporter is recorded as unsampled unless you name the rate yourself.
+
 For an exporter that never advertises a rate, name it yourself:
 
 ```properties
 riptide.receivers.nf9.flow-sampling-interval-fallback=1000
 ```
 
-This is a last resort, not an override.
+For NetFlow v9 and IPFIX this is a last resort, not an override.
 What the exporter says always wins: a rate on the flow record first, then the rate from its sampler options table, then this setting, then unsampled.
 An exporter that explicitly reports an interval of 1 has said it does not sample, and that answer stands over the fallback.
+
+For **NetFlow v5** the same setting is the *only* rung above unsampled rather than a last resort, because the rate a v5 exporter states in its header is not yet read.
+It applies to a dedicated `netflow5` receiver and to the v5 half of a `multi` receiver alike:
+
+```properties
+riptide.receivers.nf5.type=netflow5
+riptide.receivers.nf5.flow-sampling-interval-fallback=1000
+```
+
+:::caution
+Because the v5 header interval is not read yet, this setting is applied to v5 flows even when the exporter's header states a mode and an interval of its own.
+For v5 only, the fallback is therefore an override in practice, which is the opposite of how it behaves for v9 and IPFIX.
+If your v5 exporters set the sampling mode bits, check what they advertise before configuring a rate here.
+:::
+
 Note the fallback applies to the whole receiver, so exporters sharing a port share it.
+That matters most for v5, where it is doing all the work: a receiver fronting a mixed fleet gives every v5 exporter behind it the same rate.
+Give exporters that sample at different rates their own receivers and ports.
 
 :::note
 riptide records the sampling rate; it does not scale NetFlow or IPFIX `bytes` and `packets` by it.

--- a/src/main/java/org/riptide/config/ReceiverConfig.java
+++ b/src/main/java/org/riptide/config/ReceiverConfig.java
@@ -56,6 +56,12 @@ public abstract sealed class ReceiverConfig {
     @Data
     @EqualsAndHashCode(callSuper = true)
     public static final class Neflow5Config extends ReceiverConfig {
+        /**
+         * NetFlow v5 has no options-template mechanism to advertise a sampling rate, so unlike v9
+         * and IPFIX this is the only way an operator can state one. Accepting the property here
+         * also stops a dedicated v5 receiver failing startup on a setting its siblings take.
+         */
+        Long flowSamplingIntervalFallback = null;
 
         @Override
         public <T> T accept(final Cases<T> cases) {

--- a/src/main/java/org/riptide/flows/Daemon.java
+++ b/src/main/java/org/riptide/flows/Daemon.java
@@ -99,7 +99,8 @@ public class Daemon implements ApplicationRunner {
                 .map(e -> e.getValue().accept(new ReceiverConfig.Cases<Listener>() {
                     @Override
                     public Listener match(final ReceiverConfig.Neflow5Config config) {
-                        final var parser = new Netflow5UdpParser(e.getKey(), dispatcher, identity, metricRegistry);
+                        final var parser = new Netflow5UdpParser(e.getKey(), dispatcher, identity, metricRegistry)
+                                .withFlowSamplingIntervalFallback(config.getFlowSamplingIntervalFallback());
 
                         return new UdpListener(e.getKey(), parser, metricRegistry)
                                 .withPort(config.getPort())
@@ -164,7 +165,8 @@ public class Daemon implements ApplicationRunner {
                         final var parsers = new HashSet<DispatchableUdpParser>();
 
                         if (config.isNetflow5()) {
-                            parsers.add(new Netflow5UdpParser(e.getKey() + ":netflow5", dispatcher, identity, metricRegistry));
+                            parsers.add(new Netflow5UdpParser(e.getKey() + ":netflow5", dispatcher, identity, metricRegistry)
+                                    .withFlowSamplingIntervalFallback(config.getFlowSamplingIntervalFallback()));
                         }
 
                         if (config.isSflow()) {

--- a/src/main/java/org/riptide/flows/parser/netflow5/Netflow5FlowBuilder.java
+++ b/src/main/java/org/riptide/flows/parser/netflow5/Netflow5FlowBuilder.java
@@ -8,20 +8,36 @@ package org.riptide.flows.parser.netflow5;
 
 import org.riptide.flows.parser.data.Flow;
 import org.riptide.flows.parser.netflow5.proto.Header;
+import org.riptide.flows.parser.netflow5.proto.Packet;
 import org.riptide.flows.parser.netflow5.proto.Record;
 
 import java.net.InetAddress;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.stream.Stream;
 
 public final class Netflow5FlowBuilder {
-    private Netflow5FlowBuilder() {
 
+    /**
+     * The rate an operator declared for this receiver, {@code null} when none is configured.
+     *
+     * <p>NetFlow v5 has no options-template mechanism, so unlike v9 there is no rung between the
+     * exporter and this one: whatever the exporter cannot say, only configuration can.
+     */
+    private Long flowSamplingIntervalFallback;
+
+    public void setFlowSamplingIntervalFallback(final Long flowSamplingIntervalFallback) {
+        this.flowSamplingIntervalFallback = flowSamplingIntervalFallback;
     }
 
-    public static Flow buildFlow(final Instant receivedAt,
-                                 final Header header,
-                                 final Record record) {
+    public Stream<Flow> buildFlows(final Instant receivedAt, final Packet packet) {
+        return packet.records.stream()
+                .map(record -> buildFlow(receivedAt, packet.header, record));
+    }
+
+    public Flow buildFlow(final Instant receivedAt,
+                          final Header header,
+                          final Record record) {
 
         final var timestamp = Instant.ofEpochSecond(header.unixSecs, header.unixNSecs);
         final var bootTime = timestamp.minus(header.sysUptime, ChronoUnit.MILLIS);
@@ -178,10 +194,29 @@ public final class Netflow5FlowBuilder {
                 };
             }
 
+            /**
+             * What the operator configured, then unsampled. NetFlow v5 exporters cannot advertise
+             * a rate out of band the way v9 does, so this receiver-wide setting is the only rung
+             * above the default — until the packet header is read as well.
+             */
             @Override
             public double getSamplingInterval() {
-                return 1.0;
+                final Double configured = usable(asDouble(flowSamplingIntervalFallback));
+                return configured != null ? configured : 1.0;
             }
         };
+    }
+
+    /**
+     * A rate counts as an answer when it is present and finite, including an explicit 1: an
+     * operator configuring 1 has stated this receiver's exporters do not sample. Only absent,
+     * 0 and non-finite fall through to the next rung. Mirrors {@code Netflow9FlowBuilder}.
+     */
+    private static Double usable(final Double interval) {
+        return interval != null && Double.isFinite(interval) && interval >= 1.0 ? interval : null;
+    }
+
+    private static Double asDouble(final Long value) {
+        return value != null ? value.doubleValue() : null;
     }
 }

--- a/src/main/java/org/riptide/flows/parser/netflow5/Netflow5UdpParser.java
+++ b/src/main/java/org/riptide/flows/parser/netflow5/Netflow5UdpParser.java
@@ -22,12 +22,16 @@ import org.riptide.pipeline.Identity;
 import org.riptide.pipeline.Source;
 
 import java.net.InetSocketAddress;
+import java.time.Instant;
 import java.util.List;
 import java.util.function.BiConsumer;
+import java.util.stream.Stream;
 
 import static org.riptide.flows.utils.BufferUtils.slice;
 
 public class Netflow5UdpParser extends UdpParserBase implements DispatchableUdpParser {
+
+    private final Netflow5FlowBuilder flowBuilder = new Netflow5FlowBuilder();
 
     public Netflow5UdpParser(final String name,
                              final BiConsumer<Source, List<Flow>> dispatcher,
@@ -45,7 +49,34 @@ public class Netflow5UdpParser extends UdpParserBase implements DispatchableUdpP
     protected FlowPacket parse(final Session session,
                                final ByteBuf buffer) throws Exception {
         final Header header = new Header(slice(buffer, Header.SIZE));
-        return new Packet(header, buffer);
+        final Packet packet = new Packet(header, buffer);
+
+        return new FlowPacket() {
+            @Override
+            public Stream<Flow> buildFlows(final Instant receivedAt) {
+                return flowBuilder.buildFlows(receivedAt, packet);
+            }
+
+            @Override
+            public long getObservationDomainId() {
+                return packet.getObservationDomainId();
+            }
+
+            @Override
+            public long getSequenceNumber() {
+                return packet.getSequenceNumber();
+            }
+
+            @Override
+            public int getSequenceIncrement() {
+                return packet.getSequenceIncrement();
+            }
+        };
+    }
+
+    public Netflow5UdpParser withFlowSamplingIntervalFallback(final Long flowSamplingIntervalFallback) {
+        this.flowBuilder.setFlowSamplingIntervalFallback(flowSamplingIntervalFallback);
+        return this;
     }
 
     @Override

--- a/src/main/java/org/riptide/flows/parser/netflow5/proto/Packet.java
+++ b/src/main/java/org/riptide/flows/parser/netflow5/proto/Packet.java
@@ -8,20 +8,21 @@ package org.riptide.flows.parser.netflow5.proto;
 import com.google.common.base.MoreObjects;
 import io.netty.buffer.ByteBuf;
 import org.riptide.flows.parser.exceptions.InvalidPacketException;
-import org.riptide.flows.parser.data.Flow;
-import org.riptide.flows.parser.FlowPacket;
-import org.riptide.flows.parser.netflow5.Netflow5FlowBuilder;
 
-import java.time.Instant;
 import java.util.Iterator;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Stream;
 
 import static org.riptide.flows.utils.BufferUtils.slice;
 
-public final class Packet implements Iterable<Record>, FlowPacket {
+/**
+ * The decoded wire representation, with no opinion on how flows are built from it.
+ *
+ * <p>Flow construction lives in {@code Netflow5FlowBuilder}, which the parser holds so that
+ * receiver settings can reach it — the same split NetFlow v9 and IPFIX already use.
+ */
+public final class Packet implements Iterable<Record> {
 
     public final Header header;
 
@@ -51,24 +52,15 @@ public final class Packet implements Iterable<Record>, FlowPacket {
         return this.records.iterator();
     }
 
-    @Override
-    public Stream<Flow> buildFlows(final Instant receivedAt) {
-        return this.records.stream()
-                .map(record -> Netflow5FlowBuilder.buildFlow(receivedAt, this.header, record));
-    }
-
-    @Override
     public long getObservationDomainId() {
         // parenthesized: '+' binds tighter than '<<', which used to shift by (8 + engineId)
         return (((long) this.header.engineType) << 8) + ((long) this.header.engineId);
     }
 
-    @Override
     public long getSequenceNumber() {
         return this.header.flowSequence;
     }
 
-    @Override
     public int getSequenceIncrement() {
         // NetFlow v5 sequence numbers count flows
         return this.records.size();

--- a/src/test/java/org/riptide/config/DaemonConfigTest.java
+++ b/src/test/java/org/riptide/config/DaemonConfigTest.java
@@ -117,6 +117,36 @@ class DaemonConfigTest {
         assertThat(nf9.getFlowSamplingIntervalFallback()).isEqualTo(100L);
     }
 
+    /**
+     * NetFlow v5 cannot advertise a sampling rate out of band, so the configured fallback is the
+     * only way to state one. Before this bound, the property threw {@code BindException} and took
+     * startup with it, leaving a sampling v5 exporter with no supported way to be corrected.
+     */
+    @Test
+    void netflow5ReceiverBindsSamplingIntervalFallback() {
+        final var config = bind(Map.of(
+                "riptide.receivers.nf5.type", "netflow5",
+                "riptide.receivers.nf5.port", "2055",
+                "riptide.receivers.nf5.flow-sampling-interval-fallback", "1000"));
+
+        final var receiver = config.getReceivers().get("nf5");
+        assertThat(receiver).isInstanceOf(ReceiverConfig.Neflow5Config.class);
+        final var nf5 = (ReceiverConfig.Neflow5Config) receiver;
+        assertThat(nf5.getPort()).isEqualTo(2055);
+        assertThat(nf5.getFlowSamplingIntervalFallback()).isEqualTo(1000L);
+    }
+
+    /** Unset stays null, so the builder can tell "not configured" from a configured 1. */
+    @Test
+    void netflow5SamplingIntervalFallbackDefaultsToUnset() {
+        final var config = bind(Map.of(
+                "riptide.receivers.nf5.type", "netflow5",
+                "riptide.receivers.nf5.port", "2055"));
+
+        final var nf5 = (ReceiverConfig.Neflow5Config) config.getReceivers().get("nf5");
+        assertThat(nf5.getFlowSamplingIntervalFallback()).isNull();
+    }
+
     /** Relaxed binding: the camelCase spelling that used to be the only one accepted still works. */
     @Test
     void receiverBindsCamelCaseKeysAndIsoDurations() {

--- a/src/test/java/org/riptide/flows/Netflow5SamplingFallbackTest.java
+++ b/src/test/java/org/riptide/flows/Netflow5SamplingFallbackTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.codahale.metrics.MetricRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.riptide.config.DaemonConfig;
+import org.riptide.flows.parser.data.Flow;
+import org.riptide.flows.parser.ie.values.ValueConversionService;
+import org.riptide.flows.parser.session.ExporterSamplingTable;
+import org.riptide.pipeline.Pipeline;
+import org.riptide.pipeline.Source;
+import org.riptide.snmp.ExporterInterfaceTable;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.DefaultApplicationArguments;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@code flow-sampling-interval-fallback} must reach NetFlow v5, on every receiver that accepts v5.
+ *
+ * <p>These assertions are made against a running {@link Daemon} rather than against the flow builder
+ * because the defect was in the wiring, not the resolution: {@code Daemon} constructed the v5 parser
+ * without the setting while passing the same {@code MultiConfig} value to the v9 and IPFIX parsers
+ * beside it. A builder-level test would have stayed green throughout.
+ *
+ * <p>The v5 half of a {@code multi} receiver is the case that failed silently. A dedicated
+ * {@code netflow5} receiver failed loudly instead — the property did not bind at all and startup
+ * aborted — so the first test here also pins that the property is merely accepted.
+ */
+class Netflow5SamplingFallbackTest {
+
+    /** Sampling word {@code 0x0000}: this exporter advertises nothing, so only configuration can speak. */
+    private static final String UNSAMPLED_CAPTURE = "/flows/netflow5.dat";
+
+    private static final Pattern LISTENING =
+            Pattern.compile("listening on UDP 127\\.0\\.0\\.1:(\\d+)");
+
+    private Logger logger;
+    private ListAppender<ILoggingEvent> appender;
+    private Level originalLevel;
+
+    @BeforeEach
+    void captureDaemonLog() {
+        this.logger = (Logger) LoggerFactory.getLogger(Daemon.class);
+        this.originalLevel = this.logger.getLevel();
+        // The bound port is only discoverable from this line, so the level must not be inherited.
+        this.logger.setLevel(Level.INFO);
+        this.appender = new ListAppender<>();
+        this.appender.start();
+        this.logger.addAppender(this.appender);
+    }
+
+    @AfterEach
+    void releaseDaemonLog() {
+        this.logger.detachAppender(this.appender);
+        this.appender.stop();
+        this.logger.setLevel(this.originalLevel);
+    }
+
+    @Test
+    void dedicatedNetflow5ReceiverAppliesTheConfiguredFallback() throws Exception {
+        final var flows = flowsFromDaemonConfigured(Map.of(
+                "riptide.receivers.nf5.type", "netflow5",
+                "riptide.receivers.nf5.host", "127.0.0.1",
+                "riptide.receivers.nf5.port", "0",
+                "riptide.receivers.nf5.flow-sampling-interval-fallback", "1000"));
+
+        assertThat(flows)
+                .as("a v5 receiver must honour the only rate setting v5 has")
+                .isNotEmpty()
+                .allSatisfy(flow -> assertThat(flow.getSamplingInterval()).isEqualTo(1000.0));
+    }
+
+    /**
+     * The regression this change exists to close. On {@code main} the v5 parser is constructed at
+     * {@code Daemon} without the fallback while v9 and IPFIX beside it receive the same value, so
+     * this asserted 1.0 and nothing anywhere reported that half the configuration was inert.
+     */
+    @Test
+    void multiReceiverAppliesTheConfiguredFallbackToNetflow5() throws Exception {
+        final var flows = flowsFromDaemonConfigured(Map.of(
+                "riptide.receivers.mixed.type", "multi",
+                "riptide.receivers.mixed.host", "127.0.0.1",
+                "riptide.receivers.mixed.port", "0",
+                "riptide.receivers.mixed.flow-sampling-interval-fallback", "1000"));
+
+        assertThat(flows)
+                .as("v5 shares the receiver's fallback with v9 and IPFIX, not a private default")
+                .isNotEmpty()
+                .allSatisfy(flow -> assertThat(flow.getSamplingInterval()).isEqualTo(1000.0));
+    }
+
+    @Test
+    void withoutAConfiguredFallbackNetflow5StaysUnsampled() throws Exception {
+        final var flows = flowsFromDaemonConfigured(Map.of(
+                "riptide.receivers.nf5.type", "netflow5",
+                "riptide.receivers.nf5.host", "127.0.0.1",
+                "riptide.receivers.nf5.port", "0"));
+
+        assertThat(flows)
+                .as("no exporter rate and no configured rate means unsampled")
+                .isNotEmpty()
+                .allSatisfy(flow -> assertThat(flow.getSamplingInterval()).isEqualTo(1.0));
+    }
+
+    /**
+     * A configured 1 is an answer, not an absent value. It states this receiver's exporters do not
+     * sample, and must survive the same {@code usable()} check that discards 0.
+     */
+    @Test
+    void aConfiguredFallbackOfOneIsHonoured() throws Exception {
+        final var flows = flowsFromDaemonConfigured(Map.of(
+                "riptide.receivers.nf5.type", "netflow5",
+                "riptide.receivers.nf5.host", "127.0.0.1",
+                "riptide.receivers.nf5.port", "0",
+                "riptide.receivers.nf5.flow-sampling-interval-fallback", "1"));
+
+        assertThat(flows)
+                .isNotEmpty()
+                .allSatisfy(flow -> assertThat(flow.getSamplingInterval()).isEqualTo(1.0));
+    }
+
+    /** Starts a daemon on an ephemeral port, sends one v5 capture at it, and returns what it built. */
+    private List<Flow> flowsFromDaemonConfigured(final Map<String, Object> properties) throws Exception {
+        final var pipeline = Mockito.mock(Pipeline.class);
+        final var daemon = daemon(properties, pipeline);
+
+        try {
+            daemon.run(new DefaultApplicationArguments());
+            send(boundPort(), payload());
+            return awaitDispatchedFlows(pipeline);
+        } finally {
+            daemon.stop();
+        }
+    }
+
+    private static byte[] payload() throws Exception {
+        final var url = Netflow5SamplingFallbackTest.class.getResource(UNSAMPLED_CAPTURE);
+        return Files.readAllBytes(Paths.get(url.toURI()));
+    }
+
+    private static void send(final int port, final byte[] payload) throws Exception {
+        try (var socket = new DatagramSocket()) {
+            socket.send(new DatagramPacket(
+                    payload, payload.length, InetAddress.getByName("127.0.0.1"), port));
+        }
+    }
+
+    /** The kernel picked the port, so the startup log is the only place it is stated. */
+    private int boundPort() {
+        return this.appender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .map(LISTENING::matcher)
+                .filter(java.util.regex.Matcher::find)
+                .map(matcher -> Integer.parseInt(matcher.group(1)))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "no receiver reported a bound port; log was " + this.appender.list));
+    }
+
+    /** Ingest is asynchronous, so poll rather than assume the packet has been handled on return. */
+    @SuppressWarnings("unchecked")
+    private static List<Flow> awaitDispatchedFlows(final Pipeline pipeline) throws Exception {
+        final var captor = ArgumentCaptor.forClass(List.class);
+        final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+
+        while (System.nanoTime() < deadline) {
+            try {
+                Mockito.verify(pipeline, Mockito.atLeastOnce())
+                        .process(Mockito.any(Source.class), captor.capture());
+                return (List<Flow>) captor.getValue();
+            } catch (final AssertionError notYet) {
+                Thread.sleep(25);
+            }
+        }
+        throw new AssertionError("no flows reached the pipeline within 10s");
+    }
+
+    private Daemon daemon(final Map<String, Object> properties, final Pipeline pipeline) {
+        final var config = new Binder(new MapConfigurationPropertySource(properties))
+                .bind("riptide", DaemonConfig.class)
+                .orElseGet(DaemonConfig::new);
+        return new Daemon(
+                pipeline,
+                new MetricRegistry(),
+                Mockito.mock(ValueConversionService.class),
+                Mockito.mock(ValueConversionService.class),
+                Mockito.mock(ExporterInterfaceTable.class),
+                Mockito.mock(ExporterSamplingTable.class),
+                config);
+    }
+}

--- a/src/test/java/org/riptide/flows/fuzz/Netflow5ParserFuzzTest.java
+++ b/src/test/java/org/riptide/flows/fuzz/Netflow5ParserFuzzTest.java
@@ -7,6 +7,7 @@ package org.riptide.flows.fuzz;
 
 import com.code_intelligence.jazzer.junit.FuzzTest;
 import io.netty.buffer.ByteBuf;
+import org.riptide.flows.parser.netflow5.Netflow5FlowBuilder;
 import org.riptide.flows.parser.netflow5.proto.Header;
 import org.riptide.flows.parser.netflow5.proto.Packet;
 
@@ -31,7 +32,7 @@ class Netflow5ParserFuzzTest {
             final Header header = new Header(slice(buffer, Header.SIZE));
             final Packet packet = new Packet(header, buffer);
             // Terminate the lazy stream so the record field decode actually runs.
-            packet.buildFlows(Instant.EPOCH).forEach(flow -> { });
+            new Netflow5FlowBuilder().buildFlows(Instant.EPOCH, packet).forEach(flow -> { });
         } catch (final Throwable t) {
             if (!FuzzSupport.isDesignedRejection(t)) {
                 throw t;

--- a/src/test/java/org/riptide/flows/netflow5/Netflow5ConverterTest.java
+++ b/src/test/java/org/riptide/flows/netflow5/Netflow5ConverterTest.java
@@ -11,6 +11,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.riptide.flows.parser.exceptions.InvalidPacketException;
 import org.riptide.flows.parser.data.Flow;
+import org.riptide.flows.parser.netflow5.Netflow5FlowBuilder;
 import org.riptide.flows.parser.netflow5.proto.Header;
 import org.riptide.flows.parser.netflow5.proto.Packet;
 
@@ -76,7 +77,7 @@ public class Netflow5ConverterTest {
             final ByteBuf buffer = Unpooled.wrappedBuffer(payload);
             final Header header = new Header(slice(buffer, Header.SIZE));
             final Packet packet = new Packet(header, buffer);
-            flows.addAll(packet.buildFlows(Instant.EPOCH).toList());
+            flows.addAll(new Netflow5FlowBuilder().buildFlows(Instant.EPOCH, packet).toList());
         }
         return flows;
     }


### PR DESCRIPTION
`flow-sampling-interval-fallback` never reached NetFlow v5. This is the first of two changes splitting #445; it is deliberately the half that carries **no behavioural flip**, so it can land on normal review timing.

## The defect has two faces

| receiver | before | |
|---|---|---|
| dedicated `netflow5` | `BindException`, daemon will not start | loud, but leaves no way to declare a rate for v5 |
| `multi` | binds cleanly, then dropped for v5 only | silent |

`MultiConfig` already carries `flowSamplingIntervalFallback`, and `Daemon` passed it to the v9 and IPFIX parsers standing beside the v5 one:

```java
parsers.add(new Netflow5UdpParser(...));                                          // dropped
    .withFlowSamplingIntervalFallback(config.getFlowSamplingIntervalFallback())   // v9
    .withFlowSamplingIntervalFallback(config.getFlowSamplingIntervalFallback());  // ipfix
```

Nothing logged it, and flows carry a plausible `1.0` whether the setting was applied or ignored. Because the dedicated spelling hard-failed, an operator trying the obvious thing first was pushed toward the `multi` receiver — the one path where the value was accepted and then did nothing.

## What changed

- `Neflow5Config` gains `flowSamplingIntervalFallback`; `Netflow5UdpParser` gains the builder method; `Daemon` passes it on both paths.
- `Netflow5FlowBuilder` becomes an instance, and `proto.Packet` becomes pure wire data with flow construction moved behind the parser. This mirrors the split NetFlow v9 and IPFIX already use, and it is the seam the header sampling rate attaches to next.

## Verification

`mvn verify` green — 1008 tests, SpotBugs 0, checkstyle, Error Prone and coverage gates clean.

The regression test was proven rather than assumed: reverting the `Daemon` multi wiring makes `multiReceiverAppliesTheConfiguredFallbackToNetflow5` fail with `expected: 1000.0 but was: 1.0`. The four new tests run against a live `Daemon` on an ephemeral port rather than against the builder, because the defect was in the wiring — a builder-level test would have stayed green throughout.

## Known gap, carried deliberately

The v5 header already states a sampling rate and riptide still does not read it. Until it does, this setting is applied to v5 flows **even when the exporter's header states a mode and interval of its own** — so for v5 alone the fallback is an override in practice, the opposite of how it behaves for v9 and IPFIX. Flows from such exporters recorded `1.0` before this change, so nothing regresses, but the contradiction is real and is documented as a caution in `receivers.md`.

Reading the header is the second change and closes #445. Note the mode-set case carries none of the ambiguity that deferred that work: when the mode bits are set the interval is unambiguous, and only mode-0-with-a-non-zero-interval is contested.

Refs #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)