### PR TITLE
docs: add the OpenSSF Best Practices badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
 [![Latest Release](https://img.shields.io/github/v/release/Riptide-Labs/riptide?sort=semver)](https://github.com/Riptide-Labs/riptide/releases)
 [![License](https://img.shields.io/github/license/Riptide-Labs/riptide)](LICENSE)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13984/badge)](https://www.bestpractices.dev/projects/13984)
 [![Container Image](https://img.shields.io/badge/ghcr.io-riptide-blue?logo=docker)](https://github.com/Riptide-Labs/riptide/pkgs/container/riptide)
 [![Java](https://img.shields.io/badge/dynamic/xml?url=https%3A%2F%2Fraw.githubusercontent.com%2FRiptide-Labs%2Friptide%2Fmain%2Fpom.xml&query=%2F%2F*%5Blocal-name()%3D%27java.version%27%5D&label=Java&logo=openjdk)](pom.xml)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->


### PR DESCRIPTION
Closes #475.

Adds the OpenSSF Best Practices badge to the README badge row, next to the license badge, since both describe the project's standing rather than its build state.

The project is registered as [bestpractices.dev project 13984](https://www.bestpractices.dev/en/projects/13984). Scorecard's `CII-Best-Practices` check scored 0 because it found no badge entry at all; registration alone lifts that off the floor. The badge image tracks the assessment level automatically, so it needs no further maintenance as criteria are answered.

## Before merging

The badge currently renders `in progress 0%`. The entry carries two independent assessments and both are still mostly unanswered:

| Assessment | State |
| --- | --- |
| OSPS Baseline Level 1 | 54% (13/24 auto-detected) |
| Classic passing badge | 0% (0/67 answered) |

Scorecard reads the **classic** badge level, not the Baseline tier. Filling in the classic self-assessment is what takes the check from 2/10 to 5/10 and makes the badge read `passing`. That is a web form on bestpractices.dev, not a repo change, so it is not part of this PR.

One criterion needs a repo setting first: **OSPS-AC-03.01** (direct commits to the primary branch must be prevented). `main`'s protection has `enforce_admins: false` with `required_approving_review_count: 0`, so an administrator can push past the required `build`/`e2e`/`lint` checks. Enabling admin enforcement keeps merges working and only closes the check-bypassing path.

Everything else in both assessments answers Met or N/A from evidence already in the repo: DCO enforcement, `SECURITY.md` with private vulnerability reporting, cosign-signed releases with SBOM and SLSA provenance, CodeQL + SpotBugs + Error Prone, nightly Jazzer fuzzing of all four parsers, a JaCoCo coverage gate, and secret scanning with push protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)