### PR TITLE
release: merge v0.8.0 version commits back to main

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.riptide.flows</groupId>
     <artifactId>riptide-flows</artifactId>
-    <version>0.7.2-SNAPSHOT</version>
+    <version>0.8.0</version>
     <name>riptide-flows</name>
     <description>NetFlow analysis engine</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.riptide.flows</groupId>
     <artifactId>riptide-flows</artifactId>
-    <version>0.8.0</version>
+    <version>0.8.1-SNAPSHOT</version>
     <name>riptide-flows</name>
     <description>NetFlow analysis engine</description>
 


### PR DESCRIPTION
Version bump commits for v0.8.0, merged back so `main` carries `0.8.1-SNAPSHOT`.

- `release: Riptide version 0.8.0` — the commit `v0.8.0` is tagged on
- `release: Set new snapshot version 0.8.1-SNAPSHOT`

The tag is already pushed; the release pipeline builds from it independently of this merge.