### PR TITLE
fix(snmp): make the back-off overflow-proof instead of checking for it

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -11060,9 +11060,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/src/main/java/org/riptide/snmp/InterfaceSnapshotPoller.java
+++ b/src/main/java/org/riptide/snmp/InterfaceSnapshotPoller.java
@@ -372,14 +372,15 @@ public class InterfaceSnapshotPoller implements InterfaceSource {
         final long ceiling = Math.max(base, this.config.getDeadEndpointCeilingMs());
         final int doublings = Math.max(0, Math.min(consecutiveFailures - 1, 30));
         long delay = base;
-        for (int i = 0; i < doublings; i++) {
-            delay *= 2;
-            if (delay >= ceiling || delay < 0) {
-                delay = ceiling;
-                break;
-            }
+        for (int i = 0; i < doublings && delay < ceiling; i++) {
+            // Test against half the ceiling rather than doubling first and clamping after. The
+            // latter needs an overflow check that can never fire (the ceiling is reached first),
+            // so it reads as a guard while being dead code. This keeps delay within
+            // [base, ceiling] by construction, so it can never go negative — which would
+            // schedule the next walk in the past and busy-loop the endpoint being backed off.
+            delay = delay > ceiling / 2 ? ceiling : delay * 2;
         }
-        return millisToNanos(Math.min(delay, ceiling));
+        return millisToNanos(delay);
     }
 
     /**


### PR DESCRIPTION
Clears the two open code scanning alerts that have a real fix behind them.

## `java/constant-comparison` (alert 132, warning)

`InterfaceSnapshotPoller.backoffNanos` doubled the retry delay and clamped afterwards, guarding the double with `delay < 0`. That guard can never fire — the loop always breaks at `delay >= ceiling` first — so it read as a safety net while being dead code.

Testing against half the ceiling *before* doubling keeps `delay` within `[base, ceiling]` by construction, which is the property the caller needs: a negative delay would schedule the next walk in the past and busy-loop the very endpoint the back-off exists to leave alone. The trailing `Math.min` becomes redundant and goes.

Behaviour is unchanged. `backOffLengthensOnRepeatedFailureAndCapsAtTheCeiling` (base 1000, ceiling 8000) covers the sequence `1000 → 2000 → 4000 → 8000` and its cap; it produces the same values before and after.

Worth noting this ships in the next release either way — `InterfaceSnapshotPoller` arrived with #448 and has not been released yet, so the dead branch would have gone out in it.

## js-yaml (alert 120, high)

GHSA-5p4m-2wfm-xmqj, quadratic CPU consumption in `!!omap` resolution. `docs/` resolves js-yaml 4.3.0 transitively through Docusaurus; 4.3.1 is patched. A targeted three-line lockfile bump, not a re-resolve.

Build-time dependency of the documentation site only — it does not reach the jar, the packages, or the container image, so this is not a product vulnerability. It is simply the one high-severity alert open.

## Verification

`make jar` green locally: SpotBugs 0, checkstyle, Error Prone, Surefire, coverage gates met.

## Not in this PR

- Alert 137 (`missing-override-annotation`) is on `canEqual`, generated by Lombok `@Data`. Not fixable in source.
- Alerts 133/134/136 (`uncaught-number-format-exception`) are test code parsing a regex group capturing `(\d+)`.
- Scorecard fuzzing (118) and OpenSSF badge (117) are separate work.
- Scorecard SAST (119) and CI tests (135) both score 9/10; the misses are non-PR commits such as the release merge-back.

Closes #472
