### PR TITLE
feat(netflow5): read the sampling rate the v5 header already carries

### DIFF
--- a/docs/docs/configuration/receivers.md
+++ b/docs/docs/configuration/receivers.md
@@ -86,7 +86,20 @@ IPFIX does not yet get this correlation: its rate is read only from the flow rec
 
 **NetFlow v5 has no options-table mechanism**, so there is nothing for riptide to correlate.
 A v5 exporter states its rate in the packet header instead, in a single 16-bit field holding a 2-bit sampling mode and a 14-bit interval.
-riptide reads the mode from that field and reports it as the sampling algorithm, but **does not yet read the interval** — so a sampling v5 exporter is recorded as unsampled unless you name the rate yourself.
+riptide reads both, so a sampling v5 exporter is recorded correctly without configuration.
+
+An interval of zero means the exporter is not sampling.
+The mode bits do not carry that meaning: many exporters that sample leave them at zero and populate the interval anyway, because the mode is not a mandatory field — pmacct's own NetFlow v5 exporter never sets it.
+riptide therefore reads a non-zero interval as a rate whether or not the mode is set, which is what nfdump, pmacct, goflow2 and Akvorado all do.
+
+If you need the old behaviour, where the header interval was ignored:
+
+```properties
+riptide.receivers.nf5.trust-header-sampling-interval=false
+```
+
+This governs only the ambiguous case, where the exporter gives an interval but leaves the mode bits at zero.
+A header that states a mode *and* an interval is unambiguous and is always read, so turning this off cannot make riptide ignore an exporter that signalled properly.
 
 For an exporter that never advertises a rate, name it yourself:
 
@@ -98,7 +111,7 @@ For NetFlow v9 and IPFIX this is a last resort, not an override.
 What the exporter says always wins: a rate on the flow record first, then the rate from its sampler options table, then this setting, then unsampled.
 An exporter that explicitly reports an interval of 1 has said it does not sample, and that answer stands over the fallback.
 
-For **NetFlow v5** the same setting is the *only* rung above unsampled rather than a last resort, because the rate a v5 exporter states in its header is not yet read.
+The same holds for **NetFlow v5**, where the rung above the fallback is the packet header rather than an options table.
 It applies to a dedicated `netflow5` receiver and to the v5 half of a `multi` receiver alike:
 
 ```properties
@@ -106,23 +119,42 @@ riptide.receivers.nf5.type=netflow5
 riptide.receivers.nf5.flow-sampling-interval-fallback=1000
 ```
 
-:::caution
-Because the v5 header interval is not read yet, this setting is applied to v5 flows even when the exporter's header states a mode and an interval of its own.
-For v5 only, the fallback is therefore an override in practice, which is the opposite of how it behaves for v9 and IPFIX.
-If your v5 exporters set the sampling mode bits, check what they advertise before configuring a rate here.
-:::
+Use it for a v5 exporter that samples but leaves the header field at zero, which older firmware does.
 
 Note the fallback applies to the whole receiver, so exporters sharing a port share it.
-That matters most for v5, where it is doing all the work: a receiver fronting a mixed fleet gives every v5 exporter behind it the same rate.
-Give exporters that sample at different rates their own receivers and ports.
+Give exporters that sample at different rates their own receivers and ports, unless they state their rates in the header — in which case each is read individually and the fallback never comes up.
+
+:::warning[NetFlow v5 rates changed]
+Earlier releases ignored the v5 header interval and recorded every v5 flow as unsampled (`samplingInterval = 1`).
+Flows from an exporter that advertises a rate now carry that rate instead.
+
+Nothing about stored `bytes` and `packets` changes, and no query breaks — but a query that multiplies by `samplingInterval` will return a different, larger and more correct answer for v5 rows written after the upgrade.
+Rows written before it are not rewritten, because correcting them would need each exporter's rate at each past moment, which is exactly what was never recorded.
+A query spanning the upgrade therefore mixes both, and the earlier rows under-report by each exporter's true rate.
+
+Find which exporters are affected, and when each flipped:
+
+```sql
+SELECT exporterAddr, samplingInterval, min(timestamp), max(timestamp)
+FROM flows
+WHERE flowProtocol = 'NetflowV5' AND samplingInterval != 1
+GROUP BY exporterAddr, samplingInterval
+```
+
+**If you compensated for this by hardcoding a multiplier** in a dashboard or query — because you knew riptide under-reported these exporters — remove it, or you will now double-count.
+
+To keep the previous behaviour while you correct queries, set `trust-header-sampling-interval=false` on the affected receivers.
+:::
 
 :::note
 riptide records the sampling rate; it does not scale NetFlow or IPFIX `bytes` and `packets` by it.
 Stored counters are what the exporter reported, and the rate sits alongside them for a query to apply.
 
-Two things to know before writing that query.
+Three things to know before writing that query.
 sFlow already scales at ingest (`bytes = frame_length × sampling_rate`) and still reports its rate, so multiplying sFlow rows again double-counts them: filter them out, or restrict the query to NetFlow and IPFIX.
-And the 1-minute rollups carry neither the rate nor a scaled measure, so `SUM(bytes * samplingInterval)` only means anything against the raw `flows` table.
+The 1-minute rollups carry neither the rate nor a scaled measure, so `SUM(bytes * samplingInterval)` only means anything against the raw `flows` table.
+And if you are coming from **nfdump or pmacct**, note that both multiply NetFlow v5 `bytes` and `packets` by the rate at ingest, where riptide does not.
+Counters that arrive here are unscaled, so a query ported from either will need the multiplication added rather than removed.
 :::
 
 ## Exporter identity

--- a/docs/docs/configuration/receivers.md
+++ b/docs/docs/configuration/receivers.md
@@ -88,9 +88,9 @@ IPFIX does not yet get this correlation: its rate is read only from the flow rec
 A v5 exporter states its rate in the packet header instead, in a single 16-bit field holding a 2-bit sampling mode and a 14-bit interval.
 riptide reads both, so a sampling v5 exporter is recorded correctly without configuration.
 
-An interval of zero means the exporter is not sampling.
-The mode bits do not carry that meaning: many exporters that sample leave them at zero and populate the interval anyway, because the mode is not a mandatory field — pmacct's own NetFlow v5 exporter never sets it.
-riptide therefore reads a non-zero interval as a rate whether or not the mode is set, which is what nfdump, pmacct, goflow2 and Akvorado all do.
+An interval of zero states no rate, and riptide records such a flow as unsampled unless a fallback is configured below.
+The mode bits do not carry that meaning: many exporters that sample leave them at zero and populate the interval anyway, because the mode is not a mandatory field — pmacct's NetFlow v5 exporter never sets it.
+riptide therefore reads a non-zero interval as a rate whether or not the mode is set, as nfdump, pmacct, goflow2 and Akvorado do.
 
 If you need the old behaviour, where the header interval was ignored:
 
