### PR TITLE
feat(sampling): record where a flow's sampling rate came from

### DIFF
--- a/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-data-trust.json
+++ b/deployment/clickhouse/container-fs/grafana/provisioning/dashboards/riptide-data-trust.json
@@ -186,7 +186,7 @@
           }
         }
       ],
-      "description": "How many different sampling algorithm and interval combinations are in use across the selected scope. More than one means byte figures from different exporters are not directly comparable \u2014 every top-N ranking in the other dashboards silently assumes they are."
+      "description": "How many different sampling algorithm and interval combinations are in use across the selected scope. More than one means byte figures from different exporters are not directly comparable — every top-N ranking in the other dashboards silently assumes they are."
     },
     {
       "id": 2,
@@ -433,14 +433,14 @@
           "editorType": "sql",
           "format": 1,
           "queryType": "table",
-          "rawSql": "SELECT if(exporterName != '', exporterName, exporterAddr) AS \"Exporter\",\n       toString(samplingAlgorithm) AS \"Algorithm\",\n       samplingInterval AS \"Interval\", count() AS \"Flows\",\n       sum(bytes) AS \"Bytes\"\nFROM ${database}.flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone)\nGROUP BY \"Exporter\", \"Algorithm\", \"Interval\"\nORDER BY \"Flows\" DESC LIMIT 50",
+          "rawSql": "SELECT if(exporterName != '', exporterName, exporterAddr) AS \"Exporter\",\n       toString(samplingAlgorithm) AS \"Algorithm\",\n       samplingInterval AS \"Interval\",\n       if(samplingProvenance != '', samplingProvenance, 'before 0.8') AS \"Rate source\",\n       count() AS \"Flows\",\n       sum(bytes) AS \"Bytes\"\nFROM ${database}.flows WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone)\nGROUP BY \"Exporter\", \"Algorithm\", \"Interval\", \"Rate source\"\nORDER BY \"Flows\" DESC LIMIT 50",
           "refId": "A",
           "meta": {
             "timezone": "UTC"
           }
         }
       ],
-      "description": "The sampling algorithm and interval each exporter reported, with how much traffic it contributed. An interval of 1 is unsampled. Two exporters with different intervals contribute bytes on different scales \u2014 this table is where you find that out before it distorts a comparison."
+      "description": "The sampling algorithm and interval each exporter reported, with where the interval came from and how much traffic it contributed. An interval of 1 means different things depending on the rate source: 'record', 'options' or 'header' is the exporter stating it does not sample, while 'assumed' is riptide having nothing to go on. 'derived' is riptide's own arithmetic on an IPFIX selector algorithm, and is the value to distrust first. Two exporters with different intervals contribute bytes on different scales — this table is where you find that out before it distorts a comparison. One exporter on several rows with different rate sources is a rate that is not resolving consistently."
     },
     {
       "id": 6,
@@ -520,7 +520,7 @@
     {
       "id": 7,
       "type": "table",
-      "title": "Scope matrix \u2014 tenant, organisation, zone",
+      "title": "Scope matrix — tenant, organisation, zone",
       "datasource": {
         "type": "grafana-clickhouse-datasource",
         "uid": "${datasource}"
@@ -670,7 +670,74 @@
           }
         }
       ],
-      "description": "Each exporter with the protocol version, engine identifiers and system name it presented. A device appearing twice with different engine IDs has been renumbered or replaced \u2014 which breaks any history keyed on that identity."
+      "description": "Each exporter with the protocol version, engine identifiers and system name it presented. A device appearing twice with different engine IDs has been renumbered or replaced — which breaks any history keyed on that identity."
+    },
+    {
+      "id": 9,
+      "type": "stat",
+      "title": "Exporters with an inconsistent rate source",
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "graphMode": "none",
+        "colorMode": "value",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "${datasource}"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "queryType": "table",
+          "rawSql": "SELECT count() AS \"Exporters\" FROM (\n  SELECT exporterAddr FROM ${database}.flows\n  WHERE $__timeFilter(timestamp) AND $__conditionalAll(tenant IN (${tenant:singlequote}), $tenant) AND $__conditionalAll(zone IN (${zone:singlequote}), $zone)\n  GROUP BY exporterAddr\n  HAVING uniqExact(samplingProvenance) > 1\n)",
+          "refId": "A",
+          "meta": {
+            "timezone": "UTC"
+          }
+        }
+      ],
+      "description": "Exporters whose sampling rate resolved from more than one rung over this window. Any value above zero is worth investigating: firmware that populates the sampling field on some export paths and not others interleaves 'header' and 'assumed' for one exporter, and a NetFlow v9 sampler options table that expires between refreshes does the same with 'options'. Both silently mix traffic recorded on different scales from one device. Rows written before the provenance column existed carry an empty source and count as a distinct rung, so expect a non-zero value across the upgrade."
     }
   ],
   "annotations": {
@@ -688,5 +755,5 @@
       "keepTime": true
     }
   ],
-  "description": "Can the other dashboards be believed? Sampling configuration, clock corrections, scope labelling and exporter identity \u2014 the metadata that silently invalidates a byte comparison when it changes. Read this one first when a number looks wrong somewhere else. Collection Health answers whether data is arriving; this answers whether it means what you think."
+  "description": "Can the other dashboards be believed? Sampling configuration, clock corrections, scope labelling and exporter identity — the metadata that silently invalidates a byte comparison when it changes. Read this one first when a number looks wrong somewhere else. Collection Health answers whether data is arriving; this answers whether it means what you think."
 }

--- a/docs/docs/configuration/receivers.md
+++ b/docs/docs/configuration/receivers.md
@@ -128,6 +128,48 @@ Use it for a v5 exporter that samples but leaves the header field at zero, which
 Note the fallback applies to the whole receiver, so exporters sharing a port share it.
 Give exporters that sample at different rates their own receivers and ports, unless they state their rates in the header — in which case each is read individually and the fallback never comes up.
 
+### Where a rate came from
+
+A stored `samplingInterval` of `1` is ambiguous on its own.
+It can mean the exporter stated that it does not sample, which is an answer and outranks a configured fallback, or that nothing stated a rate anywhere and riptide recorded `1` in the absence of one.
+Those are opposite facts, and a query cannot separate them by value.
+
+Every flow therefore carries `samplingProvenance` — the rung of the ladder that supplied its interval:
+
+| value | the rate came from |
+|---|---|
+| `record` | the flow record itself (NetFlow v9 / IPFIX fields 34, 49, 50), or an sFlow sample |
+| `options` | the exporter's sampler options table (NetFlow v9) |
+| `header` | the NetFlow v5 packet header |
+| `derived` | riptide's own arithmetic on an IPFIX selector algorithm and its ranges |
+| `fallback` | the receiver's `flow-sampling-interval-fallback` |
+| `assumed` | nothing stated a rate; `1` was recorded in the absence of one |
+| `''` (empty) | the row was written before this column existed |
+
+Two of these deserve care.
+
+`derived` is not something the exporter said.
+It is a rate riptide computed from the selector algorithm and the ranges the exporter supplied, so it carries less authority than `record` and is the value to distrust first when numbers look wrong.
+
+`record` on an **sFlow** row does not mean the row should be multiplied.
+sFlow rates are always on the sample, but sFlow counters are already scaled at ingest, so the caveat below still applies and `flowProtocol` — not the provenance — is what tells you.
+
+Rows written before this column existed read `''`.
+They are not backfilled, and cannot be: reconstructing them would need each exporter's rate at each past moment, which is precisely the information whose absence this column records.
+
+An exporter alternating between two provenances is worth investigating.
+Firmware that populates the sampling field on some export paths and not others produces an interleaved mix of `header` and `assumed` for one exporter; a v9 sampler options table that expires between refreshes produces the same pattern with `options` and `assumed`:
+
+```sql
+SELECT exporterAddr, samplingProvenance, samplingInterval, count() AS flows
+FROM flows
+WHERE timestamp > now() - INTERVAL 1 HOUR
+GROUP BY exporterAddr, samplingProvenance, samplingInterval
+ORDER BY exporterAddr, flows DESC
+```
+
+More than one provenance for one exporter means its rate is not resolving consistently.
+
 :::warning[NetFlow v5 rates changed]
 Earlier releases ignored the v5 header interval. What they recorded instead depended on the receiver:
 
@@ -138,17 +180,18 @@ Stored `bytes` and `packets` are unchanged either way, and no query errors.
 
 Rows written before the upgrade are not rewritten: correcting them would need each exporter's rate at each past moment, which is exactly what was never recorded. A query spanning the upgrade mixes both conventions.
 
