### PR TITLE
refactor(snmp): name the interface source method for what it does

### DIFF
--- a/src/main/java/org/riptide/snmp/InterfaceSnapshotPoller.java
+++ b/src/main/java/org/riptide/snmp/InterfaceSnapshotPoller.java
@@ -131,7 +131,7 @@ public class InterfaceSnapshotPoller implements InterfaceSource {
         // from inside the executor factory naming neither property nor class, and non-positive
         // expiry or exporter bound make every trackAndResolve() return empty with only a meter to show
         // for it. Note 0 does not mean "unlimited" here, unlike the negative-cache TTL it
-        // replaces — hence checking rather than reinterpreting.
+        // replaces, so check rather than reinterpreting.
         requirePositive(config.getRefreshIntervalMs(), "riptide.snmp.poll.refresh-interval-ms");
         requirePositive(config.getSnapshotExpiryMs(), "riptide.snmp.poll.snapshot-expiry-ms");
         requirePositive(config.getPoolWidth(), "riptide.snmp.poll.pool-width");

--- a/src/main/java/org/riptide/snmp/InterfaceSnapshotPoller.java
+++ b/src/main/java/org/riptide/snmp/InterfaceSnapshotPoller.java
@@ -38,7 +38,8 @@ import java.util.function.LongSupplier;
  *
  * <p>Three properties are structural rather than enforced:
  * <ul>
- *   <li>Enrichment never walks. {@link #resolve} only reads, so no parser thread can block on SNMP.</li>
+ *   <li>Enrichment never walks. {@link #trackAndResolve} registers and reads but never issues SNMP,
+ *       so no parser thread can block on it.</li>
  *   <li>At most one walk per endpoint is in flight, because each registration carries a single
  *       in-flight flag.</li>
  *   <li>Fleet-wide concurrency is bounded by the walker pool, independently of exporter count.</li>
@@ -102,7 +103,7 @@ public class InterfaceSnapshotPoller implements InterfaceSource {
     private final Meter deregistered;
     /**
      * Counts <em>lookups</em> refused at the exporter bound, not distinct exporters: it is
-     * marked on the resolve path, so a single rejected exporter contributes once per flow and
+     * marked on the trackAndResolve path, so a single rejected exporter contributes once per flow and
      * per direction. It is a pressure signal, not a population count, and cannot be used
      * directly to size {@code max-exporters}; compare it against the exporters gauge instead.
      */
@@ -128,7 +129,7 @@ public class InterfaceSnapshotPoller implements InterfaceSource {
         // Fail loudly at startup rather than silently. Each of these otherwise disables SNMP
         // enrichment in a way that looks like a data problem: a non-positive pool width throws
         // from inside the executor factory naming neither property nor class, and non-positive
-        // expiry or exporter bound make every resolve() return empty with only a meter to show
+        // expiry or exporter bound make every trackAndResolve() return empty with only a meter to show
         // for it. Note 0 does not mean "unlimited" here, unlike the negative-cache TTL it
         // replaces — hence checking rather than reinterpreting.
         requirePositive(config.getRefreshIntervalMs(), "riptide.snmp.poll.refresh-interval-ms");
@@ -180,7 +181,7 @@ public class InterfaceSnapshotPoller implements InterfaceSource {
      * static pins and exporter-pushed option data, just without SNMP-derived fields.
      */
     @Override
-    public Optional<IfInfo> resolve(final SnmpEndpoint endpoint, final int ifIndex) {
+    public Optional<IfInfo> trackAndResolve(final SnmpEndpoint endpoint, final int ifIndex) {
         final long now = this.nanoTime.getAsLong();
         final Registration registration = register(endpoint, now);
         if (registration == null) {

--- a/src/main/java/org/riptide/snmp/InterfaceSource.java
+++ b/src/main/java/org/riptide/snmp/InterfaceSource.java
@@ -20,10 +20,18 @@ import java.util.Optional;
 public interface InterfaceSource {
 
     /**
-     * Resolves one interface, and may register the exporter as worth polling.
+     * Records that {@code endpoint} is sending flows, then resolves one interface.
+     *
+     * <p>The tracking half is load-bearing, not a side effect worth optimising away. An
+     * implementation may use these calls both to decide an exporter is worth polling at all and to
+     * decide it is still alive, so a caller that skips this for an ifIndex it believes it already
+     * knows withholds liveness for the whole exporter. {@link InterfaceSnapshotPoller} deregisters
+     * after {@code refresh-interval-ms × deregister-after} without a call and drops the snapshot
+     * with the registration, so the exporter's next flow starts from a cold warmup window. Call it
+     * for every flow and direction carrying a usable ifIndex, and use the answer or don't.
      *
      * <p>Empty means "not known right now" rather than "does not exist": during the warmup window
      * between an exporter's first flow and its first completed walk, every ifIndex resolves empty.
      */
-    Optional<IfInfo> resolve(SnmpEndpoint endpoint, int ifIndex);
+    Optional<IfInfo> trackAndResolve(SnmpEndpoint endpoint, int ifIndex);
 }

--- a/src/main/java/org/riptide/snmp/InterfaceSource.java
+++ b/src/main/java/org/riptide/snmp/InterfaceSource.java
@@ -26,7 +26,7 @@ public interface InterfaceSource {
      * implementation may use these calls both to decide an exporter is worth polling at all and to
      * decide it is still alive, so a caller that skips this for an ifIndex it believes it already
      * knows withholds liveness for the whole exporter. {@link InterfaceSnapshotPoller} deregisters
-     * after {@code refresh-interval-ms × deregister-after} without a call and drops the snapshot
+     * after {@code refresh-interval-ms * deregister-after} without a call and drops the snapshot
      * with the registration, so the exporter's next flow starts from a cold warmup window. Call it
      * for every flow and direction carrying a usable ifIndex, and use the answer or don't.
      *

--- a/src/main/java/org/riptide/snmp/SnmpEnricher.java
+++ b/src/main/java/org/riptide/snmp/SnmpEnricher.java
@@ -97,9 +97,11 @@ public class SnmpEnricher implements Enricher {
                 .map(n -> n.definition().getInterfaces().get(ifIndex))
                 .orElse(null);
         final IfInfo options = this.exporterInterfaceTable.lookup(source.identity(), ifIndex).orElse(null);
-        // reads the polled snapshot; registers the exporter on its first flow but never walks
+        // reads the polled snapshot; registers the exporter on its first flow but never walks.
+        // Called even when the pins above already cover every field: the call is what keeps the
+        // exporter in the poll set, so skipping it would cost the interfaces that are not pinned.
         final IfInfo live = snmpEndpoint
-                .flatMap(endpoint -> this.interfaceSource.resolve(endpoint, ifIndex))
+                .flatMap(endpoint -> this.interfaceSource.trackAndResolve(endpoint, ifIndex))
                 .orElse(null);
         final IfInfo merged = IfInfo.merge(pinned, IfInfo.optionsThenSnmp(options, live));
         if (merged != null) {

--- a/src/test/java/org/riptide/snmp/InterfaceSnapshotPollerTest.java
+++ b/src/test/java/org/riptide/snmp/InterfaceSnapshotPollerTest.java
@@ -131,7 +131,7 @@ class InterfaceSnapshotPollerTest {
         final var poller = poller(thrower, config);
         final var endpoint = endpoint("10.5.0.1");
 
-        poller.resolve(endpoint, 1);
+        poller.trackAndResolve(endpoint, 1);
         poller.tick(this.clock.get());
         awaitWalks(poller, thrower, 1);
 
@@ -157,14 +157,14 @@ class InterfaceSnapshotPollerTest {
         final var poller = poller(snmp, config());
         final var endpoint = endpoint("10.5.0.2");
 
-        poller.resolve(endpoint, 1);
+        poller.trackAndResolve(endpoint, 1);
         poller.tick(this.clock.get());
         awaitWalks(poller, snmp, 1);
 
         poller.invalidateAll();
 
         // the existing snapshot is still served while the re-walk happens underneath
-        assertThat(poller.resolve(endpoint, 1)).contains(new IfInfo("eth0", "uplink", 1000L));
+        assertThat(poller.trackAndResolve(endpoint, 1)).contains(new IfInfo("eth0", "uplink", 1000L));
         poller.tick(this.clock.get());
         awaitWalks(poller, snmp, 2);
     }
@@ -182,14 +182,14 @@ class InterfaceSnapshotPollerTest {
         final var poller = poller(snmp, config());
         final var endpoint = endpoint("10.5.0.3");
 
-        poller.resolve(endpoint, 1);
+        poller.trackAndResolve(endpoint, 1);
         poller.tick(this.clock.get());
         assertThat(snmp.entered.await(5, TimeUnit.SECONDS)).isTrue();
 
         // long past the deregistration threshold, but the walk is still parked
         advanceMs(600_000L * 5);
         poller.tick(this.clock.get());
-        poller.resolve(endpoint, 1);
+        poller.trackAndResolve(endpoint, 1);
         poller.tick(this.clock.get());
         assertThat(snmp.walks.get()).isEqualTo(1);
 
@@ -222,13 +222,13 @@ class InterfaceSnapshotPollerTest {
         appender.start();
         logger.addAppender(appender);
         try {
-            poller.resolve(endpoint, 1);
+            poller.trackAndResolve(endpoint, 1);
             poller.tick(this.clock.get());
             awaitWalks(poller, snmp, 1);
 
             // ifIndex 99 is absent from the walked table; 500 flows must not mean 500 warnings
             for (int i = 0; i < 500; i++) {
-                assertThat(poller.resolve(endpoint, 99)).isEmpty();
+                assertThat(poller.trackAndResolve(endpoint, 99)).isEmpty();
             }
             assertThat(missWarnings(appender)).isEqualTo(1);
 
@@ -236,7 +236,7 @@ class InterfaceSnapshotPollerTest {
             advanceMs(700_000);
             poller.tick(this.clock.get());
             awaitWalks(poller, snmp, 2);
-            poller.resolve(endpoint, 99);
+            poller.trackAndResolve(endpoint, 99);
             assertThat(missWarnings(appender)).isEqualTo(2);
         } finally {
             logger.detachAppender(appender);
@@ -255,12 +255,12 @@ class InterfaceSnapshotPollerTest {
         appender.start();
         logger.addAppender(appender);
         try {
-            poller.resolve(endpoint, 1);
+            poller.trackAndResolve(endpoint, 1);
             poller.tick(this.clock.get());
             awaitWalks(poller, snmp, 1);
 
             for (int ifIndex = 1000; ifIndex < 6000; ifIndex++) {
-                poller.resolve(endpoint, ifIndex);
+                poller.trackAndResolve(endpoint, ifIndex);
             }
             assertThat(missWarnings(appender)).isLessThanOrEqualTo(64);
         } finally {
@@ -279,7 +279,7 @@ class InterfaceSnapshotPollerTest {
         final var snmp = new FakeSnmp();
         final var poller = poller(snmp, config());
 
-        // no resolve() call means no registration, however long the scheduler runs
+        // no trackAndResolve() call means no registration, however long the scheduler runs
         poller.tick(this.clock.get());
         advanceMs(600_000);
         poller.tick(this.clock.get());
@@ -294,12 +294,12 @@ class InterfaceSnapshotPollerTest {
         final var endpoint = endpoint("10.0.0.1");
 
         // warmup: registered, but nothing walked yet, so the ladder's SNMP rung is empty
-        assertThat(poller.resolve(endpoint, 1)).isEmpty();
+        assertThat(poller.trackAndResolve(endpoint, 1)).isEmpty();
 
         poller.tick(this.clock.get());
         awaitWalks(poller, snmp, 1);
 
-        assertThat(poller.resolve(endpoint, 1)).contains(new IfInfo("eth0", "uplink", 1000L));
+        assertThat(poller.trackAndResolve(endpoint, 1)).contains(new IfInfo("eth0", "uplink", 1000L));
     }
 
     @Test
@@ -309,7 +309,7 @@ class InterfaceSnapshotPollerTest {
         final var endpoint = endpoint("10.0.0.2");
 
         for (int ifIndex = 1; ifIndex <= 50; ifIndex++) {
-            poller.resolve(endpoint, ifIndex);
+            poller.trackAndResolve(endpoint, ifIndex);
         }
         assertThat(snmp.walks.get()).isZero();
 
@@ -318,7 +318,7 @@ class InterfaceSnapshotPollerTest {
 
         // and after a snapshot exists, 50 more lookups still cost nothing
         for (int ifIndex = 1; ifIndex <= 50; ifIndex++) {
-            poller.resolve(endpoint, ifIndex);
+            poller.trackAndResolve(endpoint, ifIndex);
         }
         assertThat(snmp.walks.get()).isEqualTo(1);
     }
@@ -329,12 +329,12 @@ class InterfaceSnapshotPollerTest {
         final var poller = poller(snmp, config());
         final var endpoint = endpoint("10.0.0.3");
 
-        poller.resolve(endpoint, 1);
+        poller.trackAndResolve(endpoint, 1);
         poller.tick(this.clock.get());
         awaitWalks(poller, snmp, 1);
 
         // 99 is not in the walked table: a known absence, not an unknown
-        assertThat(poller.resolve(endpoint, 99)).isEmpty();
+        assertThat(poller.trackAndResolve(endpoint, 99)).isEmpty();
         assertThat(snmp.walks.get()).isEqualTo(1);
     }
 
@@ -344,17 +344,17 @@ class InterfaceSnapshotPollerTest {
         final var poller = poller(snmp, config());
         final var endpoint = endpoint("10.0.0.4");
 
-        poller.resolve(endpoint, 1);
+        poller.trackAndResolve(endpoint, 1);
         poller.tick(this.clock.get());
         awaitWalks(poller, snmp, 1);
 
         // past the refresh interval but inside the expiry backstop: a name from the previous
         // cycle beats no name, which is the whole reason these are two settings
         advanceMs(700_000);
-        assertThat(poller.resolve(endpoint, 1)).isPresent();
+        assertThat(poller.trackAndResolve(endpoint, 1)).isPresent();
 
         advanceMs(1_200_000); // now beyond snapshotExpiryMs
-        assertThat(poller.resolve(endpoint, 1)).isEmpty();
+        assertThat(poller.trackAndResolve(endpoint, 1)).isEmpty();
     }
 
     @Test
@@ -363,19 +363,19 @@ class InterfaceSnapshotPollerTest {
         final var poller = poller(snmp, config());
         final var endpoint = endpoint("10.0.0.5");
 
-        poller.resolve(endpoint, 1);
+        poller.trackAndResolve(endpoint, 1);
         poller.tick(this.clock.get());
         awaitWalks(poller, snmp, 1);
 
         // ticks before the interval elapses must not re-walk
         advanceMs(300_000);
-        poller.resolve(endpoint, 1);
+        poller.trackAndResolve(endpoint, 1);
         poller.tick(this.clock.get());
         Thread.sleep(50);
         assertThat(snmp.walks.get()).isEqualTo(1);
 
         advanceMs(400_000); // past refresh + jitter
-        poller.resolve(endpoint, 1);
+        poller.trackAndResolve(endpoint, 1);
         poller.tick(this.clock.get());
         awaitWalks(poller, snmp, 2);
     }
@@ -388,7 +388,7 @@ class InterfaceSnapshotPollerTest {
         final var poller = poller(snmp, config());
         final var endpoint = endpoint("10.0.0.6");
 
-        poller.resolve(endpoint, 1);
+        poller.trackAndResolve(endpoint, 1);
         poller.tick(this.clock.get());
         assertThat(snmp.entered.await(5, TimeUnit.SECONDS)).isTrue();
 
@@ -411,7 +411,7 @@ class InterfaceSnapshotPollerTest {
         final var poller = poller(snmp, config);
 
         for (int i = 1; i <= 20; i++) {
-            poller.resolve(endpoint("10.1.0." + i), 1);
+            poller.trackAndResolve(endpoint("10.1.0." + i), 1);
         }
         poller.tick(this.clock.get());
 
@@ -433,7 +433,7 @@ class InterfaceSnapshotPollerTest {
         final var poller = poller(snmp, config);
         final var endpoint = endpoint("10.0.0.7");
 
-        poller.resolve(endpoint, 1);
+        poller.trackAndResolve(endpoint, 1);
         poller.tick(this.clock.get());
         awaitWalks(poller, snmp, 1);
 
@@ -477,7 +477,7 @@ class InterfaceSnapshotPollerTest {
         final var poller = poller(snmp, config);
         final var endpoint = endpoint("10.0.0.8");
 
-        poller.resolve(endpoint, 1);
+        poller.trackAndResolve(endpoint, 1);
         poller.tick(this.clock.get());
         awaitWalks(poller, snmp, 1);
 
@@ -495,7 +495,7 @@ class InterfaceSnapshotPollerTest {
         poller.tick(this.clock.get());
         Thread.sleep(50);
         assertThat(snmp.walks.get()).isEqualTo(3);
-        assertThat(poller.resolve(endpoint, 1)).isPresent();
+        assertThat(poller.trackAndResolve(endpoint, 1)).isPresent();
     }
 
     @Test
@@ -507,13 +507,13 @@ class InterfaceSnapshotPollerTest {
         final var poller = poller(snmp, config);
         final var endpoint = endpoint("10.0.0.9");
 
-        poller.resolve(endpoint, 1);
+        poller.trackAndResolve(endpoint, 1);
         poller.tick(this.clock.get());
         awaitWalks(poller, snmp, 1);
 
         // without the reload this endpoint would not be retried for the whole base delay
         poller.invalidateAll();
-        poller.resolve(endpoint, 1);
+        poller.trackAndResolve(endpoint, 1);
         poller.tick(this.clock.get());
         awaitWalks(poller, snmp, 2);
     }
@@ -524,11 +524,11 @@ class InterfaceSnapshotPollerTest {
         final var poller = poller(snmp, config());
         final var endpoint = endpoint("10.0.0.10");
 
-        poller.resolve(endpoint, 1);
+        poller.trackAndResolve(endpoint, 1);
         poller.tick(this.clock.get());
         awaitWalks(poller, snmp, 1);
 
-        // silent for deregisterAfter (3) refresh intervals, with no further resolve() calls
+        // silent for deregisterAfter (3) refresh intervals, with no further trackAndResolve() calls
         advanceMs(600_000L * 3 + 1_000);
         poller.tick(this.clock.get());
         Thread.sleep(50);
@@ -548,7 +548,7 @@ class InterfaceSnapshotPollerTest {
 
         // registration follows flow arrival, so a spoofed source population must not grow the heap
         for (int i = 1; i <= 50; i++) {
-            poller.resolve(endpoint("10.2.0." + i), 1);
+            poller.trackAndResolve(endpoint("10.2.0." + i), 1);
         }
 
         poller.tick(this.clock.get());
@@ -572,7 +572,7 @@ class InterfaceSnapshotPollerTest {
         final var poller = poller(snmp, config);
 
         for (int i = 1; i <= 40; i++) {
-            poller.resolve(endpoint("10.4.0." + i), 1);
+            poller.trackAndResolve(endpoint("10.4.0." + i), 1);
         }
         poller.tick(this.clock.get());
         awaitWalks(poller, snmp, 40); // the cold-start burst, drained by the pool
@@ -616,8 +616,8 @@ class InterfaceSnapshotPollerTest {
         final var second = new FakeSnmp();
         final var pollerB = new InterfaceSnapshotPoller(second, config, new MetricRegistry(), this.clock::get, false);
 
-        pollerA.resolve(endpoint, 1);
-        pollerB.resolve(endpoint, 1);
+        pollerA.trackAndResolve(endpoint, 1);
+        pollerB.trackAndResolve(endpoint, 1);
         pollerA.tick(this.clock.get());
         pollerB.tick(this.clock.get());
         awaitWalks(pollerA, first, 1);

--- a/src/test/java/org/riptide/snmp/SnmpEnricherTest.java
+++ b/src/test/java/org/riptide/snmp/SnmpEnricherTest.java
@@ -37,6 +37,11 @@ import static org.mockito.Mockito.when;
         "riptide.nodes.test-agent.snmp.community=" + TestSnmpAgent.COMMUNITY,
         // enrichment-ladder per-field pin: static alias overrides SNMP, rest is live
         "riptide.nodes.test-agent.interfaces.1.alias=Uplink pinned by file",
+        // pinned in every field IfInfo carries, so the live rung can add nothing for it —
+        // the case the liveness test below depends on
+        "riptide.nodes.test-agent.interfaces.3.name=ge-0/0/3",
+        "riptide.nodes.test-agent.interfaces.3.alias=Fully pinned by file",
+        "riptide.nodes.test-agent.interfaces.3.high-speed=1000",
         "riptide.snmp.options.retentionMs=4242"
 })
 public class SnmpEnricherTest {
@@ -213,6 +218,11 @@ public class SnmpEnricherTest {
 
     @Test
     public void pinnedInterfacesStillCallTrackAndResolveToMaintainLiveness() throws Exception {
+        // ifIndex 3 is pinned in name, alias and highSpeed, so the live rung cannot contribute a
+        // single field for it and skipping the call would look free. It is not: the call is what
+        // registers the exporter and refreshes its liveness, so withholding it would deregister
+        // the exporter and cost ifIndex 2 — pinned in nothing — its alias and speed for a whole
+        // walk cycle. Guards the short-circuit proposed in #446.
         final InterfaceSource interfaceSource = Mockito.mock(InterfaceSource.class);
         when(interfaceSource.trackAndResolve(Mockito.any(), Mockito.anyInt())).thenReturn(java.util.Optional.empty());
 
@@ -223,15 +233,24 @@ public class SnmpEnricherTest {
         final Flow flow = Mockito.mock(Flow.class);
         when(flow.getSrcAddr()).thenReturn(InetAddress.getByName("10.10.10.10"));
         when(flow.getDstAddr()).thenReturn(InetAddress.getByName("10.20.20.10"));
-        when(flow.getInputSnmp()).thenReturn(1);
+        when(flow.getInputSnmp()).thenReturn(3);
         when(flow.getOutputSnmp()).thenReturn(2);
 
         final var source = new Source("here", InetAddress.getByName("127.0.0.1"));
         pipeline.process(source, List.of(flow));
 
         final var targetIp = InetAddress.getByName("127.0.0.1");
-        Mockito.verify(interfaceSource).trackAndResolve(Mockito.argThat(ep -> ep != null && ep.getInetSocketAddress().getAddress().equals(targetIp)), Mockito.eq(1));
+        // the fully pinned interface: the assertion that actually fails if the ladder short-circuits
+        Mockito.verify(interfaceSource).trackAndResolve(Mockito.argThat(ep -> ep != null && ep.getInetSocketAddress().getAddress().equals(targetIp)), Mockito.eq(3));
         Mockito.verify(interfaceSource).trackAndResolve(Mockito.argThat(ep -> ep != null && ep.getInetSocketAddress().getAddress().equals(targetIp)), Mockito.eq(2));
+
+        // and the pin still reaches the flow, so the mock's empty live rung proves the pin
+        // supplied every field rather than the enricher silently dropping them
+        assertThat(repository.flows()).allSatisfy(enrichedFlow -> {
+            assertThat(enrichedFlow.getInputSnmpIfName()).isEqualTo("ge-0/0/3");
+            assertThat(enrichedFlow.getInputSnmpIfAlias()).isEqualTo("Fully pinned by file");
+            assertThat(enrichedFlow.getInputSnmpIfSpeed()).isEqualTo(1000L);
+        });
     }
 
     private static ExporterInterfaceTable emptyInterfaceTable() {

--- a/src/test/java/org/riptide/snmp/SnmpEnricherTest.java
+++ b/src/test/java/org/riptide/snmp/SnmpEnricherTest.java
@@ -211,6 +211,29 @@ public class SnmpEnricherTest {
         });
     }
 
+    @Test
+    public void pinnedInterfacesStillCallTrackAndResolveToMaintainLiveness() throws Exception {
+        final InterfaceSource interfaceSource = Mockito.mock(InterfaceSource.class);
+        when(interfaceSource.trackAndResolve(Mockito.any(), Mockito.anyInt())).thenReturn(java.util.Optional.empty());
+
+        final var enrichers = List.<Enricher>of(new SnmpEnricher(interfaceSource, this.nodeRegistry, emptyInterfaceTable()));
+        final var repository = new TestRepository(metricRegistry);
+        final var pipeline = new Pipeline(enrichers, repository.asPersister(), this.metricRegistry, this.flowMapper);
+
+        final Flow flow = Mockito.mock(Flow.class);
+        when(flow.getSrcAddr()).thenReturn(InetAddress.getByName("10.10.10.10"));
+        when(flow.getDstAddr()).thenReturn(InetAddress.getByName("10.20.20.10"));
+        when(flow.getInputSnmp()).thenReturn(1);
+        when(flow.getOutputSnmp()).thenReturn(2);
+
+        final var source = new Source("here", InetAddress.getByName("127.0.0.1"));
+        pipeline.process(source, List.of(flow));
+
+        final var targetIp = InetAddress.getByName("127.0.0.1");
+        Mockito.verify(interfaceSource).trackAndResolve(Mockito.argThat(ep -> ep != null && ep.getInetSocketAddress().getAddress().equals(targetIp)), Mockito.eq(1));
+        Mockito.verify(interfaceSource).trackAndResolve(Mockito.argThat(ep -> ep != null && ep.getInetSocketAddress().getAddress().equals(targetIp)), Mockito.eq(2));
+    }
+
     private static ExporterInterfaceTable emptyInterfaceTable() {
         final SnmpOptionsConfig cacheConfig = new SnmpOptionsConfig();
         cacheConfig.setRetentionMs(60_000);


### PR DESCRIPTION
`InterfaceSource.resolve` promised a read while the production implementation also registered the exporter as worth polling and stamped its liveness. The javadoc disclosed it in an aside, so the method still read as skippable to anyone optimising against the name.

That is not academic. #446 proposed skipping the live rung for an ifIndex the operator had already pinned in full. On a partially pinned exporter, withholding those calls stops refreshing `lastSeenNanos`, the poller deregisters after `refresh-interval-ms × deregister-after` and drops the snapshot with the registration, and the interfaces that were not pinned lose their alias and speed for a whole walk cycle.

This renames the method to `trackAndResolve` and states the liveness contract as a requirement rather than an aside. It also adds a note at the one call site in `SnmpEnricher` explaining why the call is made even when the static pins already cover every field.

## Deviation from the issue

#463 proposed splitting tracking from lookup (`touch(endpoint)` alongside `resolve(endpoint, ifIndex)`). This PR deliberately does not do that.

The registration work is O(2N) per packet where it could be O(1) (~24 records per packet, two directions, one exporter), but that is only ~1.6 µs per packet, well under 1% of a core at the measured ceiling. Too small to pay for the two behaviour changes a split forces:

- exporters whose flows only ever carry ifIndex 0 would start registering and being walked, since `touch` would sit above the ifIndex guard
- `snmp.poller.rejectedLookups` is documented as counting lookups rather than exporters

Adding a pure `lookup()` alongside is worse still, leaving two methods where picking the inviting one silently drops the exporter from the poll set. Naming the single method for what it does closes the same trap without either cost.

## Verification

No behaviour change. `@FunctionalInterface` and both enricher test lambdas are preserved, since the interface keeps exactly one method. Full `mvn test` suite green.

Closes #463
Refs #446