@@ -98,8 +98,12 @@ If you need the old behaviour, where the header interval was ignored:
 riptide.receivers.nf5.trust-header-sampling-interval=false
 ```
 
-This governs only the ambiguous case, where the exporter gives an interval but leaves the mode bits at zero.
-A header that states a mode *and* an interval is unambiguous and is always read, so turning this off cannot make riptide ignore an exporter that signalled properly.
+This setting exists only on `netflow5` and `multi` receivers.
+Setting it on a `netflow9`, `ipfix` or `sflow` receiver fails startup, because riptide rejects properties a receiver does not define.
+
+It governs only the ambiguous case: an interval given with the mode bits set to something other than 1 (deterministic) or 2 (random).
+A header stating mode 1 or 2 *together with* a non-zero interval is unambiguous and always read, so turning this off cannot make riptide ignore an exporter that signalled properly.
+A mode with a zero interval names a method and no rate, so it is not affected either way — the fallback below supplies the number.
 
 For an exporter that never advertises a rate, name it yourself:
 
@@ -148,8 +152,8 @@ More than one row per `exporterAddr` means that exporter's recorded rate changed
 
 **If you compensated for this by hardcoding a multiplier** in a dashboard or query — because you knew riptide was not reading these exporters' rates — remove it, or you will now double-count.
 
-To pin the old behaviour while you correct queries, set `trust-header-sampling-interval=false` on the affected receivers.
-Note this only suppresses the header for exporters that leave the mode bits at zero; an exporter that states a mode is always read, so for those the old value cannot be restored by configuration.
+To pin the old behaviour while you correct queries, set `trust-header-sampling-interval=false` on the affected **`netflow5` and `multi`** receivers — it is not accepted on other receiver types and will fail startup there.
+Note this only suppresses the header for exporters that leave the mode bits unset; an exporter stating mode 1 or 2 with a rate is always read, so for those the old value cannot be restored by configuration.
 Set `flow-sampling-interval-fallback` to the value you were relying on if you need a specific rate recorded.
 :::
 
@@ -160,8 +164,9 @@ Stored counters are what the exporter reported, and the rate sits alongside them
 Three things to know before writing that query.
 sFlow already scales at ingest (`bytes = frame_length × sampling_rate`) and still reports its rate, so multiplying sFlow rows again double-counts them: filter them out, or restrict the query to NetFlow and IPFIX.
 The 1-minute rollups carry neither the rate nor a scaled measure, so `SUM(bytes * samplingInterval)` only means anything against the raw `flows` table.
-And if you are coming from **nfdump or pmacct**, note that both multiply NetFlow v5 `bytes` and `packets` by the rate at ingest, where riptide does not.
-Counters that arrive here are unscaled, so a query ported from either will need the multiplication added rather than removed.
+And if you are coming from **nfdump or pmacct**, check whether counters were being scaled for you.
+Both can multiply NetFlow v5 `bytes` and `packets` by the sampling rate at ingest (in pmacct via `nfacctd_renormalize`, in nfdump depending on how sampling was detected or forced with `-s`), where riptide never does.
+Counters stored here are always as the exporter reported them, so a query ported from either may need the multiplication added rather than removed.
 :::
 
 ## Exporter identity

--- a/docs/docs/configuration/receivers.md
+++ b/docs/docs/configuration/receivers.md
@@ -125,25 +125,32 @@ Note the fallback applies to the whole receiver, so exporters sharing a port sha
 Give exporters that sample at different rates their own receivers and ports, unless they state their rates in the header — in which case each is read individually and the fallback never comes up.
 
 :::warning[NetFlow v5 rates changed]
-Earlier releases ignored the v5 header interval and recorded every v5 flow as unsampled (`samplingInterval = 1`).
-Flows from an exporter that advertises a rate now carry that rate instead.
+Earlier releases ignored the v5 header interval. What they recorded instead depended on the receiver:
 
-Nothing about stored `bytes` and `packets` changes, and no query breaks — but a query that multiplies by `samplingInterval` will return a different, larger and more correct answer for v5 rows written after the upgrade.
-Rows written before it are not rewritten, because correcting them would need each exporter's rate at each past moment, which is exactly what was never recorded.
-A query spanning the upgrade therefore mixes both, and the earlier rows under-report by each exporter's true rate.
+- **No fallback configured** — every v5 flow was recorded as unsampled, `samplingInterval = 1`. Flows from an exporter that advertises a rate now carry that rate, so a query multiplying by `samplingInterval` returns a **larger** and more correct answer.
+- **`flow-sampling-interval-fallback` configured** — every v5 flow carried the configured value, whatever the exporter said. The exporter's own rate now wins, so the recorded value can move in **either** direction. An exporter advertising 1:20 behind a receiver configured for 1000 drops from 1000 to 20, and a query multiplying by the rate returns an answer 50× smaller than before — and correct, where the old one was not.
 
-Find which exporters are affected, and when each flipped:
+Stored `bytes` and `packets` are unchanged either way, and no query errors.
+
+Rows written before the upgrade are not rewritten: correcting them would need each exporter's rate at each past moment, which is exactly what was never recorded. A query spanning the upgrade mixes both conventions.
+
+Find which exporters now report a rate, and when each changed:
 
 ```sql
 SELECT exporterAddr, samplingInterval, min(timestamp), max(timestamp)
 FROM flows
-WHERE flowProtocol = 'NetflowV5' AND samplingInterval != 1
+WHERE flowProtocol = 'NetflowV5'
 GROUP BY exporterAddr, samplingInterval
