### PR TITLE
docs: add mvrueden and christianpape as contributors

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -30,10 +30,29 @@
         "infra",
         "maintenance"
       ]
+    },
+    {
+      "login": "mvrueden",
+      "name": "mvrueden",
+      "avatar_url": "https://avatars.githubusercontent.com/u/4202259?v=4",
+      "profile": "https://github.com/mvrueden",
+      "contributions": [
+        "code",
+        "review"
+      ]
+    },
+    {
+      "login": "christianpape",
+      "name": "Christian Pape",
+      "avatar_url": "https://avatars.githubusercontent.com/u/4200555?v=4",
+      "profile": "https://github.com/christianpape",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,
-  "skipCi": true,
+  "skipCi": false,
   "repoType": "github",
   "repoHost": "https://github.com",
   "projectName": "riptide",

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <!-- community -->
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ![riptide-logo](./artwork/riptide-logo.png)
@@ -168,6 +168,8 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="http://open-desk.org"><img src="https://avatars.githubusercontent.com/u/405105?v=4?s=100" width="100px;" alt="Dustin Frisch"/><br /><sub><b>Dustin Frisch</b></sub></a><br /><a href="https://github.com/Riptide-Labs/riptide/commits?author=fooker" title="Code">💻</a> <a href="#research-fooker" title="Research">🔬</a> <a href="https://github.com/Riptide-Labs/riptide/pulls?q=is%3Apr+reviewed-by%3Afooker" title="Reviewed Pull Requests">👀</a> <a href="#ideas-fooker" title="Ideas, Planning, & Feedback">🤔</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://blog.no42.org"><img src="https://avatars.githubusercontent.com/u/1095181?v=4?s=100" width="100px;" alt="Ronny Trommer"/><br /><sub><b>Ronny Trommer</b></sub></a><br /><a href="https://github.com/Riptide-Labs/riptide/commits?author=indigo423" title="Code">💻</a> <a href="https://github.com/Riptide-Labs/riptide/commits?author=indigo423" title="Documentation">📖</a> <a href="#infra-indigo423" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="#maintenance-indigo423" title="Maintenance">🚧</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/mvrueden"><img src="https://avatars.githubusercontent.com/u/4202259?v=4?s=100" width="100px;" alt="mvrueden"/><br /><sub><b>mvrueden</b></sub></a><br /><a href="https://github.com/Riptide-Labs/riptide/commits?author=mvrueden" title="Code">💻</a> <a href="https://github.com/Riptide-Labs/riptide/pulls?q=is%3Apr+reviewed-by%3Amvrueden" title="Reviewed Pull Requests">👀</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/christianpape"><img src="https://avatars.githubusercontent.com/u/4200555?v=4?s=100" width="100px;" alt="Christian Pape"/><br /><sub><b>Christian Pape</b></sub></a><br /><a href="https://github.com/Riptide-Labs/riptide/commits?author=christianpape" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Adds the two contributors missing from the all-contributors table, and fixes the reason the bot's own pull requests could not merge.

The table listed 2 people while git history has 4 distinct human authors. Both missing contributors date from the pre-rename `PikkaLabs/riptide` era, so the bot never recorded them when the table was seeded.

| Contributor | Commits | Period | Work |
|---|---|---|---|
| `@mvrueden` | 72 | 2023-10 → 2025-02 | Postgres persister/repository, bean configuration refactor, location handling, convo-key removal, PR reviews |
| `@christianpape` | 8 | 2023-11 | SNMP integration (#16), human-readable ifIndex name lookup |

Bots (`dependabot[bot]`, `allcontributors[bot]`) stay excluded.

## Why this replaces #487's original contents and #488

The bot opened one pull request per contributor, both branched from the same base commit, and each bumped the badge from 2 to 3. Merging either one would have left the other conflicting.

More importantly neither could merge at all. Branch protection on `main` requires `build`, `e2e` and `lint`, but `.all-contributorsrc` had `"skipCi": true`, so every bot commit carried `[skip ci]` and GitHub Actions never started those checks. Both pull requests reported *no checks reported* and sat permanently blocked. `enforce_admins` is on, so an admin merge could not bypass it either.

This branch therefore carries a single commit that:

1. adds both contributors, with entries and table markup generated by `all-contributors-cli` (the rendered rows match the bot's own output byte-for-byte),
2. sets `"skipCi": false` so future all-contributors pull requests run the required checks and can merge.

#488 is superseded and closed.

Closes #486