### PR TITLE
docs: regenerate the contributor list and fail the build when it drifts

### DIFF
--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -52,3 +52,10 @@ jobs:
       - name: Lint workflows
         run: |
           make lint-actions
+      # Not about workflows, but it belongs to the same "enforce it mechanically"
+      # job and needs no extra permissions. The contributor badge count and the
+      # credit table are literals in README.md, so they drift silently whenever
+      # .all-contributorsrc is edited without re-running the generator.
+      - name: Check the contributor list is in sync
+        run: |
+          make contributors-check

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ SNAPSHOT_VERSION    := $(MAJOR_VERSION).$(MINOR_VERSION).$(shell expr $(PATCH_VE
 OCI_TAG             := riptide:local
 DATE                := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ") # Date format RFC3339
 JAVA_MAJOR_VERSION  := 25
+# Pinned like actionlint and zizmor: an unpinned `npx all-contributors-cli` would
+# let a new release rewrite README.md and turn the sync check red on its own
+ALL_CONTRIBUTORS_VERSION := 6.26.1
 RELEASE_LOG         := target/release.log
 OK                  := "[ 👍 ]"
 SKIP                := "[ ⏭️ ]"
@@ -58,6 +61,8 @@ help:
 	@echo "  fuzz:         Coverage-guided fuzzing of the flow parsers (Jazzer); FUZZ_TIME=<seconds> per target"
 	@echo "  bench:        Run the JMH microbenchmarks; BENCH_TARGET=<regex> to narrow, BENCH_OPTS=<jmh flags>"
 	@echo "  lint-actions: Lint the GitHub Actions workflows (actionlint + zizmor)"
+	@echo "  contributors: Regenerate the README contributor badge and table from .all-contributorsrc"
+	@echo "  contributors-check: Fail if the README contributor section is out of sync with .all-contributorsrc"
 	@echo "  docs:         Build the Docusaurus documentation site into docs/build"
 	@echo "  docs-serve:   Run the documentation site locally with live reload"
 	@echo "  landing-serve: Serve the landing page locally for preview"
@@ -136,6 +141,26 @@ deps-lint-actions:
 lint-actions: deps-lint-actions
 	actionlint
 	zizmor --persona=regular .github/workflows
+
+.PHONY: deps-contributors
+deps-contributors:
+	command -v npx
+
+# The badge count and the credit table are literals in README.md, rewritten only
+# when the generator runs. .all-contributorsrc is the source of truth; edit it,
+# then run this.
+.PHONY: contributors
+contributors: deps-contributors
+	npx -y all-contributors-cli@$(ALL_CONTRIBUTORS_VERSION) generate
+
+# Fails when the committed README.md no longer matches .all-contributorsrc.
+# Drift is silent otherwise — the badge read 1 while the rc file listed two
+# contributors, and nothing caught it.
+.PHONY: contributors-check
+contributors-check: contributors
+	@git diff --exit-code -- README.md \
+		|| { echo "$(FAIL) README.md is out of sync with .all-contributorsrc — run 'make contributors' and commit the result"; exit 1; }
+	@echo "$(OK) README.md matches .all-contributorsrc"
 
 .PHONY: deps-docs
 deps-docs:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <!-- community -->
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ![riptide-logo](./artwork/riptide-logo.png)
@@ -167,7 +167,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   <tbody>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="http://open-desk.org"><img src="https://avatars.githubusercontent.com/u/405105?v=4?s=100" width="100px;" alt="Dustin Frisch"/><br /><sub><b>Dustin Frisch</b></sub></a><br /><a href="https://github.com/Riptide-Labs/riptide/commits?author=fooker" title="Code">💻</a> <a href="#research-fooker" title="Research">🔬</a> <a href="https://github.com/Riptide-Labs/riptide/pulls?q=is%3Apr+reviewed-by%3Afooker" title="Reviewed Pull Requests">👀</a> <a href="#ideas-fooker" title="Ideas, Planning, & Feedback">🤔</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://blog.no42.org"><img src="https://avatars.githubusercontent.com/u/1095181?v=4?s=100" width="100px;" alt="Ronny Trommer"/><br /><sub><b>Ronny Trommer</b></sub></a><br /><a href="#infra-indigo423" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://blog.no42.org"><img src="https://avatars.githubusercontent.com/u/1095181?v=4?s=100" width="100px;" alt="Ronny Trommer"/><br /><sub><b>Ronny Trommer</b></sub></a><br /><a href="https://github.com/Riptide-Labs/riptide/commits?author=indigo423" title="Code">💻</a> <a href="https://github.com/Riptide-Labs/riptide/commits?author=indigo423" title="Documentation">📖</a> <a href="#infra-indigo423" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="#maintenance-indigo423" title="Maintenance">🚧</a></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Follow-up to #477.

The All Contributors badge read `1` while `.all-contributorsrc` listed two contributors.

## The fix

The count is not dynamic. `all_contributors-1-orange` is a literal in the shields.io URL, rewritten only when the all-contributors CLI runs. The rc file had gained a second contributor and a wider set of credits for @indigo423, but `generate` was never re-run, so the README kept the old numbers.

Regenerating brings both back in sync with the rc file, which is the source of truth:

| | Before | After |
| --- | --- | --- |
| Badge | `all_contributors-1` | `all_contributors-2` |
| @indigo423 credits | Infrastructure 🚇 | Code 💻, Documentation 📖, Infrastructure 🚇, Maintenance 🚧 |

So the badge undercounted and the table undercredited, both from the same missed regeneration. No hand edits — the README change is the verbatim output of the generator.

## The guard

Regenerating once fixes today's drift but not tomorrow's, so the second commit makes drift unmergeable rather than merely fixed.

- `make contributors` regenerates the README from `.all-contributorsrc`.
- `make contributors-check` regenerates, then diffs against the committed README and fails if they differ.

It runs as a step in the existing `lint` job. That job is already a required status check and the step needs no permissions beyond the `contents: read` the workflow already declares, so this adds a gate without widening any access.

The CLI version is pinned in the Makefile alongside the actionlint and zizmor pins. Unpinned, a new all-contributors release could rewrite `README.md` and turn the check red without anyone touching the repository.

Verified both directions locally:

| Case | Result |
| --- | --- |
| README in sync with rc | exits 0, prints `README.md matches .all-contributorsrc` |
| One digit of the badge changed and committed | exits non-zero, prints the diff and `run 'make contributors' and commit the result` |

## Why a check rather than the all-contributors bot

The bot would open a PR from a `@all-contributors please add ...` comment, which is more convenient. It also means granting a third-party GitHub App write access to contents and pull requests. On a repository that pins every action to a SHA and has just earned the OpenSSF Best Practices badge, that seemed the wrong trade for a project with two contributors. A check costs nothing and catches hand-edits to the rc file, which the bot would not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)