### PR TITLE
fix(docs): bump nanoid past the zero-size infinite loop

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -14119,9 +14119,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Addresses part of [code scanning alert #120](https://github.com/Riptide-Labs/riptide/security/code-scanning/120) (Scorecard `Vulnerabilities`, currently 7/10).

The alert reports three OSV findings. All three are npm packages in the documentation site's tree; none is in the collector. This clears the one that has a fix available. The other two are tracked in #482.

| Advisory | Package | Installed | Patched | Reached via | This PR |
| --- | --- | --- | --- | --- | --- |
| GHSA-2v37-7h3g-55p8 (CVE-2026-67213) | `nanoid` | 3.3.16 | 3.3.17 | `postcss@8.5.23` → `^3.3.16` | **fixed** → 3.3.18 |
| GHSA-5p2g-fcmc-qvqq (CVE-2025-71329) | `image-size` | 2.0.2 | none | `@docusaurus/mdx-loader@3.10.2` → `^2.0.2` | tracked in #482 |
| GHSA-w3rx-r6r6-pgpr (CVE-2025-71330) | `image-size` | 2.0.2 | none | same | tracked in #482 |

`nanoid` before 3.3.17 spins forever in `customAlphabet` and `customRandom` when handed a size of 0. Since `postcss` accepts `^3.3.16`, refreshing the lockfile is enough — `package.json` does not change and the diff is three lines.

## Why the image-size findings stay

There is nothing to upgrade to, and there will not be: `image-size/image-size` is **archived**, its last push landing 2026-06-03, a week before these advisories were published. Both advisories record `last_affected: 2.0.2` rather than a fixed version, 2.0.2 is the newest release on npm, and Docusaurus is already at its current 3.10.2. Dependabot agrees independently — alerts #17 and #18 both carry `first_patched_version: null`.

What unblocks it is Docusaurus dropping the dependency: facebook/docusaurus#12231. #482 tracks that here.

They could be suppressed in `docs/osv-scanner.toml`, which Scorecard honors, but a suppression on a permanently unfixed advisory tends to outlive the reason for it. Leaving them visible and explained seems better than hiding them, so the check goes to 8/10 rather than 10/10.

## Exposure

Low for all three, before and after. These are build-time dependencies of a static site: the `Dockerfile` references no node, the jar is Java only, and the inputs are repository content arriving through a reviewed pull request on a protected branch. The realistic worst case is a hung docs build, not anything reachable in a running riptide.

## Verification

- `make docs` builds clean on 3.3.18 — `npm ci` from the new lockfile, then `[SUCCESS] Generated static files in "build"`.
- OSV reports no advisories against `nanoid@3.3.18`.
- The `Docs` workflow runs on PRs touching `docs/**`, so CI rebuilds the site here too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)