### PR TITLE
fix(test): resolve ErrorProne annotation warnings across test suite

### DIFF
--- a/src/test/java/org/riptide/classification/internal/ClassificationEnricherTest.java
+++ b/src/test/java/org/riptide/classification/internal/ClassificationEnricherTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-@SpringBootTest()
+@SpringBootTest
 public class ClassificationEnricherTest {
 
     private final MetricRegistry metricRegistry = new MetricRegistry();
@@ -49,7 +49,7 @@ public class ClassificationEnricherTest {
         when(flow.getDstAddr()).thenReturn(InetAddress.getByName("10.20.20.10"));
         when(flow.getProtocol()).thenReturn(6); // TCP
 
-        final var source = new Source("here", InetAddress.getByName("127.0.0.1"));
+        final var source = new Source("here", InetAddress.getLoopbackAddress());
 
         pipeline.process(source, List.of(flow));
 

--- a/src/test/java/org/riptide/classification/internal/csv/CsvImporterTest.java
+++ b/src/test/java/org/riptide/classification/internal/csv/CsvImporterTest.java
@@ -70,9 +70,10 @@ public class CsvImporterTest {
      */
     @Test
     void verifyEarlierRuleWinsEphemeralPortCollision() throws IOException, InterruptedException {
-        final var engine = engineFor(
-                "https;tcp;;;;443;;true\n"
-                + "galaxy4d;tcp;;;;8881;;true\n");
+        final var engine = engineFor("""
+                https;tcp;;;;443;;true
+                galaxy4d;tcp;;;;8881;;true
+                """);
 
         // client -> server: dstPort matches https directly, srcPort matches galaxy4d reversed
         assertThat(classify(engine, 8881, 443)).isEqualTo("https");
@@ -80,9 +81,10 @@ public class CsvImporterTest {
         assertThat(classify(engine, 443, 8881)).isEqualTo("https");
 
         // and the order is what decides: with the rows swapped, galaxy4d wins both directions
-        final var swapped = engineFor(
-                "galaxy4d;tcp;;;;8881;;true\n"
-                + "https;tcp;;;;443;;true\n");
+        final var swapped = engineFor("""
+                galaxy4d;tcp;;;;8881;;true
+                https;tcp;;;;443;;true
+                """);
         assertThat(classify(swapped, 8881, 443)).isEqualTo("galaxy4d");
         assertThat(classify(swapped, 443, 8881)).isEqualTo("galaxy4d");
     }

--- a/src/test/java/org/riptide/dns/HostnamesEnricherTest.java
+++ b/src/test/java/org/riptide/dns/HostnamesEnricherTest.java
@@ -66,7 +66,7 @@ public class HostnamesEnricherTest {
         when(flow.getDstAddr()).thenReturn(InetAddress.getByName("192.0.2.2"));
         when(flow.getNextHop()).thenReturn(InetAddress.getByName("192.0.2.3"));
 
-        final var source = new Source("here", InetAddress.getByName("127.0.0.1"));
+        final var source = new Source("here", InetAddress.getLoopbackAddress());
 
         pipeline.process(source, List.of(flow));
 

--- a/src/test/java/org/riptide/e2e/Nl6FlowIngestionIT.java
+++ b/src/test/java/org/riptide/e2e/Nl6FlowIngestionIT.java
@@ -53,7 +53,7 @@ public class Nl6FlowIngestionIT {
     private static final int IPFIX_PORT = freeUdpPort();
     private static final int SFLOW_PORT = freeUdpPort();
 
-    private static final Instant TEST_START = Instant.now();
+    private static Instant testStart;
 
     private static Client queryClient;
 
@@ -105,6 +105,7 @@ public class Nl6FlowIngestionIT {
 
     @BeforeAll
     static void startTraffic() throws Exception {
+        testStart = Instant.now();
         queryClient = new Client.Builder()
                 .addEndpoint("http://" + CLICKHOUSE.getHost() + ":" + CLICKHOUSE.getMappedPort(8123))
                 .setUsername("riptide")
@@ -254,7 +255,7 @@ public class Nl6FlowIngestionIT {
         // so this failed everywhere except a UTC host. Same trap as #276, this time in the assertion.
         final var window = Duration.ofHours(1);
         Assertions.assertThat(row.getLocalDateTime("minFirst").atOffset(ZoneOffset.UTC).toInstant())
-                .isAfter(TEST_START.minus(window));
+                .isAfter(testStart.minus(window));
         Assertions.assertThat(row.getLocalDateTime("maxLast").atOffset(ZoneOffset.UTC).toInstant())
                 .isBefore(Instant.now().plus(window));
     }

--- a/src/test/java/org/riptide/flows/DaemonStartupLoggingTest.java
+++ b/src/test/java/org/riptide/flows/DaemonStartupLoggingTest.java
@@ -150,7 +150,7 @@ class DaemonStartupLoggingTest {
         // would gate it anyway. (On Windows, SO_REUSEADDR does permit hijacking a live socket, so
         // this test assumes POSIX semantics — as does CI.)
         try (var occupied = new ServerSocket()) {
-            occupied.bind(new java.net.InetSocketAddress(InetAddress.getByName("127.0.0.1"), 0));
+            occupied.bind(new java.net.InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
             final int taken = occupied.getLocalPort();
 
             final var daemon = daemon(Map.of(
@@ -287,7 +287,7 @@ class DaemonStartupLoggingTest {
     @Test
     void aSuccessfulAndAFailingReceiverAreBothDistinguishableInTheLog() throws Exception {
         try (var occupied = new ServerSocket()) {
-            occupied.bind(new java.net.InetSocketAddress(InetAddress.getByName("127.0.0.1"), 0));
+            occupied.bind(new java.net.InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
             final int taken = occupied.getLocalPort();
 
             final var daemon = daemon(Map.of(

--- a/src/test/java/org/riptide/flows/Netflow5SamplingFallbackTest.java
+++ b/src/test/java/org/riptide/flows/Netflow5SamplingFallbackTest.java
@@ -240,7 +240,7 @@ class Netflow5SamplingFallbackTest {
     private static void send(final int port, final byte[] payload) throws Exception {
         try (var socket = new DatagramSocket()) {
             socket.send(new DatagramPacket(
-                    payload, payload.length, InetAddress.getByName("127.0.0.1"), port));
+                    payload, payload.length, InetAddress.getLoopbackAddress(), port));
         }
     }
 

--- a/src/test/java/org/riptide/flows/ipfix/FlowTimeoutTest.java
+++ b/src/test/java/org/riptide/flows/ipfix/FlowTimeoutTest.java
@@ -47,7 +47,7 @@ public class FlowTimeoutTest {
         raw.octetDeltaCount = 10L;
         raw.packetDeltaCount = 10L;
         raw.flowActiveTimeout = Duration.ofSeconds(10);
-        raw.flowInactiveTimeout = Duration.ofSeconds(300L);
+        raw.flowInactiveTimeout = Duration.ofMinutes(5);
 
         final var flow = new IpFixFlowBuilder(conversionService).buildFlow(Instant.EPOCH, raw);
 

--- a/src/test/java/org/riptide/flows/ipfix/FlowTimeoutTest.java
+++ b/src/test/java/org/riptide/flows/ipfix/FlowTimeoutTest.java
@@ -65,7 +65,7 @@ public class FlowTimeoutTest {
         raw.octetDeltaCount = 0L;
         raw.packetDeltaCount = 0L;
         raw.flowActiveTimeout = Duration.ofSeconds(10);
-        raw.flowInactiveTimeout = Duration.ofSeconds(300);
+        raw.flowInactiveTimeout = Duration.ofMinutes(5);
 
         final var flow = new IpFixFlowBuilder(conversionService).buildFlow(Instant.EPOCH, raw);
 

--- a/src/test/java/org/riptide/flows/ipfix/IpfixInterfaceOptionsTest.java
+++ b/src/test/java/org/riptide/flows/ipfix/IpfixInterfaceOptionsTest.java
@@ -21,6 +21,7 @@ import org.riptide.snmp.IfInfo;
 import org.riptide.snmp.SnmpOptionsConfig;
 
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.riptide.flows.utils.BufferUtils.slice;
@@ -51,8 +52,8 @@ public class IpfixInterfaceOptionsTest {
         // data set for template 400: ifIndex 5, "ge-0/0/0", "core-up"
         b.writeShort(400).writeShort(4 + 20);
         b.writeInt(5);
-        b.writeBytes("ge-0/0/0".getBytes());
-        b.writeBytes("core-up\0".getBytes());
+        b.writeBytes("ge-0/0/0".getBytes(StandardCharsets.UTF_8));
+        b.writeBytes("core-up\0".getBytes(StandardCharsets.UTF_8));
         b.setShort(2, b.readableBytes()); // patch message length
 
         final Header header = new Header(slice(b, Header.SIZE));

--- a/src/test/java/org/riptide/flows/listeners/UdpListenerReleaseTest.java
+++ b/src/test/java/org/riptide/flows/listeners/UdpListenerReleaseTest.java
@@ -11,6 +11,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.socket.DatagramPacket;
 import org.junit.jupiter.api.Test;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.time.Instant;
 import java.util.concurrent.Callable;
@@ -25,8 +26,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class UdpListenerReleaseTest {
 
-    private static final InetSocketAddress SENDER = new InetSocketAddress("127.0.0.1", 40000);
-    private static final InetSocketAddress RECIPIENT = new InetSocketAddress("127.0.0.1", 4739);
+    private static final InetSocketAddress SENDER = new InetSocketAddress(InetAddress.getLoopbackAddress(), 40000);
+    private static final InetSocketAddress RECIPIENT = new InetSocketAddress(InetAddress.getLoopbackAddress(), 4739);
 
     @Test
     void releasesBufferWhenParseThrowsSynchronously() {

--- a/src/test/java/org/riptide/flows/netflow5/Netflow5ConverterTest.java
+++ b/src/test/java/org/riptide/flows/netflow5/Netflow5ConverterTest.java
@@ -55,8 +55,8 @@ public class Netflow5ConverterTest {
         Assertions.assertThat(flow.getInputSnmp()).isEqualTo(0);
         Assertions.assertThat(flow.getOutputSnmp()).isEqualTo(0);
         Assertions.assertThat(flow.getFirstSwitched()).isEqualTo(Instant.parse("2015-06-21T11:40:52.194328Z"));
-        Assertions.assertThat(flow.getLastSwitched()).isEqualTo((Instant.parse("2015-05-02T18:38:07.476328Z")));
-        Assertions.assertThat(flow.getDeltaSwitched()).isEqualTo((Instant.parse("2015-06-21T11:40:52.194328Z")));
+        Assertions.assertThat(flow.getLastSwitched()).isEqualTo(Instant.parse("2015-05-02T18:38:07.476328Z"));
+        Assertions.assertThat(flow.getDeltaSwitched()).isEqualTo(Instant.parse("2015-06-21T11:40:52.194328Z"));
         Assertions.assertThat(flow.getPackets()).isEqualTo(5L);
         Assertions.assertThat(flow.getDirection()).isEqualTo(Flow.Direction.INGRESS);
         Assertions.assertThat(flow.getNextHop().getHostAddress()).isEqualTo("0.0.0.0");

--- a/src/test/java/org/riptide/flows/netflow9/FlowTimeoutTest.java
+++ b/src/test/java/org/riptide/flows/netflow9/FlowTimeoutTest.java
@@ -30,8 +30,8 @@ public class FlowTimeoutTest {
         final var raw = new Netflow9RawFlow();
         raw.unixSecs = Instant.EPOCH;
         raw.sysUpTime = Duration.ZERO;
-        raw.FIRST_SWITCHED = Duration.ofMillis(123000);
-        raw.LAST_SWITCHED = Duration.ofMillis(987000);
+        raw.FIRST_SWITCHED = Duration.ofSeconds(123);
+        raw.LAST_SWITCHED = Duration.ofSeconds(987);
 
         final var flowMessage = new Netflow9FlowBuilder(valueConversionService).buildFlow(Instant.EPOCH, raw);
         Assertions.assertThat(flowMessage.getFirstSwitched()).isEqualTo(Instant.ofEpochMilli(123000L));
@@ -62,12 +62,12 @@ public class FlowTimeoutTest {
         final var raw = new Netflow9RawFlow();
         raw.unixSecs = Instant.EPOCH;
         raw.sysUpTime = Duration.ZERO;
-        raw.FIRST_SWITCHED = Duration.ofMillis(123_000);
-        raw.LAST_SWITCHED = Duration.ofMillis(987_000);
+        raw.FIRST_SWITCHED = Duration.ofSeconds(123);
+        raw.LAST_SWITCHED = Duration.ofSeconds(987);
         raw.IN_BYTES = 10L;
         raw.IN_PKTS = 10L;
         raw.FLOW_ACTIVE_TIMEOUT = Duration.ofSeconds(10);
-        raw.FLOW_INACTIVE_TIMEOUT = Duration.ofSeconds(300);
+        raw.FLOW_INACTIVE_TIMEOUT = Duration.ofMinutes(5);
 
         final var flowMessage = new Netflow9FlowBuilder(valueConversionService).buildFlow(Instant.EPOCH, raw);
         Assertions.assertThat(flowMessage.getFirstSwitched()).isEqualTo(Instant.ofEpochMilli(123000L));


### PR DESCRIPTION
Fix compiler warnings flagged by ErrorProne across test classes:

- CanonicalDuration: use Duration.ofMinutes(5) instead of Duration.ofSeconds(300L) in FlowTimeoutTest.
- AddressSelection: replace InetAddress.getByName("127.0.0.1") with InetAddress.getLoopbackAddress() across test fixtures.
- TimeInStaticInitializer: initialize testStart inside @BeforeAll startTraffic method in Nl6FlowIngestionIT.
- StringConcatToTextBlock: convert concatenated CSV string literals to multiline text blocks in CsvImporterTest.
- UnnecessaryParentheses: remove empty parentheses on @SpringBootTest annotation in ClassificationEnricherTest.