### PR TITLE
fix(netflow5): name the last sampling rung for what it knows

### DIFF
--- a/docs/docs/deploy/operations.md
+++ b/docs/docs/deploy/operations.md
@@ -150,20 +150,24 @@ Two gauges describe what a UDP parser is holding. They are easy to confuse, and 
 ## NetFlow v5 sampling rate resolution
 
 NetFlow v5 has no options table, so a v5 flow's sampling rate resolves from the packet header, then
-the receiver's `flow-sampling-interval-fallback`, then unsampled. Which rung answered is metered per
-**packet** (the rate lives in the header, so every record in a packet resolves identically) and per
-receiver.
+the receiver's `flow-sampling-interval-fallback`, then an assumed `1`. Which rung answered is metered
+per **packet** (the rate lives in the header, so every record in a packet resolves identically) and
+per receiver.
 
 | Metric | Meaning |
 |---|---|
 | `parsers.<name>.samplingRate.header` | packets whose rate came from the exporter's header |
 | `parsers.<name>.samplingRate.fallback` | packets that fell through to the configured rate |
-| `parsers.<name>.samplingRate.unsampled` | packets with no rate anywhere, recorded as `1` |
+| `parsers.<name>.samplingRate.assumed` | packets with no rate anywhere, recorded as `1` |
+
+`assumed` is not the same statement as an exporter reporting a rate of `1`.
+An exporter that states `1` has said it does not sample, and that lands under `header`.
+`assumed` means nothing stated a rate at all, and `1` is what riptide wrote in the absence of one — the stored `samplingInterval` cannot tell the two apart, which is what these meters are for.
 
 These exist because the resolution is invisible in the data path: riptide records the rate without
 applying it, so an exporter that starts or stops advertising changes no counter and raises no error.