-Find which exporters now report a rate, and when each changed:
+The rows whose meaning changed name themselves. Find which exporters now report a rate, and when each changed:
 
 ```sql
 SELECT exporterAddr, samplingInterval, min(timestamp), max(timestamp)
 FROM flows
-WHERE flowProtocol = 'NetflowV5'
+WHERE flowProtocol = 'NetflowV5' AND samplingProvenance = 'header'
 GROUP BY exporterAddr, samplingInterval
 ORDER BY exporterAddr, min(timestamp)
 ```
 
-More than one row per `exporterAddr` means that exporter's recorded rate changed, and the `min(timestamp)` of the later row is when.
+The `min(timestamp)` of the earliest row per exporter is when that exporter's rate started being read.
+Rows from before the upgrade carry a different provenance (`fallback`, `assumed`, or `''` if they predate the column), so no timestamp guess is needed to tell the two conventions apart.
 
 **If you compensated for this by hardcoding a multiplier** in a dashboard or query — because you knew riptide was not reading these exporters' rates — remove it, or you will now double-count.
 
@@ -161,9 +204,10 @@ Set `flow-sampling-interval-fallback` to the value you were relying on if you ne
 riptide records the sampling rate; it does not scale NetFlow or IPFIX `bytes` and `packets` by it.
 Stored counters are what the exporter reported, and the rate sits alongside them for a query to apply.
 
-Three things to know before writing that query.
+Four things to know before writing that query.
 sFlow already scales at ingest (`bytes = frame_length × sampling_rate`) and still reports its rate, so multiplying sFlow rows again double-counts them: filter them out, or restrict the query to NetFlow and IPFIX.
 The 1-minute rollups carry neither the rate nor a scaled measure, so `SUM(bytes * samplingInterval)` only means anything against the raw `flows` table.