+ORDER BY exporterAddr, min(timestamp)
 ```
 
-**If you compensated for this by hardcoding a multiplier** in a dashboard or query — because you knew riptide under-reported these exporters — remove it, or you will now double-count.
+More than one row per `exporterAddr` means that exporter's recorded rate changed, and the `min(timestamp)` of the later row is when.
 
-To keep the previous behaviour while you correct queries, set `trust-header-sampling-interval=false` on the affected receivers.
+**If you compensated for this by hardcoding a multiplier** in a dashboard or query — because you knew riptide was not reading these exporters' rates — remove it, or you will now double-count.
+
+To pin the old behaviour while you correct queries, set `trust-header-sampling-interval=false` on the affected receivers.
+Note this only suppresses the header for exporters that leave the mode bits at zero; an exporter that states a mode is always read, so for those the old value cannot be restored by configuration.
+Set `flow-sampling-interval-fallback` to the value you were relying on if you need a specific rate recorded.
 :::
 
 :::note

--- a/docs/docs/deploy/operations.md
+++ b/docs/docs/deploy/operations.md
@@ -75,6 +75,14 @@ Upgrading to 0.7.0 also changes what one **metric** means rather than any config
 [Parser gauges: exporters and templates](#parser-gauges-exporters-and-templates) before relying on
 `parsers.<name>.sessionCount`.
 
+**NetFlow v5 sampling rates change on upgrade.** riptide now reads the sampling rate a v5 exporter
+states in its packet header, where it previously ignored it. Stored `bytes` and `packets` are
+untouched and nothing fails, but any query multiplying by `samplingInterval` returns a different
+answer for v5 rows written from here on, and older rows are not rewritten. Watch
+`parsers.<name>.samplingRate.header` to see which receivers are now resolving from the header. Full
+detail, including how to identify affected exporters and how to pin the old behaviour, is in
+[Sampling rate](../configuration/receivers.md#sampling-rate).
+
 ## Ingest loss counters
 
 Flows can be dropped at two bounded queues, and each one counts what it discards — nothing is
@@ -138,6 +146,25 @@ Two gauges describe what a UDP parser is holding. They are easy to confuse, and 
 |---|---|
 | `parsers.<name>.sessionCount` | exporters — one per `(session, observation domain)` pair |
 | `parsers.<name>.templateCount` | templates held across all exporters |
+
+## NetFlow v5 sampling rate resolution
+
+NetFlow v5 has no options table, so a v5 flow's sampling rate resolves from the packet header, then
+the receiver's `flow-sampling-interval-fallback`, then unsampled. Which rung answered is metered per
+**packet** (the rate lives in the header, so every record in a packet resolves identically) and per
+receiver.
+
+| Metric | Meaning |
+|---|---|
+| `parsers.<name>.samplingRate.header` | packets whose rate came from the exporter's header |
+| `parsers.<name>.samplingRate.fallback` | packets that fell through to the configured rate |
+| `parsers.<name>.samplingRate.unsampled` | packets with no rate anywhere, recorded as `1` |
+
+These exist because the resolution is invisible in the data path: riptide records the rate without
+applying it, so an exporter that starts or stops advertising changes no counter and raises no error.
+A `header` rate that falls to zero means a fleet stopped advertising and is now being recorded as
+unsampled — or on the configured rate, which may not match. See
+[Sampling rate](../configuration/receivers.md#sampling-rate) for the resolution order and settings.
 
 **What changed in 0.7.0.** `sessionCount` used to report the **template** total, so it overstated by
 however many templates each exporter announces. It now reports `(session, observation domain)` pairs.

--- a/src/main/java/org/riptide/config/ReceiverConfig.java
+++ b/src/main/java/org/riptide/config/ReceiverConfig.java
@@ -63,6 +63,15 @@ public abstract sealed class ReceiverConfig {
          */
         Long flowSamplingIntervalFallback = null;
 
+        /**
+         * Whether a header stating algorithm 0 alongside a non-zero interval is read as a rate.
+         *
+         * <p>Governs that case only. A header stating algorithm 1 or 2 is unambiguous and is always
+         * read, so disabling this does not let a configured fallback override an exporter that
+         * signalled its mode properly.
+         */
+        boolean trustHeaderSamplingInterval = true;
+
         @Override
         public <T> T accept(final Cases<T> cases) {
             return cases.match(this);
@@ -123,6 +132,9 @@ public abstract sealed class ReceiverConfig {
         Duration flowActiveTimeoutFallback = null;
         Duration flowInactiveTimeoutFallback = null;
         Long flowSamplingIntervalFallback = null;
+
+        /** NetFlow v5 only; see {@link Neflow5Config#trustHeaderSamplingInterval}. */
+        boolean trustHeaderSamplingInterval = true;
 
         @Override
         public <T> T accept(final Cases<T> cases) {

--- a/src/main/java/org/riptide/config/ReceiverConfig.java
+++ b/src/main/java/org/riptide/config/ReceiverConfig.java
@@ -64,11 +64,11 @@ public abstract sealed class ReceiverConfig {
         Long flowSamplingIntervalFallback = null;
 
         /**
-         * Whether a header stating algorithm 0 alongside a non-zero interval is read as a rate.
+         * Whether an interval is read as a rate when the header's algorithm bits are not 1 or 2.
          *
-         * <p>Governs that case only. A header stating algorithm 1 or 2 is unambiguous and is always
-         * read, so disabling this does not let a configured fallback override an exporter that
-         * signalled its mode properly.
+         * <p>Governs that case only. A header stating algorithm 1 or 2 together with a non-zero
+         * interval is unambiguous and is always read, so disabling this does not let a configured
+         * fallback override an exporter that stated both a mode and a rate.
          */
         boolean trustHeaderSamplingInterval = true;
 

--- a/src/main/java/org/riptide/flows/Daemon.java
+++ b/src/main/java/org/riptide/flows/Daemon.java
@@ -100,7 +100,8 @@ public class Daemon implements ApplicationRunner {
                     @Override
                     public Listener match(final ReceiverConfig.Neflow5Config config) {
                         final var parser = new Netflow5UdpParser(e.getKey(), dispatcher, identity, metricRegistry)
-                                .withFlowSamplingIntervalFallback(config.getFlowSamplingIntervalFallback());
+                                .withFlowSamplingIntervalFallback(config.getFlowSamplingIntervalFallback())
+                                .withTrustHeaderSamplingInterval(config.isTrustHeaderSamplingInterval());
 
                         return new UdpListener(e.getKey(), parser, metricRegistry)
                                 .withPort(config.getPort())
@@ -166,7 +167,8 @@ public class Daemon implements ApplicationRunner {
 
                         if (config.isNetflow5()) {
                             parsers.add(new Netflow5UdpParser(e.getKey() + ":netflow5", dispatcher, identity, metricRegistry)
-                                    .withFlowSamplingIntervalFallback(config.getFlowSamplingIntervalFallback()));
+                                    .withFlowSamplingIntervalFallback(config.getFlowSamplingIntervalFallback())
+                                    .withTrustHeaderSamplingInterval(config.isTrustHeaderSamplingInterval()));
                         }
 
                         if (config.isSflow()) {

--- a/src/main/java/org/riptide/flows/parser/netflow5/Netflow5FlowBuilder.java
+++ b/src/main/java/org/riptide/flows/parser/netflow5/Netflow5FlowBuilder.java
@@ -87,10 +87,16 @@ public final class Netflow5FlowBuilder {
      * pin off with {@code trust-header-sampling-interval}.
      *
      * <p>An interval of 0 is the signal that an exporter does not sample. The mode bits are not.
+     *
+     * <p>Only 1 and 2 count as a signalled mode. Algorithm 3 is undefined in the v5 header, so it
+     * carries no more meaning than 0 does and must not buy the unconditional branch: a word of all
+     * ones would otherwise be read as a rate of 16383 that the operator has no way to suppress.
+     * {@code getSamplingAlgorithm} maps 3 to {@code Unassigned} for the same reason.
      */
     private double resolveSamplingInterval(final Header header) {
         final Double advertised = usable((double) header.samplingInterval);
-        if (advertised != null && (header.samplingAlgorithm != 0 || this.trustHeaderSamplingInterval)) {
+        final boolean modeSignalled = header.samplingAlgorithm == 1 || header.samplingAlgorithm == 2;
+        if (advertised != null && (modeSignalled || this.trustHeaderSamplingInterval)) {
             this.headerResolved.mark();
             return advertised;
         }

--- a/src/main/java/org/riptide/flows/parser/netflow5/Netflow5FlowBuilder.java
+++ b/src/main/java/org/riptide/flows/parser/netflow5/Netflow5FlowBuilder.java
@@ -29,11 +29,16 @@ public final class Netflow5FlowBuilder {
     private Long flowSamplingIntervalFallback;
 
     /**
-     * Whether a header stating algorithm 0 alongside a non-zero interval is read as a rate.
+     * Whether an interval is read as a rate when the header's algorithm bits are not 1 or 2.
      *
-     * <p>Governs that case alone. Algorithms 1 and 2 are unambiguous and always read: the exporter
-     * stated both how and how much, and discarding the interval would leave
-     * {@code flowSamplingIntervalFallback} overriding a rate the exporter explicitly gave.
+     * <p>Governs that case alone. A header stating algorithm 1 or 2 <em>together with a non-zero
+     * interval</em> is unambiguous and always read: the exporter said both how and how much, and
+     * discarding the interval would leave {@code flowSamplingIntervalFallback} overriding a rate
+     * the exporter explicitly gave.
+     *
+     * <p>Note the qualifier. A stated mode with a zero interval is not a rate, so it still falls
+     * through to the configured fallback — the exporter named a method and no number, and only
+     * configuration can supply the number.
      */
     private boolean trustHeaderSamplingInterval = true;
 
@@ -46,22 +51,27 @@ public final class Netflow5FlowBuilder {
     }
 
     /**
-     * Which rung answered, counted per packet.
+     * Which rung answered, counted per packet and scoped to the receiver.
      *
      * <p>Reading the header changes recorded rates without changing anything in the data path —
      * riptide stores the rate and does not apply it — so nothing else would show an operator that
      * their exporters are now being read differently. Per packet rather than per flow because the
      * rate is a property of the header: every record in a packet resolves identically, and counting
      * each one would report the same fact once per flow.
+     *
+     * <p>Named per receiver like every other parser metric, rather than globally as
+     * {@code ExporterSamplingTable} does. That table is one Spring bean for the whole daemon; this
+     * builder is one per parser, so an unscoped name would blend a dedicated v5 receiver with the
+     * v5 half of a {@code multi} receiver and hide which one stopped resolving from the header.
      */
     private final Meter headerResolved;
     private final Meter fallbackResolved;
     private final Meter unsampled;
 
-    public Netflow5FlowBuilder(final MetricRegistry metrics) {
-        this.headerResolved = metrics.meter(MetricRegistry.name("parser", "netflow5Sampling", "header"));
-        this.fallbackResolved = metrics.meter(MetricRegistry.name("parser", "netflow5Sampling", "fallback"));
-        this.unsampled = metrics.meter(MetricRegistry.name("parser", "netflow5Sampling", "unsampled"));
+    public Netflow5FlowBuilder(final String name, final MetricRegistry metrics) {
+        this.headerResolved = metrics.meter(MetricRegistry.name("parsers", name, "samplingRate", "header"));
+        this.fallbackResolved = metrics.meter(MetricRegistry.name("parsers", name, "samplingRate", "fallback"));
+        this.unsampled = metrics.meter(MetricRegistry.name("parsers", name, "samplingRate", "unsampled"));
     }
 
     public Stream<Flow> buildFlows(final Instant receivedAt, final Packet packet) {

--- a/src/main/java/org/riptide/flows/parser/netflow5/Netflow5FlowBuilder.java
+++ b/src/main/java/org/riptide/flows/parser/netflow5/Netflow5FlowBuilder.java
@@ -6,6 +6,8 @@
 package org.riptide.flows.parser.netflow5;
 
 
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
 import org.riptide.flows.parser.data.Flow;
 import org.riptide.flows.parser.netflow5.proto.Header;
 import org.riptide.flows.parser.netflow5.proto.Packet;
@@ -26,18 +28,85 @@ public final class Netflow5FlowBuilder {
      */
     private Long flowSamplingIntervalFallback;
 
+    /**
+     * Whether a header stating algorithm 0 alongside a non-zero interval is read as a rate.
+     *
+     * <p>Governs that case alone. Algorithms 1 and 2 are unambiguous and always read: the exporter
+     * stated both how and how much, and discarding the interval would leave
+     * {@code flowSamplingIntervalFallback} overriding a rate the exporter explicitly gave.
+     */
+    private boolean trustHeaderSamplingInterval = true;
+
     public void setFlowSamplingIntervalFallback(final Long flowSamplingIntervalFallback) {
         this.flowSamplingIntervalFallback = flowSamplingIntervalFallback;
     }
 
-    public Stream<Flow> buildFlows(final Instant receivedAt, final Packet packet) {
-        return packet.records.stream()
-                .map(record -> buildFlow(receivedAt, packet.header, record));
+    public void setTrustHeaderSamplingInterval(final boolean trustHeaderSamplingInterval) {
+        this.trustHeaderSamplingInterval = trustHeaderSamplingInterval;
     }
 
-    public Flow buildFlow(final Instant receivedAt,
-                          final Header header,
-                          final Record record) {
+    /**
+     * Which rung answered, counted per packet.
+     *
+     * <p>Reading the header changes recorded rates without changing anything in the data path —
+     * riptide stores the rate and does not apply it — so nothing else would show an operator that
+     * their exporters are now being read differently. Per packet rather than per flow because the
+     * rate is a property of the header: every record in a packet resolves identically, and counting
+     * each one would report the same fact once per flow.
+     */
+    private final Meter headerResolved;
+    private final Meter fallbackResolved;
+    private final Meter unsampled;
+
+    public Netflow5FlowBuilder(final MetricRegistry metrics) {
+        this.headerResolved = metrics.meter(MetricRegistry.name("parser", "netflow5Sampling", "header"));
+        this.fallbackResolved = metrics.meter(MetricRegistry.name("parser", "netflow5Sampling", "fallback"));
+        this.unsampled = metrics.meter(MetricRegistry.name("parser", "netflow5Sampling", "unsampled"));
+    }
+
+    public Stream<Flow> buildFlows(final Instant receivedAt, final Packet packet) {
+        // Resolved once for the packet: the rate lives in the header, so it is the same for every
+        // record, and resolving per flow would recompute it and over-count the meters.
+        final double samplingInterval = resolveSamplingInterval(packet.header);
+        return packet.records.stream()
+                .map(record -> buildFlow(receivedAt, packet.header, record, samplingInterval));
+    }
+
+    /**
+     * What the exporter put in the packet header, then what the operator configured, then
+     * unsampled. NetFlow v5 has no options-template mechanism, so the header is the only thing the
+     * exporter itself can say and there is no rung between it and configuration.
+     *
+     * <p>The header packs a 2-bit algorithm and a 14-bit interval into one word, and the two
+     * non-zero cases are not equally clear. Algorithm 1 or 2 means the exporter stated both how and
+     * how much, so the interval is read unconditionally — suppressing it would leave a configured
+     * fallback overriding a rate the exporter explicitly gave. Algorithm 0 with a non-zero interval
+     * is self-contradictory on its face, yet it is what a sampling exporter routinely emits: the
+     * mode bits are not a mandatory field, and pmacct's own exporter never sets them. Reading it is
+     * the default and what every comparable collector does, but it is the one case an operator can
+     * pin off with {@code trust-header-sampling-interval}.
+     *
+     * <p>An interval of 0 is the signal that an exporter does not sample. The mode bits are not.
+     */
+    private double resolveSamplingInterval(final Header header) {
+        final Double advertised = usable((double) header.samplingInterval);
+        if (advertised != null && (header.samplingAlgorithm != 0 || this.trustHeaderSamplingInterval)) {
+            this.headerResolved.mark();
+            return advertised;
+        }
+        final Double configured = usable(asDouble(this.flowSamplingIntervalFallback));
+        if (configured != null) {
+            this.fallbackResolved.mark();
+            return configured;
+        }
+        this.unsampled.mark();
+        return 1.0;
+    }
+
+    private Flow buildFlow(final Instant receivedAt,
+                           final Header header,
+                           final Record record,
+                           final double samplingInterval) {
 
         final var timestamp = Instant.ofEpochSecond(header.unixSecs, header.unixNSecs);
         final var bootTime = timestamp.minus(header.sysUptime, ChronoUnit.MILLIS);
@@ -194,15 +263,10 @@ public final class Netflow5FlowBuilder {
                 };
             }
 
-            /**
-             * What the operator configured, then unsampled. NetFlow v5 exporters cannot advertise
-             * a rate out of band the way v9 does, so this receiver-wide setting is the only rung
-             * above the default — until the packet header is read as well.
-             */
+            /** Resolved once for the packet; see {@code resolveSamplingInterval}. */
             @Override
             public double getSamplingInterval() {
-                final Double configured = usable(asDouble(flowSamplingIntervalFallback));
-                return configured != null ? configured : 1.0;
+                return samplingInterval;
             }
         };
     }

--- a/src/main/java/org/riptide/flows/parser/netflow5/Netflow5UdpParser.java
+++ b/src/main/java/org/riptide/flows/parser/netflow5/Netflow5UdpParser.java
@@ -31,13 +31,14 @@ import static org.riptide.flows.utils.BufferUtils.slice;
 
 public class Netflow5UdpParser extends UdpParserBase implements DispatchableUdpParser {
 
-    private final Netflow5FlowBuilder flowBuilder = new Netflow5FlowBuilder();
+    private final Netflow5FlowBuilder flowBuilder;
 
     public Netflow5UdpParser(final String name,
                              final BiConsumer<Source, List<Flow>> dispatcher,
                              final Identity identity,
                              final MetricRegistry metricRegistry) {
         super(Protocol.NETFLOW5, name, dispatcher, identity, metricRegistry);
+        this.flowBuilder = new Netflow5FlowBuilder(metricRegistry);
     }
 
     @Override
@@ -76,6 +77,11 @@ public class Netflow5UdpParser extends UdpParserBase implements DispatchableUdpP
 
     public Netflow5UdpParser withFlowSamplingIntervalFallback(final Long flowSamplingIntervalFallback) {
         this.flowBuilder.setFlowSamplingIntervalFallback(flowSamplingIntervalFallback);
+        return this;
+    }
+
+    public Netflow5UdpParser withTrustHeaderSamplingInterval(final boolean trustHeaderSamplingInterval) {
+        this.flowBuilder.setTrustHeaderSamplingInterval(trustHeaderSamplingInterval);
         return this;
     }
 

--- a/src/main/java/org/riptide/flows/parser/netflow5/Netflow5UdpParser.java
+++ b/src/main/java/org/riptide/flows/parser/netflow5/Netflow5UdpParser.java
@@ -38,7 +38,7 @@ public class Netflow5UdpParser extends UdpParserBase implements DispatchableUdpP
                              final Identity identity,
                              final MetricRegistry metricRegistry) {
         super(Protocol.NETFLOW5, name, dispatcher, identity, metricRegistry);
-        this.flowBuilder = new Netflow5FlowBuilder(metricRegistry);
+        this.flowBuilder = new Netflow5FlowBuilder(name, metricRegistry);
     }
 
     @Override

--- a/src/test/java/org/riptide/config/DaemonConfigTest.java
+++ b/src/test/java/org/riptide/config/DaemonConfigTest.java
@@ -170,6 +170,13 @@ class DaemonConfigTest {
     /** The same setting on a multi receiver, where it governs that receiver's v5 half. */
     @Test
     void multiReceiverBindsTrustHeaderSamplingInterval() {
+        final var defaults = (ReceiverConfig.MultiConfig) bind(Map.of(
+                "riptide.receivers.mixed.type", "multi",
+                "riptide.receivers.mixed.port", "2055")).getReceivers().get("mixed");
+        assertThat(defaults.isTrustHeaderSamplingInterval())
+                .as("on by default here too, or the two receiver types disagree silently")
+                .isTrue();
+
         final var multi = (ReceiverConfig.MultiConfig) bind(Map.of(
                 "riptide.receivers.mixed.type", "multi",
                 "riptide.receivers.mixed.port", "2055",

--- a/src/test/java/org/riptide/config/DaemonConfigTest.java
+++ b/src/test/java/org/riptide/config/DaemonConfigTest.java
@@ -147,6 +147,39 @@ class DaemonConfigTest {
         assertThat(nf5.getFlowSamplingIntervalFallback()).isNull();
     }
 
+    /**
+     * Reading the v5 header's contested algorithm-0 case is on by default, matching every
+     * comparable collector. The setting exists so an operator whose queries were calibrated around
+     * riptide ignoring the field can pin the old behaviour while they are corrected.
+     */
+    @Test
+    void trustingTheNetflow5HeaderIsOnUnlessTurnedOff() {
+        final var defaults = (ReceiverConfig.Neflow5Config) bind(Map.of(
+                "riptide.receivers.nf5.type", "netflow5",
+                "riptide.receivers.nf5.port", "2055")).getReceivers().get("nf5");
+        assertThat(defaults.isTrustHeaderSamplingInterval()).isTrue();
+
+        final var pinned = (ReceiverConfig.Neflow5Config) bind(Map.of(
+                "riptide.receivers.nf5.type", "netflow5",
+                "riptide.receivers.nf5.port", "2055",
+                "riptide.receivers.nf5.trust-header-sampling-interval", "false"))
+                .getReceivers().get("nf5");
+        assertThat(pinned.isTrustHeaderSamplingInterval()).isFalse();
+    }
+
+    /** The same setting on a multi receiver, where it governs that receiver's v5 half. */
+    @Test
+    void multiReceiverBindsTrustHeaderSamplingInterval() {
+        final var multi = (ReceiverConfig.MultiConfig) bind(Map.of(
+                "riptide.receivers.mixed.type", "multi",
+                "riptide.receivers.mixed.port", "2055",
+                "riptide.receivers.mixed.trust-header-sampling-interval", "false"))
+                .getReceivers().get("mixed");
+
+        assertThat(multi.isTrustHeaderSamplingInterval()).isFalse();
+        assertThat(multi.isNetflow5()).as("still fronting v5, just not trusting its header").isTrue();
+    }
+
     /** Relaxed binding: the camelCase spelling that used to be the only one accepted still works. */
     @Test
     void receiverBindsCamelCaseKeysAndIsoDurations() {

--- a/src/test/java/org/riptide/flows/Netflow5SamplingFallbackTest.java
+++ b/src/test/java/org/riptide/flows/Netflow5SamplingFallbackTest.java
@@ -191,6 +191,27 @@ class Netflow5SamplingFallbackTest {
                 .allSatisfy(flow -> assertThat(flow.getSamplingInterval()).isEqualTo(1.0));
     }
 
+    /**
+     * The opt-out on the v5 half of a `multi` receiver, end to end.
+     *
+     * <p>Without this, replacing the multi branch's {@code withTrustHeaderSamplingInterval(...)}
+     * with a hardcoded {@code true} passes every other test in the change — which is precisely the
+     * shape of the wiring defect the preceding change existed to fix.
+     */
+    @Test
+    void pinningTheHeaderOffReachesTheMultiReceiversNetflow5Half() throws Exception {
+        final var flows = flowsFromDaemonConfigured(Map.of(
+                "riptide.receivers.mixed.type", "multi",
+                "riptide.receivers.mixed.host", "127.0.0.1",
+                "riptide.receivers.mixed.port", "0",
+                "riptide.receivers.mixed.trust-header-sampling-interval", "false"), SAMPLED_CAPTURE);
+
+        assertThat(flows)
+                .as("the setting must reach v5 on a multi receiver, not only on a dedicated one")
+                .isNotEmpty()
+                .allSatisfy(flow -> assertThat(flow.getSamplingInterval()).isEqualTo(1.0));
+    }
+
     /** Starts a daemon on an ephemeral port, sends one v5 capture at it, and returns what it built. */
     private List<Flow> flowsFromDaemonConfigured(final Map<String, Object> properties) throws Exception {
         return flowsFromDaemonConfigured(properties, UNSAMPLED_CAPTURE);

--- a/src/test/java/org/riptide/flows/Netflow5SamplingFallbackTest.java
+++ b/src/test/java/org/riptide/flows/Netflow5SamplingFallbackTest.java
@@ -56,6 +56,9 @@ class Netflow5SamplingFallbackTest {
     /** Sampling word {@code 0x0000}: this exporter advertises nothing, so only configuration can speak. */
     private static final String UNSAMPLED_CAPTURE = "/flows/netflow5.dat";
 
+    /** Sampling word {@code 0x03e8}: algorithm 0, interval 1000 — the contested case, from a real MX80. */
+    private static final String SAMPLED_CAPTURE = "/flows/netflow5_test_juniper_mx80.dat";
+
     private static final Pattern LISTENING =
             Pattern.compile("listening on UDP 127\\.0\\.0\\.1:(\\d+)");
 
@@ -144,22 +147,71 @@ class Netflow5SamplingFallbackTest {
                 .allSatisfy(flow -> assertThat(flow.getSamplingInterval()).isEqualTo(1.0));
     }
 
+    /**
+     * The header rung reaches a dedicated v5 receiver. This capture advertises 1:1000 with the mode
+     * bits clear, so it is the contested case, resolved by default.
+     */
+    @Test
+    void dedicatedNetflow5ReceiverReadsTheHeaderRate() throws Exception {
+        final var flows = flowsFromDaemonConfigured(Map.of(
+                "riptide.receivers.nf5.type", "netflow5",
+                "riptide.receivers.nf5.host", "127.0.0.1",
+                "riptide.receivers.nf5.port", "0"), SAMPLED_CAPTURE);
+
+        assertThat(flows)
+                .isNotEmpty()
+                .allSatisfy(flow -> assertThat(flow.getSamplingInterval()).isEqualTo(1000.0));
+    }
+
+    /** And the v5 half of a multi receiver, the path that silently dropped the fallback. */
+    @Test
+    void multiReceiverReadsTheHeaderRateForNetflow5() throws Exception {
+        final var flows = flowsFromDaemonConfigured(Map.of(
+                "riptide.receivers.mixed.type", "multi",
+                "riptide.receivers.mixed.host", "127.0.0.1",
+                "riptide.receivers.mixed.port", "0"), SAMPLED_CAPTURE);
+
+        assertThat(flows)
+                .isNotEmpty()
+                .allSatisfy(flow -> assertThat(flow.getSamplingInterval()).isEqualTo(1000.0));
+    }
+
+    /** The opt-out reaches the parser too, or it is not an opt-out. */
+    @Test
+    void pinningTheHeaderOffReachesTheParser() throws Exception {
+        final var flows = flowsFromDaemonConfigured(Map.of(
+                "riptide.receivers.nf5.type", "netflow5",
+                "riptide.receivers.nf5.host", "127.0.0.1",
+                "riptide.receivers.nf5.port", "0",
+                "riptide.receivers.nf5.trust-header-sampling-interval", "false"), SAMPLED_CAPTURE);
+
+        assertThat(flows)
+                .as("the exporter states 1000 with the mode bits clear; the operator pinned it off")
+                .isNotEmpty()
+                .allSatisfy(flow -> assertThat(flow.getSamplingInterval()).isEqualTo(1.0));
+    }
+
     /** Starts a daemon on an ephemeral port, sends one v5 capture at it, and returns what it built. */
     private List<Flow> flowsFromDaemonConfigured(final Map<String, Object> properties) throws Exception {
+        return flowsFromDaemonConfigured(properties, UNSAMPLED_CAPTURE);
+    }
+
+    private List<Flow> flowsFromDaemonConfigured(final Map<String, Object> properties,
+                                                 final String capture) throws Exception {
         final var pipeline = Mockito.mock(Pipeline.class);
         final var daemon = daemon(properties, pipeline);
 
         try {
             daemon.run(new DefaultApplicationArguments());
-            send(boundPort(), payload());
+            send(boundPort(), payload(capture));
             return awaitDispatchedFlows(pipeline);
         } finally {
             daemon.stop();
         }
     }
 
-    private static byte[] payload() throws Exception {
-        final var url = Netflow5SamplingFallbackTest.class.getResource(UNSAMPLED_CAPTURE);
+    private static byte[] payload(final String capture) throws Exception {
+        final var url = Netflow5SamplingFallbackTest.class.getResource(capture);
         return Files.readAllBytes(Paths.get(url.toURI()));
     }
 

--- a/src/test/java/org/riptide/flows/fuzz/Netflow5ParserFuzzTest.java
+++ b/src/test/java/org/riptide/flows/fuzz/Netflow5ParserFuzzTest.java
@@ -33,7 +33,7 @@ class Netflow5ParserFuzzTest {
             final Header header = new Header(slice(buffer, Header.SIZE));
             final Packet packet = new Packet(header, buffer);
             // Terminate the lazy stream so the record field decode actually runs.
-            new Netflow5FlowBuilder(new MetricRegistry())
+            new Netflow5FlowBuilder("fuzz", new MetricRegistry())
                     .buildFlows(Instant.EPOCH, packet).forEach(flow -> { });
         } catch (final Throwable t) {
             if (!FuzzSupport.isDesignedRejection(t)) {

--- a/src/test/java/org/riptide/flows/fuzz/Netflow5ParserFuzzTest.java
+++ b/src/test/java/org/riptide/flows/fuzz/Netflow5ParserFuzzTest.java
@@ -7,6 +7,7 @@ package org.riptide.flows.fuzz;
 
 import com.code_intelligence.jazzer.junit.FuzzTest;
 import io.netty.buffer.ByteBuf;
+import com.codahale.metrics.MetricRegistry;
 import org.riptide.flows.parser.netflow5.Netflow5FlowBuilder;
 import org.riptide.flows.parser.netflow5.proto.Header;
 import org.riptide.flows.parser.netflow5.proto.Packet;
@@ -32,7 +33,8 @@ class Netflow5ParserFuzzTest {
             final Header header = new Header(slice(buffer, Header.SIZE));
             final Packet packet = new Packet(header, buffer);
             // Terminate the lazy stream so the record field decode actually runs.
-            new Netflow5FlowBuilder().buildFlows(Instant.EPOCH, packet).forEach(flow -> { });
+            new Netflow5FlowBuilder(new MetricRegistry())
+                    .buildFlows(Instant.EPOCH, packet).forEach(flow -> { });
         } catch (final Throwable t) {
             if (!FuzzSupport.isDesignedRejection(t)) {
                 throw t;

--- a/src/test/java/org/riptide/flows/netflow5/Netflow5ConverterTest.java
+++ b/src/test/java/org/riptide/flows/netflow5/Netflow5ConverterTest.java
@@ -5,6 +5,7 @@
 
 package org.riptide.flows.netflow5;
 
+import com.codahale.metrics.MetricRegistry;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.assertj.core.api.Assertions;
@@ -77,7 +78,8 @@ public class Netflow5ConverterTest {
             final ByteBuf buffer = Unpooled.wrappedBuffer(payload);
             final Header header = new Header(slice(buffer, Header.SIZE));
             final Packet packet = new Packet(header, buffer);
-            flows.addAll(new Netflow5FlowBuilder().buildFlows(Instant.EPOCH, packet).toList());
+            flows.addAll(new Netflow5FlowBuilder(new MetricRegistry())
+                    .buildFlows(Instant.EPOCH, packet).toList());
         }
         return flows;
     }

--- a/src/test/java/org/riptide/flows/netflow5/Netflow5ConverterTest.java
+++ b/src/test/java/org/riptide/flows/netflow5/Netflow5ConverterTest.java
@@ -78,7 +78,7 @@ public class Netflow5ConverterTest {
             final ByteBuf buffer = Unpooled.wrappedBuffer(payload);
             final Header header = new Header(slice(buffer, Header.SIZE));
             final Packet packet = new Packet(header, buffer);
-            flows.addAll(new Netflow5FlowBuilder(new MetricRegistry())
+            flows.addAll(new Netflow5FlowBuilder("test", new MetricRegistry())
                     .buildFlows(Instant.EPOCH, packet).toList());
         }
         return flows;

--- a/src/test/java/org/riptide/flows/netflow5/Netflow5SamplingLadderTest.java
+++ b/src/test/java/org/riptide/flows/netflow5/Netflow5SamplingLadderTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.netflow5;
+
+import com.codahale.metrics.MetricRegistry;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.Test;
+import org.riptide.flows.parser.data.Flow;
+import org.riptide.flows.parser.exceptions.InvalidPacketException;
+import org.riptide.flows.parser.netflow5.Netflow5FlowBuilder;
+import org.riptide.flows.parser.netflow5.proto.Header;
+import org.riptide.flows.parser.netflow5.proto.Packet;
+import org.riptide.flows.parser.netflow5.proto.Record;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.riptide.flows.utils.BufferUtils.slice;
+
+/**
+ * The NetFlow v5 sampling ladder: header, then configured fallback, then unsampled.
+ *
+ * <p>The v5 header packs a 2-bit algorithm and a 14-bit interval into one word, and the two
+ * non-zero cases are governed differently. Algorithm 1 or 2 is unambiguous and always read.
+ * Algorithm 0 with a non-zero interval is the contested case — self-contradictory on its face, but
+ * routinely emitted by sampling exporters because the mode bits are not mandatory — and it is the
+ * only thing {@code trust-header-sampling-interval} governs.
+ */
+class Netflow5SamplingLadderTest {
+
+    /**
+     * Every v5 capture in the corpus, pinned to its measured header word.
+     *
+     * <p>These values are the evidence the decision rests on, so they are asserted rather than
+     * described: two exporters advertise a round decimal rate with the mode bits clear, and the two
+     * that are not sampling advertise a clean zero. A change that silently re-reads the field
+     * differently has to break this test to do it.
+     */
+    @Test
+    void everyCaptureInTheCorpusReportsItsMeasuredRate() throws Exception {
+        assertThat(intervalFromCapture("/flows/netflow5.dat"))
+                .as("0x0000 — not sampling")
+                .isEqualTo(1.0);
+        assertThat(intervalFromCapture("/flows/netflow5_test_microtik.dat"))
+                .as("0x0000 — not sampling")
+                .isEqualTo(1.0);
+        assertThat(intervalFromCapture("/flows/netflow5_test_juniper_mx80.dat"))
+                .as("0x03e8 — algorithm 0, interval 1000")
+                .isEqualTo(1000.0);
+        assertThat(intervalFromCapture("/flows/jflow-packet.dat"))
+                .as("0x0014 — algorithm 0, interval 20")
+                .isEqualTo(20.0);
+    }
+
+    /**
+     * The pair #445 worried about, asserted as intended rather than tolerated.
+     *
+     * <p>{@code Unassigned} beside a non-unity interval says the rate is known and the mode is not.
+     * NetFlow v9 already emits exactly this whenever a record carries field 34 with no mode field,
+     * and every protocol emits it when the configured fallback supplies the rate. Do not "fix" this
+     * by suppressing the interval — see {@code Netflow9FlowBuilder#getSamplingAlgorithm}.
+     */
+    @Test
+    void anUnassignedAlgorithmBesideARealRateIsIntended() throws Exception {
+        final var flow = onlyFlow(packet(0, 1000), builder(null, true));
+
+        assertThat(flow.getSamplingInterval()).isEqualTo(1000.0);
+        assertThat(flow.getSamplingAlgorithm()).isEqualTo(Flow.SamplingAlgorithm.Unassigned);
+    }
+
+    @Test
+    void aZeroIntervalMeansUnsampled() throws Exception {
+        assertThat(onlyFlow(packet(0, 0), builder(null, true)).getSamplingInterval())
+                .isEqualTo(1.0);
+    }
+
+    @Test
+    void theHeaderBeatsTheConfiguredFallback() throws Exception {
+        assertThat(onlyFlow(packet(0, 20), builder(500L, true)).getSamplingInterval())
+                .isEqualTo(20.0);
+    }
+
+    @Test
+    void configurationFillsTheGapASilentExporterLeaves() throws Exception {
+        assertThat(onlyFlow(packet(0, 0), builder(500L, true)).getSamplingInterval())
+                .isEqualTo(500.0);
+    }
+
+    @Test
+    void anExplicitHeaderIntervalOfOneIsNotOverriddenByTheFallback() throws Exception {
+        assertThat(onlyFlow(packet(0, 1), builder(500L, true)).getSamplingInterval())
+                .isEqualTo(1.0);
+    }
+
+    /**
+     * A mode-signalling exporter is unambiguous, so its rate wins over configuration. Without this
+     * the fallback would override a rate the exporter explicitly stated — the inverse of the
+     * precedence riptide documents for v9 and IPFIX.
+     */
+    @Test
+    void aModeSignallingExporterBeatsTheConfiguredFallback() throws Exception {
+        final var flow = onlyFlow(packet(1, 100), builder(1000L, true));
+
+        assertThat(flow.getSamplingInterval()).isEqualTo(100.0);
+        assertThat(flow.getSamplingAlgorithm())
+                .isEqualTo(Flow.SamplingAlgorithm.SystematicCountBasedSampling);
+    }
+
+    @Test
+    void theContestedCaseCanBePinnedOff() throws Exception {
+        assertThat(onlyFlow(packet(0, 1000), builder(null, false)).getSamplingInterval())
+                .as("algorithm 0 falls through when the operator has pinned it off")
+                .isEqualTo(1.0);
+        assertThat(onlyFlow(packet(0, 1000), builder(500L, false)).getSamplingInterval())
+                .as("and lands on the configured fallback when there is one")
+                .isEqualTo(500.0);
+    }
+
+    /**
+     * The opt-out is scoped to the contested case. An operator pinning behaviour for a mode-0 fleet
+     * must not thereby discard correct rates from an exporter that signalled its mode properly.
+     */
+    @Test
+    void pinningTheContestedCaseOffDoesNotSuppressAStatedMode() throws Exception {
+        final var flow = onlyFlow(packet(2, 512), builder(null, false));
+
+        assertThat(flow.getSamplingInterval()).isEqualTo(512.0);
+        assertThat(flow.getSamplingAlgorithm())
+                .isEqualTo(Flow.SamplingAlgorithm.RandomNOutOfNSampling);
+    }
+
+    /**
+     * Metered per packet, not per flow: the rate lives in the header, so every record in a packet
+     * resolves identically and counting each one would report the same fact once per flow.
+     */
+    @Test
+    void whichRungAnsweredIsMeteredOncePerPacket() throws Exception {
+        final var metrics = new MetricRegistry();
+        final var builder = new Netflow5FlowBuilder(metrics);
+        builder.setFlowSamplingIntervalFallback(500L);
+
+        assertThat(builder.buildFlows(Instant.EPOCH, packet(0, 1000, 3)).toList()).hasSize(3);
+        assertThat(builder.buildFlows(Instant.EPOCH, packet(0, 0, 2)).toList()).hasSize(2);
+        assertThat(builder.buildFlows(Instant.EPOCH, packet(0, 0, 1)).toList()).hasSize(1);
+
+        assertThat(meter(metrics, "header"))
+                .as("one packet resolved from the header, not three flows")
+                .isEqualTo(1);
+        assertThat(meter(metrics, "fallback")).as("two packets fell through to config").isEqualTo(2);
+        assertThat(meter(metrics, "unsampled")).as("no packet reached the default").isZero();
+    }
+
+    @Test
+    void aPacketWithNoRateAnywhereIsMeteredAsUnsampled() throws Exception {
+        final var metrics = new MetricRegistry();
+        assertThat(new Netflow5FlowBuilder(metrics).buildFlows(Instant.EPOCH, packet(0, 0)).toList())
+                .hasSize(1);
+
+        assertThat(meter(metrics, "unsampled")).isEqualTo(1);
+        assertThat(meter(metrics, "header")).isZero();
+    }
+
+    private static long meter(final MetricRegistry metrics, final String rung) {
+        return metrics.meter(MetricRegistry.name("parser", "netflow5Sampling", rung)).getCount();
+    }
+
+    private static Netflow5FlowBuilder builder(final Long fallback, final boolean trustHeader) {
+        final var builder = new Netflow5FlowBuilder(new MetricRegistry());
+        builder.setFlowSamplingIntervalFallback(fallback);
+        builder.setTrustHeaderSamplingInterval(trustHeader);
+        return builder;
+    }
+
+    private static Flow onlyFlow(final Packet packet, final Netflow5FlowBuilder builder) {
+        final List<Flow> flows = builder.buildFlows(Instant.EPOCH, packet).toList();
+        assertThat(flows).hasSize(1);
+        return flows.getFirst();
+    }
+
+    private static Packet packet(final int algorithm, final int interval) throws InvalidPacketException {
+        return packet(algorithm, interval, 1);
+    }
+
+    /** A minimal v5 packet: a header carrying the sampling word, and {@code records} zeroed records. */
+    private static Packet packet(final int algorithm, final int interval, final int records)
+            throws InvalidPacketException {
+        final ByteBuf buffer = Unpooled.buffer(Header.SIZE + records * Record.SIZE);
+        buffer.writeShort(Header.VERSION);
+        buffer.writeShort(records);
+        buffer.writeInt(0);          // sysUptime
+        buffer.writeInt(0);          // unixSecs
+        buffer.writeInt(0);          // unixNSecs
+        buffer.writeInt(0);          // flowSequence
+        buffer.writeByte(0);         // engineType
+        buffer.writeByte(0);         // engineId
+        buffer.writeShort((algorithm << 14) | interval);
+        buffer.writeZero(records * Record.SIZE);
+
+        final Header header = new Header(slice(buffer, Header.SIZE));
+        return new Packet(header, buffer);
+    }
+
+    private static double intervalFromCapture(final String resource)
+            throws InvalidPacketException, URISyntaxException, IOException {
+        final var url = Netflow5SamplingLadderTest.class.getResource(resource);
+        final ByteBuf buffer = Unpooled.wrappedBuffer(Files.readAllBytes(Paths.get(url.toURI())));
+        final Header header = new Header(slice(buffer, Header.SIZE));
+        final Packet packet = new Packet(header, buffer);
+
+        return new Netflow5FlowBuilder(new MetricRegistry())
+                .buildFlows(Instant.EPOCH, packet)
+                .findFirst()
+                .orElseThrow()
+                .getSamplingInterval();
+    }
+}

--- a/src/test/java/org/riptide/flows/netflow5/Netflow5SamplingLadderTest.java
+++ b/src/test/java/org/riptide/flows/netflow5/Netflow5SamplingLadderTest.java
@@ -139,6 +139,24 @@ class Netflow5SamplingLadderTest {
     }
 
     /**
+     * Algorithm 3 is undefined in the v5 header, so it is not a signalled mode and must fall under
+     * the opt-out with algorithm 0. Gating the unconditional branch on {@code != 0} instead of on
+     * the two defined values would make a word of all ones — plausible from a corrupt datagram —
+     * read as a rate of 16383 that an operator has no way to suppress.
+     */
+    @Test
+    void anUndefinedAlgorithmIsNotTreatedAsASignalledMode() throws Exception {
+        assertThat(onlyFlow(packet(3, 16383), builder(null, true)).getSamplingInterval())
+                .as("still read by default, like algorithm 0")
+                .isEqualTo(16383.0);
+        assertThat(onlyFlow(packet(3, 16383), builder(null, false)).getSamplingInterval())
+                .as("but the opt-out reaches it, unlike a stated mode")
+                .isEqualTo(1.0);
+        assertThat(onlyFlow(packet(3, 16383), builder(null, true)).getSamplingAlgorithm())
+                .isEqualTo(Flow.SamplingAlgorithm.Unassigned);
+    }
+
+    /**
      * Metered per packet, not per flow: the rate lives in the header, so every record in a packet
      * resolves identically and counting each one would report the same fact once per flow.
      */

--- a/src/test/java/org/riptide/flows/netflow5/Netflow5SamplingLadderTest.java
+++ b/src/test/java/org/riptide/flows/netflow5/Netflow5SamplingLadderTest.java
@@ -139,6 +139,28 @@ class Netflow5SamplingLadderTest {
     }
 
     /**
+     * A stated mode with a zero interval names a method and no number, so it is not a rate and
+     * falls through like any other zero. The configured fallback then supplies the number rather
+     * than overriding one — the exporter never gave one to override.
+     *
+     * <p>With nothing configured the flow reports the mode beside an interval of 1. That reads
+     * oddly, but it is the honest answer: riptide knows how this exporter samples and not how much,
+     * and inventing a rate would be worse than reporting the default.
+     */
+    @Test
+    void aStatedModeWithNoIntervalIsNotARate() throws Exception {
+        assertThat(onlyFlow(packet(1, 0), builder(1000L, true)).getSamplingInterval())
+                .as("the fallback supplies the number the exporter omitted")
+                .isEqualTo(1000.0);
+
+        final var unconfigured = onlyFlow(packet(1, 0), builder(null, true));
+        assertThat(unconfigured.getSamplingInterval()).isEqualTo(1.0);
+        assertThat(unconfigured.getSamplingAlgorithm())
+                .as("the mode is still reported; only the rate is unknown")
+                .isEqualTo(Flow.SamplingAlgorithm.SystematicCountBasedSampling);
+    }
+
+    /**
      * Algorithm 3 is undefined in the v5 header, so it is not a signalled mode and must fall under
      * the opt-out with algorithm 0. Gating the unconditional branch on {@code != 0} instead of on
      * the two defined values would make a word of all ones — plausible from a corrupt datagram —
@@ -163,7 +185,7 @@ class Netflow5SamplingLadderTest {
     @Test
     void whichRungAnsweredIsMeteredOncePerPacket() throws Exception {
         final var metrics = new MetricRegistry();
-        final var builder = new Netflow5FlowBuilder(metrics);
+        final var builder = new Netflow5FlowBuilder("test", metrics);
         builder.setFlowSamplingIntervalFallback(500L);
 
         assertThat(builder.buildFlows(Instant.EPOCH, packet(0, 1000, 3)).toList()).hasSize(3);
@@ -180,19 +202,51 @@ class Netflow5SamplingLadderTest {
     @Test
     void aPacketWithNoRateAnywhereIsMeteredAsUnsampled() throws Exception {
         final var metrics = new MetricRegistry();
-        assertThat(new Netflow5FlowBuilder(metrics).buildFlows(Instant.EPOCH, packet(0, 0)).toList())
+        assertThat(new Netflow5FlowBuilder("test", metrics).buildFlows(Instant.EPOCH, packet(0, 0)).toList())
                 .hasSize(1);
 
         assertThat(meter(metrics, "unsampled")).isEqualTo(1);
         assertThat(meter(metrics, "header")).isZero();
     }
 
+    /**
+     * The spec scenario as written: two exporters, one advertising and one silent, counted apart
+     * in the same registry rather than in separate ones.
+     */
+    @Test
+    void headerResolvedAndUnsampledExportersAreCountedApart() throws Exception {
+        final var metrics = new MetricRegistry();
+        final var builder = new Netflow5FlowBuilder("test", metrics);
+
+        assertThat(builder.buildFlows(Instant.EPOCH, packet(0, 1000)).toList()).hasSize(1);
+        assertThat(builder.buildFlows(Instant.EPOCH, packet(0, 0)).toList()).hasSize(1);
+
+        assertThat(meter(metrics, "header")).isEqualTo(1);
+        assertThat(meter(metrics, "unsampled")).isEqualTo(1);
+        assertThat(meter(metrics, "fallback")).isZero();
+    }
+
+    /** Scoped per receiver, so two v5 receivers cannot blend into one set of counts. */
+    @Test
+    void metersAreScopedToTheReceiver() throws Exception {
+        final var metrics = new MetricRegistry();
+
+        assertThat(new Netflow5FlowBuilder("nf5-edge", metrics)
+                .buildFlows(Instant.EPOCH, packet(0, 1000)).toList()).hasSize(1);
+
+        assertThat(metrics.meter(MetricRegistry.name("parsers", "nf5-edge", "samplingRate", "header")).getCount())
+                .isEqualTo(1);
+        assertThat(metrics.meter(MetricRegistry.name("parsers", "nf5-core", "samplingRate", "header")).getCount())
+                .as("a second receiver's counts are its own")
+                .isZero();
+    }
+
     private static long meter(final MetricRegistry metrics, final String rung) {
-        return metrics.meter(MetricRegistry.name("parser", "netflow5Sampling", rung)).getCount();
+        return metrics.meter(MetricRegistry.name("parsers", "test", "samplingRate", rung)).getCount();
     }
 
     private static Netflow5FlowBuilder builder(final Long fallback, final boolean trustHeader) {
-        final var builder = new Netflow5FlowBuilder(new MetricRegistry());
+        final var builder = new Netflow5FlowBuilder("test", new MetricRegistry());
         builder.setFlowSamplingIntervalFallback(fallback);
         builder.setTrustHeaderSamplingInterval(trustHeader);
         return builder;
@@ -234,7 +288,7 @@ class Netflow5SamplingLadderTest {
         final Header header = new Header(slice(buffer, Header.SIZE));
         final Packet packet = new Packet(header, buffer);
 
-        return new Netflow5FlowBuilder(new MetricRegistry())
+        return new Netflow5FlowBuilder("test", new MetricRegistry())
                 .buildFlows(Instant.EPOCH, packet)
                 .findFirst()
                 .orElseThrow()


### PR DESCRIPTION
Second of two changes for #445, and the one that closes it. **Stacked on #464** — review that first; this PR's diff is only its own two commits.

`Netflow5FlowBuilder` reported *how* a v5 exporter samples but never *how much*. `Header` parsed both the 2-bit algorithm and the 14-bit interval; only the algorithm was used. The `sampling-rate-resolution` spec already claimed otherwise, so this also closes a spec/code divergence.

## Why this was deferred, and what closed it

Two of the four v5 captures carry **algorithm 0 alongside a non-zero interval** — Juniper MX80 `0x03e8` = 1000, jflow `0x0014` = 20. Either those exporters are not sampling and the field is garbage, or they sample and omit the mode bits. Reading it under the first interpretation is a 1000× error.

A source-level survey settled it. **Five of five collectors read the interval by default; zero gate on the mode bits.** Two recorded why:

- **pmacct** (`pkt_handlers.c:4873`) extracts the mode bits, casts them to void, and comments: *"checking srate value instead of is_sampled as Sampling Mode seems not to be a mandatory field."*
- **nfdump** (`getSampler()`) reads the algorithm only *inside* the branch that already decided to trust the interval.

Decisively, **pmacct's own exporter** writes `hdr->sampling = htons(config.sampling_rate & 0x3FFF)` and never sets the mode bits. Mode-0-with-a-rate is a normal export, not corruption.

## The rule

| header | read? |
|---|---|
| algorithm 1 or 2, interval > 0 | **always** — unambiguous, no setting suppresses it |
| algorithm 0 or 3, interval > 0 | subject to `trust-header-sampling-interval` (default `true`) |
| interval == 0 | not sampling |

Scoping the flag to the contested case matters: a single flag over the whole header would mean an operator pinning behaviour for a mode-0 fleet also discards correct rates from mode-signalling exporters, and re-opens the override contradiction #464 documents, where a configured fallback silently beats a rate the exporter stated.

`algorithm 0 → Unassigned` is unchanged, so `(Unassigned, 1000)` is intended output — already the pair v9 emits when a rate resolves without a mode. There is a test asserting it as intended so nobody "fixes" it.

Which rung answered is metered per packet (the rate lives in the header, so every record in a packet resolves identically).

## Verification

`mvn verify` green — 1025 tests, SpotBugs 0, coverage gates met.

Each corpus capture is pinned to its measured value (`netflow5.dat` → 1.0, `microtik` → 1.0, `juniper_mx80` → 1000, `jflow` → 20), so a future change cannot silently flip them.

Review caught two things now fixed in `83cfa64`:

- the unconditional branch was gated on `algorithm != 0`, so **reserved algorithm 3** took it — a sampling word of `0xFFFF` read as a rate of 16383 that the opt-out could not suppress. Now gated on 1 or 2, with a test.
- the upgrade warning assumed pre-upgrade rows were all `samplingInterval = 1`. Receivers with a fallback configured recorded the configured value, and #464's own docs told v5 operators to configure exactly that. Corrected — for those the rate can move **down** as well as up.

## Upgrade impact

Recorded rates change for exporters that advertise one. Stored `bytes`/`packets` are untouched and no query errors, but a query multiplying by `samplingInterval` returns a different answer for v5 rows written from here on. Older rows cannot be corrected retroactively — that would need each exporter's rate at each past moment, which is what was never recorded.

Documented with the identifying query, the both-directions caveat, the opt-out and its limits, and an explicit warning for anyone who hardcoded a compensating multiplier.

Closes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)