### PR TITLE
docs: add the OpenSSF Baseline badge and group the README badges by theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
 
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+<!-- status -->
 [![Riptide Build](https://github.com/Riptide-Labs/riptide/actions/workflows/build.yml/badge.svg)](https://github.com/Riptide-Labs/riptide/actions/workflows/build.yml)
-[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
 [![Latest Release](https://img.shields.io/github/v/release/Riptide-Labs/riptide?sort=semver)](https://github.com/Riptide-Labs/riptide/releases)
-[![License](https://img.shields.io/github/license/Riptide-Labs/riptide)](LICENSE)
-[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13984/badge)](https://www.bestpractices.dev/projects/13984)
-[![OpenSSF Baseline](https://www.bestpractices.dev/projects/13984/baseline)](https://www.bestpractices.dev/en/projects/13984/baseline-1)
 [![Container Image](https://img.shields.io/badge/ghcr.io-riptide-blue?logo=docker)](https://github.com/Riptide-Labs/riptide/pkgs/container/riptide)
 [![Java](https://img.shields.io/badge/dynamic/xml?url=https%3A%2F%2Fraw.githubusercontent.com%2FRiptide-Labs%2Friptide%2Fmain%2Fpom.xml&query=%2F%2F*%5Blocal-name()%3D%27java.version%27%5D&label=Java&logo=openjdk)](pom.xml)
+
+<!-- security & licensing -->
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13984/badge)](https://www.bestpractices.dev/projects/13984)
+[![OpenSSF Baseline](https://www.bestpractices.dev/projects/13984/baseline)](https://www.bestpractices.dev/en/projects/13984/baseline-1)
+[![License](https://img.shields.io/github/license/Riptide-Labs/riptide)](LICENSE)
+
+<!-- community -->
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ![riptide-logo](./artwork/riptide-logo.png)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Latest Release](https://img.shields.io/github/v/release/Riptide-Labs/riptide?sort=semver)](https://github.com/Riptide-Labs/riptide/releases)
 [![License](https://img.shields.io/github/license/Riptide-Labs/riptide)](LICENSE)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13984/badge)](https://www.bestpractices.dev/projects/13984)
+[![OpenSSF Baseline](https://www.bestpractices.dev/projects/13984/baseline)](https://www.bestpractices.dev/en/projects/13984/baseline-1)
 [![Container Image](https://img.shields.io/badge/ghcr.io-riptide-blue?logo=docker)](https://github.com/Riptide-Labs/riptide/pkgs/container/riptide)
 [![Java](https://img.shields.io/badge/dynamic/xml?url=https%3A%2F%2Fraw.githubusercontent.com%2FRiptide-Labs%2Friptide%2Fmain%2Fpom.xml&query=%2F%2F*%5Blocal-name()%3D%27java.version%27%5D&label=Java&logo=openjdk)](pom.xml)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->


### PR DESCRIPTION
Follow-up to #476 / #475.

## Add the OpenSSF Baseline badge

Both OpenSSF self-assessments are now at 100%: the classic badge reads `passing`, and Baseline Level 1 was achieved on 2026-08-07.

The two badges report different things, and neither level implies the other:

- **OpenSSF Best Practices** is the classic passing/silver/gold tier. This is the one Scorecard's `CII-Best-Practices` check reads.
- **OpenSSF Baseline** is conformance level against the OSPS Baseline, a separate and more security-specific criteria set with three levels.

The Baseline badge links to the `baseline-1` assessment rather than the project root, so a reader lands on the criteria the badge is actually reporting.

## Group the badges by theme

Eight badges in one undifferentiated run gave a reader nothing to navigate by. GitHub does not hard-break inside a paragraph, so they all flowed into a single wrapped row regardless of being one per line in the source. Splitting them into paragraphs is what actually produces rows.

Verified against GitHub's own `/markdown` renderer:

| Row | Badges |
| --- | --- |
| status | Riptide Build, Latest Release, Container Image, Java |
| security & licensing | OpenSSF Best Practices, OpenSSF Baseline, License |
| community | All Contributors |

## Drive-by fix

The `ALL-CONTRIBUTORS-BADGE:START/END` markers previously wrapped all eight badges. The all-contributors CLI replaces everything between those markers with its own badge, so a regeneration would have deleted the other seven. The markers now enclose the contributors badge alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)