-A `header` rate that falls to zero means a fleet stopped advertising and is now being recorded as
-unsampled — or on the configured rate, which may not match. See
+A `header` rate that falls to zero means a fleet stopped advertising and is now being recorded at an
+assumed `1` — or on the configured rate, which may not match. See
 [Sampling rate](../configuration/receivers.md#sampling-rate) for the resolution order and settings.
 
 **What changed in 0.7.0.** `sessionCount` used to report the **template** total, so it overstated by

--- a/src/main/java/org/riptide/flows/parser/netflow5/Netflow5FlowBuilder.java
+++ b/src/main/java/org/riptide/flows/parser/netflow5/Netflow5FlowBuilder.java
@@ -66,12 +66,16 @@ public final class Netflow5FlowBuilder {
      */
     private final Meter headerResolved;
     private final Meter fallbackResolved;
-    private final Meter unsampled;
+    private final Meter assumed;
 
     public Netflow5FlowBuilder(final String name, final MetricRegistry metrics) {
         this.headerResolved = metrics.meter(MetricRegistry.name("parsers", name, "samplingRate", "header"));
         this.fallbackResolved = metrics.meter(MetricRegistry.name("parsers", name, "samplingRate", "fallback"));
-        this.unsampled = metrics.meter(MetricRegistry.name("parsers", name, "samplingRate", "unsampled"));
+        // "assumed", not "unsampled": this rung fires when nothing stated a rate, and 1.0 is what
+        // riptide assumes in that case. Naming it "unsampled" would assert the exporter is not
+        // sampling — which is the one thing this rung cannot know, and is exactly the claim an
+        // exporter makes when it states a rate of 1 through the header rung above.
+        this.assumed = metrics.meter(MetricRegistry.name("parsers", name, "samplingRate", "assumed"));
     }
 
     public Stream<Flow> buildFlows(final Instant receivedAt, final Packet packet) {
@@ -83,8 +87,8 @@ public final class Netflow5FlowBuilder {
     }
 
     /**
-     * What the exporter put in the packet header, then what the operator configured, then
-     * unsampled. NetFlow v5 has no options-template mechanism, so the header is the only thing the
+     * What the exporter put in the packet header, then what the operator configured, then an
+     * assumed 1.0. NetFlow v5 has no options-template mechanism, so the header is the only thing the
      * exporter itself can say and there is no rung between it and configuration.
      *
      * <p>The header packs a 2-bit algorithm and a 14-bit interval into one word, and the two
@@ -115,7 +119,7 @@ public final class Netflow5FlowBuilder {
             this.fallbackResolved.mark();
             return configured;
         }
-        this.unsampled.mark();
+        this.assumed.mark();
         return 1.0;
     }
 

--- a/src/test/java/org/riptide/flows/netflow5/Netflow5SamplingLadderTest.java
+++ b/src/test/java/org/riptide/flows/netflow5/Netflow5SamplingLadderTest.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.riptide.flows.utils.BufferUtils.slice;
 
 /**
- * The NetFlow v5 sampling ladder: header, then configured fallback, then unsampled.
+ * The NetFlow v5 sampling ladder: header, then configured fallback, then an assumed 1.0.
  *
  * <p>The v5 header packs a 2-bit algorithm and a 14-bit interval into one word, and the two
  * non-zero cases are governed differently. Algorithm 1 or 2 is unambiguous and always read.
@@ -196,7 +196,7 @@ class Netflow5SamplingLadderTest {
                 .as("one packet resolved from the header, not three flows")
                 .isEqualTo(1);
         assertThat(meter(metrics, "fallback")).as("two packets fell through to config").isEqualTo(2);
-        assertThat(meter(metrics, "unsampled")).as("no packet reached the default").isZero();
+        assertThat(meter(metrics, "assumed")).as("no packet reached the default").isZero();
     }
 
     @Test
@@ -205,7 +205,7 @@ class Netflow5SamplingLadderTest {
         assertThat(new Netflow5FlowBuilder("test", metrics).buildFlows(Instant.EPOCH, packet(0, 0)).toList())
                 .hasSize(1);
 
-        assertThat(meter(metrics, "unsampled")).isEqualTo(1);
+        assertThat(meter(metrics, "assumed")).isEqualTo(1);
         assertThat(meter(metrics, "header")).isZero();
     }
 
@@ -222,7 +222,7 @@ class Netflow5SamplingLadderTest {
         assertThat(builder.buildFlows(Instant.EPOCH, packet(0, 0)).toList()).hasSize(1);
 
         assertThat(meter(metrics, "header")).isEqualTo(1);
-        assertThat(meter(metrics, "unsampled")).isEqualTo(1);
+        assertThat(meter(metrics, "assumed")).isEqualTo(1);
         assertThat(meter(metrics, "fallback")).isZero();
     }
 


### PR DESCRIPTION
`parsers.<name>.samplingRate.unsampled` — the v5 ladder's final rung, added in #465 — asserts the exporter is not sampling. That is the one thing the rung cannot know. It fires when *nothing* stated a rate anywhere, and `1.0` is what riptide wrote in the absence of one.

Worse, the claim is already taken. An exporter that states a rate of `1` in its header has genuinely said it does not sample, and that lands under `header`. So two distinct facts were reading as the same word, inside the metric whose whole job is telling them apart.

Renamed to `assumed`, with the distinction spelled out in the operations reference.

**No scrape breaks.** #465 merged as 560281c and `git tag --contains` is empty — the meters have never shipped in a release, so this is free now and would not be after the next tag.

Groundwork for #467 (record the sampling rate's provenance as a column on `flows`): the metric and the column have to agree on what a rung is called, and `fallback`/`assumed` are the names that survive that. `assumed` also avoids colliding with nfdump's `SAMPLER_DEFAULT`, which means the *configured* rung, not the unknown one.

## Verification

`make jar` (i.e. `mvn verify`, incl. Error Prone / checkstyle / SpotBugs / jacoco) — BUILD SUCCESS, SpotBugs 0, coverage checks met. `Netflow5SamplingLadderTest`: 15 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)