+A rate of `1` is not always a statement that the exporter does not sample — check `samplingProvenance` before treating one as trustworthy, and see [Where a rate came from](#where-a-rate-came-from).
 And if you are coming from **nfdump or pmacct**, check whether counters were being scaled for you.
 Both can multiply NetFlow v5 `bytes` and `packets` by the sampling rate at ingest (in pmacct via `nfacctd_renormalize`, in nfdump depending on how sampling was detected or forced with `-s`), where riptide never does.
 Counters stored here are always as the exporter reported them, so a query ported from either may need the multiplication added rather than removed.

--- a/docs/docs/deploy/operations.md
+++ b/docs/docs/deploy/operations.md
@@ -83,6 +83,17 @@ answer for v5 rows written from here on, and older rows are not rewritten. Watch
 detail, including how to identify affected exporters and how to pin the old behaviour, is in
 [Sampling rate](../configuration/receivers.md#sampling-rate).
 
+**A `samplingProvenance` column is added to `flows` on upgrade.** It records which rung of the
+resolution ladder supplied each row's `samplingInterval`, so a stored `1` stops being ambiguous
+between an exporter that said it does not sample and one that said nothing at all. In manage mode
+the column is added in place with `ALTER TABLE … ADD COLUMN IF NOT EXISTS`: no operator action, no
+data loss, no rewrite. A provisioned deployment (`manage-schema: false`) fails fast naming the
+column — re-run `riptide onboard` to add it. Existing rows read `''`, which means "written before
+this column existed" and is deliberately distinct from `assumed`; they are not backfilled, because
+the information needed to reconstruct them was never recorded. No existing column, value or query
+result changes. See [Where a rate came
+from](../configuration/receivers.md#where-a-rate-came-from).
+
 ## Ingest loss counters
 
 Flows can be dropped at two bounded queues, and each one counts what it discards — nothing is
@@ -162,7 +173,21 @@ per receiver.
 
 `assumed` is not the same statement as an exporter reporting a rate of `1`.
 An exporter that states `1` has said it does not sample, and that lands under `header`.
-`assumed` means nothing stated a rate at all, and `1` is what riptide wrote in the absence of one — the stored `samplingInterval` cannot tell the two apart, which is what these meters are for.
+`assumed` means nothing stated a rate at all, and `1` is what riptide wrote in the absence of one.
+
+Each meter's leaf name is the value written to that flow's `samplingProvenance` column, so a meter and the rows it counted always agree.
+The meters answer "is this happening now" without a query; the column answers it for any period, for every protocol, and per exporter:
+
+```sql
+SELECT exporterAddr, samplingProvenance, samplingInterval, count() AS flows
+FROM flows
+WHERE timestamp > now() - INTERVAL 1 HOUR
+GROUP BY exporterAddr, samplingProvenance, samplingInterval
+ORDER BY exporterAddr, flows DESC
+```
+
+One exporter appearing under two provenances is a rate that is not resolving consistently — firmware populating the sampling field on some export paths and not others, or a v9 sampler options table expiring between refreshes.
+See [Where a rate came from](../configuration/receivers.md#where-a-rate-came-from) for the full vocabulary.
 
 These exist because the resolution is invisible in the data path: riptide records the rate without
 applying it, so an exporter that starts or stops advertising changes no counter and raises no error.

--- a/src/main/java/org/riptide/flows/parser/data/Flow.java
+++ b/src/main/java/org/riptide/flows/parser/data/Flow.java
@@ -54,6 +54,16 @@ public interface Flow {
     SamplingAlgorithm getSamplingAlgorithm();
     double getSamplingInterval();
 
+    /**
+     * Which rung of the resolution ladder supplied {@link #getSamplingInterval()}. A stored
+     * interval of {@code 1.0} is otherwise ambiguous between an exporter stating it does not
+     * sample — an answer, which outranks a configured fallback — and nothing being known at all.
+     *
+     * <p>Describes the interval only. {@link #getSamplingAlgorithm()} resolves through its own
+     * ladder and may be {@code Unassigned} on a flow whose interval has a known provenance.
+     */
+    SamplingProvenance getSamplingProvenance();
+
     enum Locality {
         PUBLIC, PRIVATE
     }
@@ -68,5 +78,51 @@ public interface Flow {
 
     enum SamplingAlgorithm {
         Unassigned, SystematicCountBasedSampling, SystematicTimeBasedSampling, RandomNOutOfNSampling, UniformProbabilisticSampling, PropertyMatchFiltering, HashBasedFiltering, FlowStateDependentIntermediateFlowSelectionProcess;
+    }
+
+    /**
+     * Where a flow's sampling interval came from — one rung of the resolution ladder.
+     *
+     * <p>Each constant carries the token written to the {@code samplingProvenance} column and used
+     * as the parser metric's leaf name. The token is the stable identifier: renaming a constant
+     * must not rewrite what stored rows mean, and the metric and the column must not drift apart.
+     */
+    enum SamplingProvenance {
+        /** Carried on the flow record itself (v9/IPFIX fields 34/49/50), or on an sFlow sample. */
+        Record("record"),
+
+        /** Learned from the exporter's sampler options table (NetFlow v9). */
+        Options("options"),
+
+        /** Read from the NetFlow v5 packet header. */
+        Header("header"),
+
+        /**
+         * Computed by riptide from an IPFIX selector algorithm and its ranges. Distinct from
+         * {@link #Record} deliberately: this is riptide's arithmetic on exporter-supplied inputs,
+         * not a rate the exporter stated, so it carries less authority than one that was.
+         */
+        Derived("derived"),
+
+        /** The receiver's {@code flow-sampling-interval-fallback}. */
+        Fallback("fallback"),
+
+        /**
+         * Nothing stated a rate anywhere and {@code 1.0} was recorded in the absence of one. Not
+         * the same claim as an exporter reporting a rate of 1: that exporter has answered that it
+         * does not sample, and its answer is attributed to the rung that carried it.
+         */
+        Assumed("assumed");
+
+        private final String token;
+
+        SamplingProvenance(final String token) {
+            this.token = token;
+        }
+
+        /** The stored/metered identifier for this rung. */
+        public String token() {
+            return this.token;
+        }
     }
 }

--- a/src/main/java/org/riptide/flows/parser/data/ResolvedRate.java
+++ b/src/main/java/org/riptide/flows/parser/data/ResolvedRate.java
@@ -5,6 +5,7 @@
 
 package org.riptide.flows.parser.data;
 
+import java.util.Objects;
 import org.riptide.flows.parser.data.Flow.SamplingProvenance;
 
 /**
@@ -21,6 +22,10 @@ import org.riptide.flows.parser.data.Flow.SamplingProvenance;
  * @param from     the rung that produced {@code interval}
  */
 public record ResolvedRate(double interval, SamplingProvenance from) {
+
+    public ResolvedRate {
+        Objects.requireNonNull(from, "from must not be null");
+    }
 
     /** Nothing stated a rate: {@code 1.0}, recorded as assumed rather than as an answer. */
     public static ResolvedRate assumed() {

--- a/src/main/java/org/riptide/flows/parser/data/ResolvedRate.java
+++ b/src/main/java/org/riptide/flows/parser/data/ResolvedRate.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Riptide Labs, <https://github.com/Riptide-Labs>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.riptide.flows.parser.data;
+
+import org.riptide.flows.parser.data.Flow.SamplingProvenance;
+
+/**
+ * A sampling interval and the rung of the resolution ladder that supplied it.
+ *
+ * <p>The two travel together so a ladder is walked once and cannot report a value from one rung
+ * while naming another. Resolving them separately would need a second traversal that drifts from
+ * the first on the next edit, and is unsafe in the IPFIX builder regardless: its selector-algorithm
+ * rung divides by exporter-supplied ranges and must not be evaluated for a record that already
+ * carries its rate.
+ *
+ * @param interval the resolved rate; {@code 1.0} when {@code from} is
+ *                 {@link SamplingProvenance#Assumed}
+ * @param from     the rung that produced {@code interval}
+ */
+public record ResolvedRate(double interval, SamplingProvenance from) {
+
+    /** Nothing stated a rate: {@code 1.0}, recorded as assumed rather than as an answer. */
+    public static ResolvedRate assumed() {
+        return new ResolvedRate(1.0, SamplingProvenance.Assumed);
+    }
+
+    public static ResolvedRate of(final double interval, final SamplingProvenance from) {
+        return new ResolvedRate(interval, from);
+    }
+}

--- a/src/main/java/org/riptide/flows/parser/ipfix/IpFixFlowBuilder.java
+++ b/src/main/java/org/riptide/flows/parser/ipfix/IpFixFlowBuilder.java
@@ -5,13 +5,17 @@
 
 package org.riptide.flows.parser.ipfix;
 
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.primitives.UnsignedLong;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.riptide.flows.parser.ie.values.ValueConversionService;
 import org.riptide.flows.parser.data.Flow;
+import org.riptide.flows.parser.data.Flow.SamplingProvenance;
 import org.riptide.flows.parser.data.Optionals;
+import org.riptide.flows.parser.data.ResolvedRate;
 import org.riptide.flows.parser.data.Timeout;
 import org.riptide.flows.parser.ipfix.proto.Packet;
 
@@ -244,12 +248,15 @@ public class IpFixFlowBuilder {
 
             /**
              * What the record carries, then what the selector algorithm implies, then what the
-             * operator configured, then unsampled. Algorithms 0, 8 and 9 have no expressible
+             * operator configured, then an assumed 1.0. Algorithms 0, 8 and 9 have no expressible
              * interval and yield NaN, which is honest but would land in a Float64 column and
              * poison any aggregate multiplying by it — so it falls through as unknown instead.
+             *
+             * <p>Walked once and memoized: the interval and the rung that produced it are two
+             * views of one resolution, and a second traversal would both drift from the first and
+             * defeat the laziness below.
              */
-            @Override
-            public double getSamplingInterval() {
+            private final Supplier<ResolvedRate> rate = Suppliers.memoize(() -> {
                 // Evaluated in order and lazily: the selector-algorithm derivation divides by
                 // exporter-supplied ranges, so it must not run for a record that already carries
                 // its rate — a degenerate range would then cost the whole packet's batch.
@@ -258,13 +265,27 @@ public class IpFixFlowBuilder {
                                 usable(rawFlow.samplerRandomInterval))
                         .orElse(null);
                 if (onRecord != null) {
-                    return onRecord;
+                    return ResolvedRate.of(onRecord, SamplingProvenance.Record);
                 }
                 final Double derived = usable(fromSelectorAlgorithm());
                 if (derived != null) {
-                    return derived;
+                    return ResolvedRate.of(derived, SamplingProvenance.Derived);
                 }
-                return Optionals.first(usable(asDouble(flowSamplingIntervalFallback))).orElse(1.0);
+                final Double configured = usable(asDouble(flowSamplingIntervalFallback));
+                if (configured != null) {
+                    return ResolvedRate.of(configured, SamplingProvenance.Fallback);
+                }
+                return ResolvedRate.assumed();
+            });
+
+            @Override
+            public double getSamplingInterval() {
+                return this.rate.get().interval();
+            }
+
+            @Override
+            public SamplingProvenance getSamplingProvenance() {
+                return this.rate.get().from();
             }
 
             /** RFC 5477 selector algorithms, as an interval where one is expressible. */

--- a/src/main/java/org/riptide/flows/parser/netflow5/Netflow5FlowBuilder.java
+++ b/src/main/java/org/riptide/flows/parser/netflow5/Netflow5FlowBuilder.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 public final class Netflow5FlowBuilder {
@@ -71,8 +72,9 @@ public final class Netflow5FlowBuilder {
      * v5 half of a {@code multi} receiver and hide which one stopped resolving from the header.
      *
      * <p>Keyed by the rung itself and named from its token, so the metric and the
-     * {@code samplingProvenance} column cannot drift apart: a rung renamed in one place is renamed
-     * in both, and a rung this builder can reach without a meter fails at construction.
+     * {@code samplingProvenance} column cannot drift apart: renaming a rung renames both. Only the
+     * three rungs a v5 packet can reach are registered — the other three would be permanently zero
+     * and would read as "this receiver never resolves that way" rather than "it cannot".
      */
     private final Map<SamplingProvenance, Meter> rungMeters;
 
@@ -92,7 +94,10 @@ public final class Netflow5FlowBuilder {
         // Resolved once for the packet: the rate lives in the header, so it is the same for every
         // record, and resolving per flow would recompute it and over-count the meters.
         final ResolvedRate rate = resolveSamplingRate(packet.header);
-        this.rungMeters.get(rate.from()).mark();
+        // Fails loudly rather than with a bare NPE if a rung is ever added to the ladder below
+        // without being registered above.
+        Objects.requireNonNull(this.rungMeters.get(rate.from()),
+                () -> "no meter registered for sampling rung " + rate.from()).mark();
         return packet.records.stream()
                 .map(record -> buildFlow(receivedAt, packet.header, record, rate));
     }

--- a/src/main/java/org/riptide/flows/parser/netflow5/Netflow5FlowBuilder.java
+++ b/src/main/java/org/riptide/flows/parser/netflow5/Netflow5FlowBuilder.java
@@ -9,6 +9,8 @@ package org.riptide.flows.parser.netflow5;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import org.riptide.flows.parser.data.Flow;
+import org.riptide.flows.parser.data.Flow.SamplingProvenance;
+import org.riptide.flows.parser.data.ResolvedRate;
 import org.riptide.flows.parser.netflow5.proto.Header;
 import org.riptide.flows.parser.netflow5.proto.Packet;
 import org.riptide.flows.parser.netflow5.proto.Record;
@@ -16,6 +18,10 @@ import org.riptide.flows.parser.netflow5.proto.Record;
 import java.net.InetAddress;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 public final class Netflow5FlowBuilder {
@@ -63,27 +69,32 @@ public final class Netflow5FlowBuilder {
      * {@code ExporterSamplingTable} does. That table is one Spring bean for the whole daemon; this
      * builder is one per parser, so an unscoped name would blend a dedicated v5 receiver with the
      * v5 half of a {@code multi} receiver and hide which one stopped resolving from the header.
+     *
+     * <p>Keyed by the rung itself and named from its token, so the metric and the
+     * {@code samplingProvenance} column cannot drift apart: a rung renamed in one place is renamed
+     * in both, and a rung this builder can reach without a meter fails at construction.
      */
-    private final Meter headerResolved;
-    private final Meter fallbackResolved;
-    private final Meter assumed;
+    private final Map<SamplingProvenance, Meter> rungMeters;
+
+    /** The rungs a v5 packet can resolve through. There is no options table and no record rung. */
+    private static final List<SamplingProvenance> RUNGS =
+            List.of(SamplingProvenance.Header, SamplingProvenance.Fallback, SamplingProvenance.Assumed);
 
     public Netflow5FlowBuilder(final String name, final MetricRegistry metrics) {
-        this.headerResolved = metrics.meter(MetricRegistry.name("parsers", name, "samplingRate", "header"));
-        this.fallbackResolved = metrics.meter(MetricRegistry.name("parsers", name, "samplingRate", "fallback"));
-        // "assumed", not "unsampled": this rung fires when nothing stated a rate, and 1.0 is what
-        // riptide assumes in that case. Naming it "unsampled" would assert the exporter is not
-        // sampling — which is the one thing this rung cannot know, and is exactly the claim an
-        // exporter makes when it states a rate of 1 through the header rung above.
-        this.assumed = metrics.meter(MetricRegistry.name("parsers", name, "samplingRate", "assumed"));
+        final var meters = new EnumMap<SamplingProvenance, Meter>(SamplingProvenance.class);
+        for (final var rung : RUNGS) {
+            meters.put(rung, metrics.meter(MetricRegistry.name("parsers", name, "samplingRate", rung.token())));
+        }
+        this.rungMeters = Collections.unmodifiableMap(meters);
     }
 
     public Stream<Flow> buildFlows(final Instant receivedAt, final Packet packet) {
         // Resolved once for the packet: the rate lives in the header, so it is the same for every
         // record, and resolving per flow would recompute it and over-count the meters.
-        final double samplingInterval = resolveSamplingInterval(packet.header);
+        final ResolvedRate rate = resolveSamplingRate(packet.header);
+        this.rungMeters.get(rate.from()).mark();
         return packet.records.stream()
-                .map(record -> buildFlow(receivedAt, packet.header, record, samplingInterval));
+                .map(record -> buildFlow(receivedAt, packet.header, record, rate));
     }
 
     /**
@@ -107,26 +118,23 @@ public final class Netflow5FlowBuilder {
      * ones would otherwise be read as a rate of 16383 that the operator has no way to suppress.
      * {@code getSamplingAlgorithm} maps 3 to {@code Unassigned} for the same reason.
      */
-    private double resolveSamplingInterval(final Header header) {
+    private ResolvedRate resolveSamplingRate(final Header header) {
         final Double advertised = usable((double) header.samplingInterval);
         final boolean modeSignalled = header.samplingAlgorithm == 1 || header.samplingAlgorithm == 2;
         if (advertised != null && (modeSignalled || this.trustHeaderSamplingInterval)) {
-            this.headerResolved.mark();
-            return advertised;
+            return ResolvedRate.of(advertised, SamplingProvenance.Header);
         }
         final Double configured = usable(asDouble(this.flowSamplingIntervalFallback));
         if (configured != null) {
-            this.fallbackResolved.mark();
-            return configured;
+            return ResolvedRate.of(configured, SamplingProvenance.Fallback);
         }
-        this.assumed.mark();
-        return 1.0;
+        return ResolvedRate.assumed();
     }
 
     private Flow buildFlow(final Instant receivedAt,
                            final Header header,
                            final Record record,
-                           final double samplingInterval) {
+                           final ResolvedRate rate) {
 
         final var timestamp = Instant.ofEpochSecond(header.unixSecs, header.unixNSecs);
         final var bootTime = timestamp.minus(header.sysUptime, ChronoUnit.MILLIS);
@@ -283,10 +291,15 @@ public final class Netflow5FlowBuilder {
                 };
             }
 
-            /** Resolved once for the packet; see {@code resolveSamplingInterval}. */
+            /** Resolved once for the packet; see {@code resolveSamplingRate}. */
             @Override
             public double getSamplingInterval() {
-                return samplingInterval;
+                return rate.interval();
+            }
+
+            @Override
+            public SamplingProvenance getSamplingProvenance() {
+                return rate.from();
             }
         };
     }

--- a/src/main/java/org/riptide/flows/parser/netflow9/Netflow9FlowBuilder.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/Netflow9FlowBuilder.java
@@ -9,7 +9,9 @@ import lombok.Getter;
 import lombok.Setter;
 import org.riptide.flows.parser.ie.values.ValueConversionService;
 import org.riptide.flows.parser.data.Flow;
+import org.riptide.flows.parser.data.Flow.SamplingProvenance;
 import org.riptide.flows.parser.data.Optionals;
+import org.riptide.flows.parser.data.ResolvedRate;
 import org.riptide.flows.parser.data.Timeout;
 import org.riptide.flows.parser.netflow9.proto.Packet;
 import com.google.common.base.Supplier;
@@ -289,18 +291,34 @@ public class Netflow9FlowBuilder {
 
             /**
              * What the exporter put on this record, then what it advertised in its sampler
-             * options table, then what the operator configured, then unsampled. A sampling
+             * options table, then what the operator configured, then an assumed 1.0. A sampling
              * exporter usually states its rate only in the options table, so without the middle
              * rung this reports 1.0 for a router sampling 1:1000.
+             *
+             * <p>Walked once and memoized: the interval and the rung that produced it are two
+             * views of one resolution, and a second traversal would drift from the first.
              */
+            private final Supplier<ResolvedRate> rate = Suppliers.memoize(() ->
+                    Optionals.first(
+                                    usable(raw.SAMPLING_INTERVAL),
+                                    usable(raw.FLOW_SAMPLER_RANDOM_INTERVAL))
+                            .map(interval -> ResolvedRate.of(interval, SamplingProvenance.Record))
+                            .or(() -> advertised.get()
+                                    .map(AdvertisedRate::interval)
+                                    .map(Netflow9FlowBuilder::usable)
+                                    .map(interval -> ResolvedRate.of(interval, SamplingProvenance.Options)))
+                            .or(() -> Optional.ofNullable(usable(asDouble(flowSamplingIntervalFallback)))
+                                    .map(interval -> ResolvedRate.of(interval, SamplingProvenance.Fallback)))
+                            .orElseGet(ResolvedRate::assumed));
+
             @Override
             public double getSamplingInterval() {
-                return Optionals.first(
-                                usable(raw.SAMPLING_INTERVAL),
-                                usable(raw.FLOW_SAMPLER_RANDOM_INTERVAL))
-                        .or(() -> advertised.get().map(AdvertisedRate::interval).map(Netflow9FlowBuilder::usable))
-                        .or(() -> Optional.ofNullable(usable(asDouble(flowSamplingIntervalFallback))))
-                        .orElse(1.0);
+                return this.rate.get().interval();
+            }
+
+            @Override
+            public SamplingProvenance getSamplingProvenance() {
+                return this.rate.get().from();
             }
         };
     }

--- a/src/main/java/org/riptide/flows/parser/netflow9/Netflow9FlowBuilder.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/Netflow9FlowBuilder.java
@@ -303,8 +303,7 @@ public class Netflow9FlowBuilder {
                                     usable(raw.SAMPLING_INTERVAL),
                                     usable(raw.FLOW_SAMPLER_RANDOM_INTERVAL))
                             .map(interval -> ResolvedRate.of(interval, SamplingProvenance.Record))
-                            .or(() -> Optional.ofNullable(advertised.get())
-                                    .flatMap(rate -> rate)
+                            .or(() -> advertised.get()
                                     .map(AdvertisedRate::interval)
                                     .map(Netflow9FlowBuilder::usable)
                                     .map(interval -> ResolvedRate.of(interval, SamplingProvenance.Options)))

--- a/src/main/java/org/riptide/flows/parser/netflow9/Netflow9FlowBuilder.java
+++ b/src/main/java/org/riptide/flows/parser/netflow9/Netflow9FlowBuilder.java
@@ -303,7 +303,8 @@ public class Netflow9FlowBuilder {
                                     usable(raw.SAMPLING_INTERVAL),
                                     usable(raw.FLOW_SAMPLER_RANDOM_INTERVAL))
                             .map(interval -> ResolvedRate.of(interval, SamplingProvenance.Record))
-                            .or(() -> advertised.get()
+                            .or(() -> Optional.ofNullable(advertised.get())
+                                    .flatMap(rate -> rate)
                                     .map(AdvertisedRate::interval)
                                     .map(Netflow9FlowBuilder::usable)
                                     .map(interval -> ResolvedRate.of(interval, SamplingProvenance.Options)))

--- a/src/main/java/org/riptide/flows/parser/sflow/SflowFlowBuilder.java
+++ b/src/main/java/org/riptide/flows/parser/sflow/SflowFlowBuilder.java
@@ -188,6 +188,20 @@ public final class SflowFlowBuilder {
             public double getSamplingInterval() {
                 return sample.samplingRate;
             }
+
+            /**
+             * Always on the sample: sFlow carries the rate by construction, so there is no ladder
+             * here and no rung below this one.
+             *
+             * <p>Note what this provenance does <em>not</em> say. sFlow counters are already
+             * scaled at ingest ({@code bytes = frameLength × samplingRate}), so multiplying an
+             * sFlow row by its interval double-counts it. That is a property of the protocol, not
+             * of the rung, and {@code flowProtocol} is what distinguishes it.
+             */
+            @Override
+            public SamplingProvenance getSamplingProvenance() {
+                return SamplingProvenance.Record;
+            }
         };
     }
 }

--- a/src/main/java/org/riptide/pipeline/EnrichedFlow.java
+++ b/src/main/java/org/riptide/pipeline/EnrichedFlow.java
@@ -15,6 +15,7 @@ import org.riptide.flows.parser.data.Flow.Direction;
 import org.riptide.flows.parser.data.Flow.FlowProtocol;
 import org.riptide.flows.parser.data.Flow.Locality;
 import org.riptide.flows.parser.data.Flow.SamplingAlgorithm;
+import org.riptide.flows.parser.data.Flow.SamplingProvenance;
 
 import java.net.InetAddress;
 import java.time.Duration;
@@ -50,6 +51,7 @@ public class EnrichedFlow {
     private Integer protocol;
     private SamplingAlgorithm samplingAlgorithm;
     private Double samplingInterval;
+    private SamplingProvenance samplingProvenance;
     private InetAddress srcAddr;
     private String srcAddrHostname;
     private Long srcAs;

--- a/src/main/java/org/riptide/repository/clickhouse/ClickhouseFlow.java
+++ b/src/main/java/org/riptide/repository/clickhouse/ClickhouseFlow.java
@@ -6,6 +6,7 @@
 package org.riptide.repository.clickhouse;
 
 import lombok.Data;
+import org.riptide.flows.parser.data.Flow;
 
 import java.net.Inet6Address;
 import java.time.Duration;
@@ -76,6 +77,11 @@ public class ClickhouseFlow {
 
     private byte samplingAlgorithm;
     private double samplingInterval = 1.0;
+
+    // Pairs with the 1.0 above: an unenriched flow carries no resolution, and "assumed" is the
+    // honest reading of a 1.0 nothing stated. '' is reserved for rows written before the column
+    // existed, which is a different fact and is not something the collector can produce.
+    private String samplingProvenance = Flow.SamplingProvenance.Assumed.token();
 
     private String application;
 

--- a/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
+++ b/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
@@ -314,5 +314,16 @@ public class ClickhouseRepository implements FlowRepository {
                 case PRIVATE -> (byte) 2;
             };
         }
+
+        /**
+         * A {@code LowCardinality(String)}, not an {@code Enum8} like the four above: the rung set
+         * is riptide's own and still growing, and the additive-column path can only add a column,
+         * never modify one, so an enum that later gained a value would need machinery that does
+         * not exist. The token comes off the constant rather than {@code name()} so renaming a
+         * Java constant cannot silently change what stored rows say.
+         */
+        protected String samplingProvenance(final Flow.SamplingProvenance value) {
+            return value.token();
+        }
     }
 }

--- a/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
+++ b/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
@@ -323,7 +323,7 @@ public class ClickhouseRepository implements FlowRepository {
          * Java constant cannot silently change what stored rows say.
          */
         protected String samplingProvenance(final Flow.SamplingProvenance value) {
-            return value != null ? value.token() : Flow.SamplingProvenance.Assumed.token();
+            return value.token();
         }
     }
 }

--- a/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
+++ b/src/main/java/org/riptide/repository/clickhouse/ClickhouseRepository.java
@@ -323,7 +323,7 @@ public class ClickhouseRepository implements FlowRepository {
          * Java constant cannot silently change what stored rows say.
          */
         protected String samplingProvenance(final Flow.SamplingProvenance value) {
-            return value.token();
+            return value != null ? value.token() : Flow.SamplingProvenance.Assumed.token();
         }
     }
 }

--- a/src/main/java/org/riptide/schema/FlowsSchema.java
+++ b/src/main/java/org/riptide/schema/FlowsSchema.java
@@ -192,6 +192,7 @@ public final class FlowsSchema {
         ADDITIVE_COLUMNS.put("dstCountry", "LowCardinality(String)");
         ADDITIVE_COLUMNS.put("dstCity", "LowCardinality(String)");
         ADDITIVE_COLUMNS.put("exporterName", "LowCardinality(String)");
+        ADDITIVE_COLUMNS.put("samplingProvenance", "LowCardinality(String)");
     }
 
     /** The additive column names, for callers distinguishing in-place-upgradeable columns. */
@@ -419,7 +420,12 @@ public final class FlowsSchema {
             srcCity LowCardinality(String),
             dstCountry LowCardinality(String),
             dstCity LowCardinality(String),
-            exporterName LowCardinality(String)
+            exporterName LowCardinality(String),
+
+            -- Which rung of the resolution ladder supplied samplingInterval: 'record', 'options',
+            -- 'header', 'derived', 'fallback' or 'assumed'. '' means the row was written before
+            -- this column existed, which is distinct from 'assumed' and is not backfillable.
+            samplingProvenance LowCardinality(String)
         ) ENGINE = MergeTree()
         ORDER BY (
             tenant, organisation,

--- a/src/test/java/org/riptide/flows/netflow5/Netflow5SamplingLadderTest.java
+++ b/src/test/java/org/riptide/flows/netflow5/Netflow5SamplingLadderTest.java
@@ -10,6 +10,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.junit.jupiter.api.Test;
 import org.riptide.flows.parser.data.Flow;
+import org.riptide.flows.parser.data.Flow.SamplingProvenance;
 import org.riptide.flows.parser.exceptions.InvalidPacketException;
 import org.riptide.flows.parser.netflow5.Netflow5FlowBuilder;
 import org.riptide.flows.parser.netflow5.proto.Header;
@@ -197,6 +198,57 @@ class Netflow5SamplingLadderTest {
                 .isEqualTo(1);
         assertThat(meter(metrics, "fallback")).as("two packets fell through to config").isEqualTo(2);
         assertThat(meter(metrics, "assumed")).as("no packet reached the default").isZero();
+    }
+
+    /**
+     * The meter and the column are two reports of one resolution, so they must never disagree.
+     * Both are named from the same enum constant; this is the assertion that the naming holds all
+     * the way through to the flow.
+     */
+    @Test
+    void theMeteredRungAndTheRecordedProvenanceAgree() throws Exception {
+        final var metrics = new MetricRegistry();
+        final var builder = new Netflow5FlowBuilder("test", metrics);
+        builder.setFlowSamplingIntervalFallback(500L);
+
+        assertThat(onlyFlow(packet(0, 1000), builder).getSamplingProvenance())
+                .isEqualTo(SamplingProvenance.Header);
+        assertThat(meter(metrics, SamplingProvenance.Header.token())).isEqualTo(1);
+
+        assertThat(onlyFlow(packet(0, 0), builder).getSamplingProvenance())
+                .isEqualTo(SamplingProvenance.Fallback);
+        assertThat(meter(metrics, SamplingProvenance.Fallback.token())).isEqualTo(1);
+
+        final var noFallback = new Netflow5FlowBuilder("test", metrics);
+        assertThat(onlyFlow(packet(0, 0), noFallback).getSamplingProvenance())
+                .isEqualTo(SamplingProvenance.Assumed);
+        assertThat(meter(metrics, SamplingProvenance.Assumed.token())).isEqualTo(1);
+    }
+
+    /** Every record in a packet carries the packet's provenance, as it carries its interval. */
+    @Test
+    void everyFlowInAPacketCarriesTheSameProvenance() throws Exception {
+        final var builder = new Netflow5FlowBuilder("test", new MetricRegistry());
+
+        assertThat(builder.buildFlows(Instant.EPOCH, packet(0, 1000, 3)).toList())
+                .allSatisfy(flow -> {
+                    assertThat(flow.getSamplingInterval()).isEqualTo(1000.0);
+                    assertThat(flow.getSamplingProvenance()).isEqualTo(SamplingProvenance.Header);
+                });
+    }
+
+    /**
+     * A header stating 1 is an exporter saying it does not sample. It reads as {@code header}, not
+     * {@code assumed} — the two produce the same interval and mean opposite things.
+     */
+    @Test
+    void aHeaderStatingOneIsAnAnswerNotAnAssumption() throws Exception {
+        final var builder = new Netflow5FlowBuilder("test", new MetricRegistry());
+
+        final var flow = onlyFlow(packet(0, 1), builder);
+
+        assertThat(flow.getSamplingInterval()).isEqualTo(1.0);
+        assertThat(flow.getSamplingProvenance()).isEqualTo(SamplingProvenance.Header);
     }
 
     @Test

--- a/src/test/java/org/riptide/flows/netflow5/Netflow5SamplingLadderTest.java
+++ b/src/test/java/org/riptide/flows/netflow5/Netflow5SamplingLadderTest.java
@@ -252,7 +252,7 @@ class Netflow5SamplingLadderTest {
     }
 
     @Test
-    void aPacketWithNoRateAnywhereIsMeteredAsUnsampled() throws Exception {
+    void aPacketWithNoRateAnywhereIsMeteredAsAssumed() throws Exception {
         final var metrics = new MetricRegistry();
         assertThat(new Netflow5FlowBuilder("test", metrics).buildFlows(Instant.EPOCH, packet(0, 0)).toList())
                 .hasSize(1);
@@ -266,7 +266,7 @@ class Netflow5SamplingLadderTest {
      * in the same registry rather than in separate ones.
      */
     @Test
-    void headerResolvedAndUnsampledExportersAreCountedApart() throws Exception {
+    void headerResolvedAndAssumedExportersAreCountedApart() throws Exception {
         final var metrics = new MetricRegistry();
         final var builder = new Netflow5FlowBuilder("test", metrics);
 

--- a/src/test/java/org/riptide/flows/parser/SamplingIntervalResolutionTest.java
+++ b/src/test/java/org/riptide/flows/parser/SamplingIntervalResolutionTest.java
@@ -6,7 +6,11 @@
 package org.riptide.flows.parser;
 
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.primitives.UnsignedLong;
+import io.netty.buffer.Unpooled;
 import org.junit.jupiter.api.Test;
+import org.riptide.flows.parser.data.Flow;
+import org.riptide.flows.parser.data.Flow.SamplingProvenance;
 import org.riptide.flows.parser.ie.Value;
 import org.riptide.flows.parser.ie.values.UnsignedValue;
 import org.riptide.flows.parser.ie.values.ValueConversionService;
@@ -24,6 +28,7 @@ import org.riptide.flows.parser.ipfix.IpFixFlowBuilder;
 import org.riptide.flows.parser.ipfix.IpfixRawFlow;
 import org.riptide.flows.parser.netflow9.Netflow9FlowBuilder;
 import org.riptide.flows.parser.netflow9.Netflow9RawFlow;
+import org.riptide.flows.parser.sflow.proto.Datagram;
 import org.riptide.flows.parser.session.ExporterSamplingTable;
 import org.riptide.flows.parser.session.ExporterSamplingTable.AdvertisedRate;
 import org.riptide.pipeline.ExporterIdentity;
@@ -37,7 +42,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * The sampling-rate resolution ladder: what the record carries, then what the exporter advertised
- * in its sampler options table, then what the operator configured, then unsampled.
+ * in its sampler options table, then what the operator configured, then an assumed 1.0 — and,
+ * for each, the provenance recorded alongside the value.
  *
  * <p>Built by hand rather than through Spring, following the fuzz harness.
  */
@@ -62,11 +68,24 @@ class SamplingIntervalResolutionTest {
         return raw;
     }
 
-    private static double v9Interval(final Netflow9RawFlow raw, final Double advertised, final Long fallback) {
+    private static Flow v9Flow(final Netflow9RawFlow raw, final Double advertised, final Long fallback) {
         final AdvertisedRate rate = advertised != null ? new AdvertisedRate(advertised, null) : null;
         final var builder = new Netflow9FlowBuilder(NETFLOW9);
         builder.setFlowSamplingIntervalFallback(fallback);
-        return builder.buildFlow(Instant.EPOCH, raw, rate).getSamplingInterval();
+        return builder.buildFlow(Instant.EPOCH, raw, rate);
+    }
+
+    private static double v9Interval(final Netflow9RawFlow raw, final Double advertised, final Long fallback) {
+        return v9Flow(raw, advertised, fallback).getSamplingInterval();
+    }
+
+    /**
+     * The interval and its provenance come off one flow, not two builds: they are two views of a
+     * single resolution, and asserting them together is what pins that they cannot disagree.
+     */
+    private static void assertResolved(final Flow flow, final double interval, final SamplingProvenance from) {
+        assertThat(flow.getSamplingInterval()).isEqualTo(interval);
+        assertThat(flow.getSamplingProvenance()).isEqualTo(from);
     }
 
     @Test
@@ -74,7 +93,7 @@ class SamplingIntervalResolutionTest {
         final var raw = v9Raw();
         raw.SAMPLING_INTERVAL = 512.0;
 
-        assertThat(v9Interval(raw, 1000.0, 2000L)).isEqualTo(512.0);
+        assertResolved(v9Flow(raw, 1000.0, 2000L), 512.0, SamplingProvenance.Record);
     }
 
     /** The ASR9k sampler table names the rate field 50, so the record form of it counts too. */
@@ -83,23 +102,23 @@ class SamplingIntervalResolutionTest {
         final var raw = v9Raw();
         raw.FLOW_SAMPLER_RANDOM_INTERVAL = 256.0;
 
-        assertThat(v9Interval(raw, 1000.0, 2000L)).isEqualTo(256.0);
+        assertResolved(v9Flow(raw, 1000.0, 2000L), 256.0, SamplingProvenance.Record);
     }
 
     /** The case this change exists for: nothing on the record, a rate in the options table. */
     @Test
     void netflow9FallsBackToTheAdvertisedRate() {
-        assertThat(v9Interval(v9Raw(), 1000.0, 2000L)).isEqualTo(1000.0);
+        assertResolved(v9Flow(v9Raw(), 1000.0, 2000L), 1000.0, SamplingProvenance.Options);
     }
 
     @Test
     void netflow9FallsBackToConfigurationWhenTheExporterSaysNothing() {
-        assertThat(v9Interval(v9Raw(), null, 2000L)).isEqualTo(2000.0);
+        assertResolved(v9Flow(v9Raw(), null, 2000L), 2000.0, SamplingProvenance.Fallback);
     }
 
     @Test
-    void netflow9ReportsUnsampledWhenNothingIsKnown() {
-        assertThat(v9Interval(v9Raw(), null, null)).isEqualTo(1.0);
+    void netflow9AssumesUnsampledWhenNothingIsKnown() {
+        assertResolved(v9Flow(v9Raw(), null, null), 1.0, SamplingProvenance.Assumed);
     }
 
     /**
@@ -116,13 +135,32 @@ class SamplingIntervalResolutionTest {
         assertThat(v9Interval(raw, null, 2000L)).isEqualTo(1.0);
     }
 
+    /**
+     * The distinction the column exists for. Both flows report 1.0; only the provenance separates
+     * an exporter that said "I do not sample" from one that said nothing at all.
+     */
+    @Test
+    void netflow9DistinguishesAStatedRateOfOneFromAnAssumedOne() {
+        final var stated = v9Raw();
+        stated.SAMPLING_INTERVAL = 1.0;
+
+        assertResolved(v9Flow(stated, null, null), 1.0, SamplingProvenance.Record);
+        assertResolved(v9Flow(v9Raw(), null, null), 1.0, SamplingProvenance.Assumed);
+    }
+
+    /** An options table advertising 1 is an answer too, and names its own rung. */
+    @Test
+    void netflow9AttributesAnAdvertisedRateOfOneToTheOptionsTable() {
+        assertResolved(v9Flow(v9Raw(), 1.0, null), 1.0, SamplingProvenance.Options);
+    }
+
     /** 0 is a placeholder rather than an answer, so it falls through. */
     @Test
     void netflow9TreatsAZeroRecordRateAsNoAnswer() {
         final var raw = v9Raw();
         raw.SAMPLING_INTERVAL = 0.0;
 
-        assertThat(v9Interval(raw, null, 2000L)).isEqualTo(2000.0);
+        assertResolved(v9Flow(raw, null, 2000L), 2000.0, SamplingProvenance.Fallback);
     }
 
     /** The join this change exists for: a rate in the table reaches the flow the builder makes. */
@@ -171,10 +209,14 @@ class SamplingIntervalResolutionTest {
 
     // ---- IPFIX ------------------------------------------------------------------------------
 
-    private static double ipfixInterval(final IpfixRawFlow raw, final Long fallback) {
+    private static Flow ipfixFlow(final IpfixRawFlow raw, final Long fallback) {
         final var builder = new IpFixFlowBuilder(IPFIX);
         builder.setFlowSamplingIntervalFallback(fallback);
-        return builder.buildFlow(Instant.EPOCH, raw).getSamplingInterval();
+        return builder.buildFlow(Instant.EPOCH, raw);
+    }
+
+    private static double ipfixInterval(final IpfixRawFlow raw, final Long fallback) {
+        return ipfixFlow(raw, fallback).getSamplingInterval();
     }
 
     /**
@@ -213,12 +255,88 @@ class SamplingIntervalResolutionTest {
         final var raw = new IpfixRawFlow();
         raw.samplingInterval = 512.0;
 
-        assertThat(ipfixInterval(raw, 2000L)).isEqualTo(512.0);
+        assertResolved(ipfixFlow(raw, 2000L), 512.0, SamplingProvenance.Record);
     }
 
     @Test
     void ipfixFallsBackToConfiguration() {
-        assertThat(ipfixInterval(new IpfixRawFlow(), 2000L)).isEqualTo(2000.0);
+        assertResolved(ipfixFlow(new IpfixRawFlow(), 2000L), 2000.0, SamplingProvenance.Fallback);
     }
 
+    @Test
+    void ipfixAssumesUnsampledWhenNothingIsKnown() {
+        assertResolved(ipfixFlow(new IpfixRawFlow(), null), 1.0, SamplingProvenance.Assumed);
+    }
+
+    /**
+     * A rate riptide computed is not a rate the exporter stated, and the column says which. This is
+     * the rung that carries the least authority, so conflating it with {@code record} would be the
+     * most misleading of the six.
+     */
+    @Test
+    void ipfixNamesAComputedRateAsDerived() {
+        final var raw = new IpfixRawFlow();
+        raw.selectorAlgorithm = 3;
+        raw.samplingSize = 1.0;
+        raw.samplingPopulation = 1000.0;
+
+        assertResolved(ipfixFlow(raw, 2000L), 1000.0, SamplingProvenance.Derived);
+    }
+
+    /**
+     * The laziness the builder's own comment demands, pinned. A record carrying its own rate must
+     * not evaluate the selector-algorithm rung: that rung divides by exporter-supplied ranges, and
+     * a degenerate one would cost the whole packet's batch. The degenerate range here would be
+     * reached only if the rung ran — reading provenance as well as the interval must not run it
+     * either, which is the property the memoized single traversal buys.
+     */
+    @Test
+    void ipfixDoesNotDeriveWhenTheRecordCarriesItsOwnRate() {
+        final var raw = new IpfixRawFlow();
+        raw.samplingInterval = 512.0;
+        raw.selectorAlgorithm = 5;
+        raw.hashSelectedRangeMin = UnsignedLong.ZERO;
+        raw.hashSelectedRangeMax = UnsignedLong.ZERO;
+
+        final var flow = ipfixFlow(raw, null);
+
+        assertResolved(flow, 512.0, SamplingProvenance.Record);
+        // reading either accessor again must not walk the ladder a second time
+        assertResolved(flow, 512.0, SamplingProvenance.Record);
+    }
+
+    // ---- sFlow ------------------------------------------------------------------------------
+
+    /** A v5 datagram carrying one compact flow sample at the given rate and no flow records. */
+    private static Datagram sflowDatagram(final long samplingRate) throws Exception {
+        final var sample = Unpooled.buffer()
+                .writeInt(1)                        // sequence
+                .writeInt(0)                        // source_id
+                .writeInt((int) samplingRate)
+                .writeInt(0)                        // sample pool
+                .writeInt(0)                        // drops
+                .writeInt(0)                        // input interface
+                .writeInt(0)                        // output interface
+                .writeInt(0);                       // flow record count
+        final var datagram = Unpooled.buffer()
+                .writeInt(Datagram.VERSION)
+                .writeInt(1)                        // agent address type: IPv4
+                .writeBytes(InetAddress.getByName("192.0.2.1").getAddress())
+                .writeInt(0)                        // sub-agent id
+                .writeInt(1)                        // sequence
+                .writeInt(0)                        // uptime
+                .writeInt(1)                        // sample count
+                .writeInt(1)                        // sample type: flow sample
+                .writeInt(sample.readableBytes())
+                .writeBytes(sample);
+        return new Datagram(datagram);
+    }
+
+    /** sFlow carries the rate on the sample by construction: one rung, always {@code record}. */
+    @Test
+    void sflowAttributesTheRateToTheSample() throws Exception {
+        final var flow = sflowDatagram(1024).buildFlows(Instant.EPOCH).findFirst().orElseThrow();
+
+        assertResolved(flow, 1024.0, SamplingProvenance.Record);
+    }
 }

--- a/src/test/java/org/riptide/provisioning/ProvisioningDdlTest.java
+++ b/src/test/java/org/riptide/provisioning/ProvisioningDdlTest.java
@@ -57,11 +57,14 @@ class ProvisioningDdlTest {
         // Additive column upgrades are emitted on every run (before the grants, same
         // table-exists precondition) so re-running onboard upgrades a pre-existing table in place.
         final List<String> sql = ProvisioningDdl.ensureShared("riptide", 50_000_000_000L);
+        final int additive = FlowsSchema.additiveColumnNames().size();
         assertThat(sql.get(0)).isEqualTo(
                 "ALTER TABLE `riptide`.flows ADD COLUMN IF NOT EXISTS srcCountry LowCardinality(String)");
-        assertThat(sql.subList(0, 5)).allMatch(s -> s.contains("ADD COLUMN IF NOT EXISTS"));
-        assertThat(sql).filteredOn(s -> s.contains("ADD COLUMN")).hasSize(5);
-        assertThat(sql.get(4)).contains("exporterName LowCardinality(String)");
+        // Counted off the additive set rather than a literal, so adding a column here is a
+        // one-line change in FlowsSchema and not a test edit.
+        assertThat(sql.subList(0, additive)).allMatch(s -> s.contains("ADD COLUMN IF NOT EXISTS"));
+        assertThat(sql).filteredOn(s -> s.contains("ADD COLUMN")).hasSize(additive);
+        assertThat(sql.get(additive - 1)).contains("samplingProvenance LowCardinality(String)");
     }
 
     @Test
@@ -69,7 +72,8 @@ class ProvisioningDdlTest {
         assertThat(ProvisioningDdl.bootstrapSchema("riptide", 30).get(1))
                 .contains("srcCountry LowCardinality(String)")
                 .contains("dstCity LowCardinality(String)")
-                .contains("exporterName LowCardinality(String)");
+                .contains("exporterName LowCardinality(String)")
+                .contains("samplingProvenance LowCardinality(String)");
     }
 
     @Test

--- a/src/test/java/org/riptide/repository/clickhouse/ClickhouseRepositoryIT.java
+++ b/src/test/java/org/riptide/repository/clickhouse/ClickhouseRepositoryIT.java
@@ -26,6 +26,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
 
@@ -355,7 +356,7 @@ public class ClickhouseRepositoryIT {
     }
 
     @Test
-    void geoColumnsPersistAndPreGeoTableUpgradesInPlace() throws Exception {
+    void additiveColumnsPersistAndAnOlderTableUpgradesInPlace() throws Exception {
         final var database = "geo_upgrade";
         final var config = configFor(database, true);
         final var repo = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), config, RESOLVERS);
@@ -368,9 +369,11 @@ public class ClickhouseRepositoryIT {
             queryClient.execute("DROP VIEW IF EXISTS " + FlowsSchema.qualifiedRollupView(database, rollup)).get();
         }
 
-        // Simulate a pre-geo table: keep a persisted row, then drop the geo columns.
+        // Simulate an older table: keep a persisted row, then drop every additive column. Driven
+        // off additiveColumnNames() rather than a literal list, so a column added to the additive
+        // set is covered here without editing this test.
         repo.persist(List.of(testFlow(Instant.now().truncatedTo(ChronoUnit.MILLIS), 60001, 443, 100L)));
-        for (final String column : List.of("srcCountry", "srcCity", "dstCountry", "dstCity", "exporterName")) {
+        for (final String column : FlowsSchema.additiveColumnNames()) {
             queryClient.execute("ALTER TABLE " + database + ".flows DROP COLUMN " + column).get();
         }
 
@@ -381,12 +384,15 @@ public class ClickhouseRepositoryIT {
                 .hasMessageContaining("exporterName")
                 .hasMessageContaining("riptide onboard");
 
-        // Manage mode adds the columns back in place; the pre-geo row survives and reads ''.
+        // Manage mode adds the columns back in place; the older row survives and reads ''.
         final var upgraded = new ClickhouseRepository(new ClickhouseRepository$FlowMapperImpl(), config, RESOLVERS);
         Assertions.assertThatCode(upgraded::start).doesNotThrowAnyException();
         final var legacy = queryClient.queryAll(
-                "SELECT srcCountry FROM " + database + ".flows WHERE srcPort = 60001");
+                "SELECT srcCountry, samplingProvenance FROM " + database + ".flows WHERE srcPort = 60001");
         Assertions.assertThat(legacy.getFirst().getString("srcCountry")).isEmpty();
+        // '' is the marker for "written before the column existed" — distinct from 'assumed',
+        // which is a resolution riptide actually made, and not backfillable into these rows.
+        Assertions.assertThat(legacy.getFirst().getString("samplingProvenance")).isEmpty();
 
         // An enriched flow round-trips its geo fields.
         final var geoFlow = testFlow(Instant.now().truncatedTo(ChronoUnit.MILLIS), 60002, 443, 100L);
@@ -403,6 +409,35 @@ public class ClickhouseRepositoryIT {
         Assertions.assertThat(row.getString("srcCity")).isEqualTo("Fulda");
         Assertions.assertThat(row.getString("dstCountry")).isEqualTo("US");
         Assertions.assertThat(row.getString("dstCity")).isEqualTo("Ashburn");
+    }
+
+    /** Every rung round-trips to a readable token, and the two 1.0 rows stay distinguishable. */
+    @Test
+    void everySamplingProvenanceRoundTripsThroughTheColumn() throws Exception {
+        final var database = "provenance_round_trip";
+        final var repo = new ClickhouseRepository(
+                new ClickhouseRepository$FlowMapperImpl(), configFor(database, true), RESOLVERS);
+        repo.start();
+
+        int port = 61000;
+        final var expected = new LinkedHashMap<Integer, Flow.SamplingProvenance>();
+        for (final var provenance : Flow.SamplingProvenance.values()) {
+            final var flow = testFlow(Instant.now().truncatedTo(ChronoUnit.MILLIS), port, 443, 100L);
+            flow.setSamplingProvenance(provenance);
+            // Two rungs legitimately produce 1.0; the column is what separates them.
+            flow.setSamplingInterval(provenance == Flow.SamplingProvenance.Assumed ? 1.0 : 1000.0);
+            repo.persist(List.of(flow));
+            expected.put(port, provenance);
+            port++;
+        }
+
+        for (final var entry : expected.entrySet()) {
+            final var row = queryClient.queryAll("SELECT samplingProvenance FROM " + database
+                    + ".flows WHERE srcPort = " + entry.getKey()).getFirst();
+            Assertions.assertThat(row.getString("samplingProvenance"))
+                    .describedAs("provenance for %s", entry.getValue())
+                    .isEqualTo(entry.getValue().token());
+        }
     }
 
     private static ClickhouseConfig configFor(final String database, final boolean manageSchema) {
@@ -468,6 +503,7 @@ public class ClickhouseRepositoryIT {
                 .tos(0)
                 .samplingAlgorithm(Flow.SamplingAlgorithm.Unassigned)
                 .samplingInterval(1.0)
+                .samplingProvenance(Flow.SamplingProvenance.Assumed)
                 .srcLocality(Flow.Locality.PUBLIC)
                 .dstLocality(Flow.Locality.PUBLIC)
                 .flowLocality(Flow.Locality.PUBLIC)

--- a/src/test/java/org/riptide/schema/FlowsSchemaTest.java
+++ b/src/test/java/org/riptide/schema/FlowsSchemaTest.java
@@ -41,6 +41,42 @@ class FlowsSchemaTest {
                 .contains("PARTITION BY toYYYYMMDD(timestamp)");
     }
 
+    /**
+     * The additive columns are the ones an existing table can gain in place. Both emissions come
+     * off one map, so a fresh table and an upgraded one end up with the same columns in the same
+     * order — the property that keeps the two shapes from diverging over successive upgrades.
+     */
+    @Test
+    void additiveColumnsAppearInBothTheCreateAndTheAlterPath() {
+        final String create = FlowsSchema.createFlowsTable("riptide");
+        final List<String> alters = FlowsSchema.addAdditiveColumns("riptide");
+
+        assertThat(FlowsSchema.additiveColumnNames()).contains("samplingProvenance");
+        assertThat(create).contains("samplingProvenance LowCardinality(String)");
+        assertThat(alters).contains(
+                "ALTER TABLE `riptide`.flows ADD COLUMN IF NOT EXISTS samplingProvenance LowCardinality(String)");
+
+        // Every additive column is emitted by both paths, in the same relative order.
+        final var declarationOrder = FlowsSchema.additiveColumnNames().stream()
+                .sorted(java.util.Comparator.comparingInt(create::indexOf))
+                .toList();
+        final var alterOrder = alters.stream()
+                .map(statement -> statement.replaceAll(".*ADD COLUMN IF NOT EXISTS (\\w+).*", "$1"))
+                .toList();
+        assertThat(alterOrder).containsExactlyElementsOf(declarationOrder);
+    }
+
+    /**
+     * A {@code LowCardinality(String)}, not an {@code Enum8}: the additive path can only add a
+     * column, so a rung added to the vocabulary later must not require an {@code ALTER … MODIFY}.
+     */
+    @Test
+    void provenanceIsAStringSoTheRungSetCanGrow() {
+        assertThat(FlowsSchema.createFlowsTable("riptide"))
+                .contains("samplingProvenance LowCardinality(String)")
+                .doesNotContain("samplingProvenance Enum8");
+    }
+
     @Test
     void timeColumnsPinUtcTimezone() {
         // The schema is timezone-explicit so stored instants display/parse in UTC regardless of the


### PR DESCRIPTION
Closes #467.

## The problem

`samplingInterval = 1.0` is ambiguous for every protocol between two opposite facts:

- the exporter said it does not sample — an answer, which `usable()` deliberately treats as beating a configured fallback
- nothing was known anywhere, and riptide wrote `1.0` in the absence of a rate

No query can separate them. Every builder already resolves through an explicit ladder and knows which rung answered — `Netflow5FlowBuilder` even meters it per packet — and then throws the rung away one line after computing it.

## What this does

Flows carry `samplingProvenance` beside the interval:

| value | the rate came from |
|---|---|
| `record` | the flow record (v9/IPFIX fields 34/49/50), or an sFlow sample |
| `options` | the exporter's sampler options table (v9) |
| `header` | the NetFlow v5 packet header |
| `derived` | riptide's arithmetic on an IPFIX selector algorithm and its ranges |
| `fallback` | the receiver's `flow-sampling-interval-fallback` |
| `assumed` | nothing stated a rate; `1.0` recorded in the absence of one |
| `''` | the row predates the column |

**One traversal, not two.** `ResolvedRate(interval, from)` is the ladder's single return type, memoized per flow. A second `getSamplingProvenance()` walking the ladder again would drift on the first edit and is unsafe in IPFIX regardless: that builder's selector-algorithm rung divides by exporter-supplied ranges and must not run for a record that already carries its rate. There is a test pinning that reading the provenance does not trip it.

**`derived` is deliberately not `record`.** It is riptide's inference from exporter-supplied ranges, not the exporter's statement, so it carries less authority and is the value to distrust first.

**`LowCardinality(String)`, not `Enum8`.** `ADDITIVE_COLUMNS` can only `ADD COLUMN`, never `MODIFY`, and this vocabulary is riptide's own and still growing (nfdump's equivalent set grew to include an override tier riptide has deferred twice). The wire token comes off the enum constant, so renaming the Java constant cannot silently rewrite what stored rows mean — and the v5 rung meters are named from the same tokens, so metric and column cannot drift.

## Upgrade

In place, through the existing additive path: `ALTER TABLE … ADD COLUMN IF NOT EXISTS`, no operator action, no data loss. Provisioned deployments fail fast naming the column and pointing at `riptide onboard`. Pre-existing rows read `''` — distinct from `assumed` — and are not backfilled, because reconstructing them needs each exporter's rate at each past moment, which is the information whose absence motivates the column.

No existing column, value or query result changes.

## What it buys

- The #465 discontinuity is a predicate (`WHERE samplingProvenance = 'header'`) instead of a remembered upgrade date. The prose `GROUP BY` recipe in `receivers.md` is replaced.
- A flapping exporter is visible in the data, not just in a meter — including the v9 case where the sampler options table expires between refreshes, which `ExporterSamplingTable`'s own comment describes as having "nothing in the data to tell the two apart".
- `riptide-data-trust` gains the rate source per exporter, plus a stat counting exporters whose rate resolved from more than one rung.

## Prior art

nfdump models the same taxonomy (`SAMPLER_OVERWRITE`/`_DEFAULT`/`_GENERIC`) and persists it, but exposes it nowhere — it multiplies at ingest, so the row is already committed. Akvorado, the one collector with riptide's architecture (raw counters, query-time `Bytes*SamplingRate`), has no provenance column because it *rejects* flows with no rate unless `default-sampling-rate` is set. That does not port here: riptide's fallback is per-receiver, so rejecting would drop every exporter sharing a port. pmacct operators hand-roll provenance with a `pre_tag_map`. Full survey in the change's `design.md`.

## Verification

`make jar` — 1041 tests, 0 failures; SpotBugs 0; coverage checks met.
`make e2e` — 42 integration tests, 0 failures, including a new `ClickhouseRepositoryIT` case round-tripping every rung through the column, and the additive-upgrade case now driven off `additiveColumnNames()` rather than a literal list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)